### PR TITLE
Improve continent buffers handling

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -53,7 +53,7 @@ const DEFAULT_CONFIG = {
   oceanicRidgeWidth: 650, // km
   // Width of the area around continent which acts as it's bumper / buffer. When this area is about to subduct,
   // drag forces will be applied to stop relative motion of the plates and prevent subduction of the neighbouring continent.
-  continentBufferWidth: 750,
+  continentBufferWidth: 1000,
   // Keeps model running. When all the plates reach the point when they move in the same direction, with the same speed,
   // model will add some random forces and divide big plates (see minSizeRatioForDivision).
   enforceRelativeMotion: true,

--- a/js/plates-model/fields-collision.js
+++ b/js/plates-model/fields-collision.js
@@ -41,13 +41,18 @@ export default function fieldsCollision (bottomField, topField) {
 
   if (bottomField.isOcean) {
     subduction(bottomField, topField)
-    if (bottomField.isContinentBuffer && !topField.isContinent) {
+    if (bottomField.isContinentBuffer && !topField.isContinent && !topField.isContinentBuffer) {
       // Special case when the continent is "trying" to subduct under the ocean. Apply drag force to stop both plates.
+      // There's one exception - when both fields are continent buffers, it means continents are about to collide soon.
+      // Don't apply forces in this case, so the orogeny can actually happen.
       applyDragForces(bottomField, topField)
     }
   } else if (bottomField.isContinent) {
     if (topField.isContinent) {
       orogeny(bottomField, topField)
+    } else if (topField.isContinentBuffer) {
+      // Continents are next to each other. They will collide soon. Remove oceanic field to let that happen.
+      topField.alive = false
     } else { // topField.isOcean || topField.isIsland
       // Special case when the continent is "trying" to subduct under the ocean. Apply drag force to stop both plates.
       applyDragForces(bottomField, topField)

--- a/js/plates-model/model.js
+++ b/js/plates-model/model.js
@@ -4,7 +4,7 @@ import Plate from './plate'
 import getGrid from './grid'
 import config from '../config'
 import markIslands from './mark-islands'
-import fieldCollision from './fields-collision'
+import fieldsCollision from './fields-collision'
 import addRelativeMotion from './add-relative-motion'
 import dividePlate from './divide-plate'
 import eulerStep from './physics/euler-integrator'
@@ -226,14 +226,14 @@ export default class Model {
         const lowerPlate = this.plates[plateIdx + i]
         const lowerField = lowerPlate && lowerPlate.fieldAtAbsolutePos(field.absolutePos)
         if (lowerField) {
-          fieldCollision(lowerField, field)
+          fieldsCollision(lowerField, field)
           // Handle only one collision per field (with the plate laying closest to it).
           return
         }
         const upperPlate = this.plates[plateIdx - i]
         const upperField = upperPlate && upperPlate.fieldAtAbsolutePos(field.absolutePos)
         if (upperField) {
-          fieldCollision(field, upperField)
+          fieldsCollision(field, upperField)
           // Handle only one collision per field (with the plate laying closest to it).
           return
         }


### PR DESCRIPTION
[#157605459]

Make continent-continent collisions more likely. When two continent buffers are colliding, we know that it's not continent-ocean collision case (where we want to spot plates), but rather continent-continent (where we want collision to happen).