### PR TITLE
Add more unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 cypress/screenshots
 cypress/snapshots/gpu-dependant/snapshots.js/__diff_output__
 .snapshot-report
+coverage

--- a/js/plates-model/subduction.js
+++ b/js/plates-model/subduction.js
@@ -46,11 +46,9 @@ export default class Subduction {
   get avgProgress () {
     let sum = 0
     let count = 0
-    this.field.forEachNeighbour(otherField => {
-      if (otherField && otherField.subduction) {
-        sum += otherField.subduction.progress
-        count += 1
-      }
+    this.forEachSubductingNeighbour(otherField => {
+      sum += otherField.subduction.progress
+      count += 1
     })
     if (count > 0) {
       return sum / count

--- a/js/stores/simulation-store.js
+++ b/js/stores/simulation-store.js
@@ -238,7 +238,7 @@ class SimulationStore {
       this.debugMarker = (new THREE.Vector3()).copy(data.debugMarker)
     }
     this.model.handleDataFromWorker(data)
-    if (this.model.stepIdx % config.stopAfter === 0) {
+    if (this.model.stepIdx > 0 && this.model.stepIdx % config.stopAfter === 0) {
       this.setOption('playing', false)
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "standard --fix",
     "lint:test": "standard",
     "test": "jest",
-    "test:watch": "jest --watch",
+    "test:watch": "jest --watch --watchPathIgnorePatterns model-serialization.test.js",
     "start": "webpack-dev-server",
     "build": "webpack",
     "build-production": "PRODUCTION=true webpack",

--- a/test/model-serialization.test.js
+++ b/test/model-serialization.test.js
@@ -1,19 +1,7 @@
 import * as THREE from 'three'
-import path from 'path'
-import getPixels from 'get-pixels'
 import Model from '../js/plates-model/model'
 
 const TIMESTEP = 0.2
-
-function getImageData (src, callback) {
-  getPixels(src, (err, pixels) => {
-    callback({
-      data: pixels.data,
-      width: pixels.shape[0],
-      height: pixels.shape[1]
-    })
-  })
-}
 
 function initFunc (plates) {
   const bluePlate = plates[210] // 210 hue
@@ -100,7 +88,7 @@ function compareHelpers (h1, h2) {
 let modelImgData = null
 
 beforeAll(done => {
-  getImageData(path.join(__dirname, 'testModel.png'), imgData => {
+  global.getModelImage('testModel.png', imgData => {
     modelImgData = imgData
     done()
   })

--- a/test/plates-model/model.test.js
+++ b/test/plates-model/model.test.js
@@ -1,0 +1,22 @@
+import Model from '../../js/plates-model/model'
+
+describe('Tectonic Explorer model', () => {
+  let modelImgData = null
+
+  beforeAll(done => {
+    global.getModelImage('testModel.png', imgData => {
+      modelImgData = imgData
+      done()
+    })
+  })
+
+  it('should be initialized correctly using image data', () => {
+    const initFunc = jest.fn()
+    const model = new Model(modelImgData, initFunc)
+    expect(model.plates.length).toEqual(3)
+    expect(initFunc).toHaveBeenCalled()
+    expect(model.time).toEqual(0)
+    expect(model.stepIdx).toEqual(0)
+    expect(model.kineticEnergy).toEqual(0)
+  })
+})

--- a/test/plates-model/subduction.test.js
+++ b/test/plates-model/subduction.test.js
@@ -1,0 +1,174 @@
+import Subduction, { MAX_SUBDUCTION_DIST } from '../../js/plates-model/subduction'
+import * as THREE from 'three'
+
+describe('Subduction model', () => {
+  it('should be initialized', () => {
+    const field = {}
+    const sub = new Subduction(field)
+    expect(sub.field).toEqual(field)
+    expect(sub.dist).toEqual(0)
+    expect(sub.topPlate).toBeUndefined()
+    expect(sub.relativeVelocity).toBeUndefined()
+  })
+
+  describe('progress', () => {
+    it('should be based on current distance traveled by field', () => {
+      const sub = new Subduction({})
+      expect(sub.progress).toEqual(0)
+      sub.dist = MAX_SUBDUCTION_DIST * 0.5
+      expect(sub.progress).toBeGreaterThan(0.1)
+      expect(sub.progress).toBeLessThan(0.9)
+      sub.dist = MAX_SUBDUCTION_DIST
+      expect(sub.progress).toEqual(1)
+    })
+  })
+
+  describe('active', () => {
+    it('should be true when the field has not moved backwards', () => {
+      const sub = new Subduction({})
+      expect(sub.active).toEqual(true)
+      sub.dist = 0.5
+      expect(sub.active).toEqual(true)
+      sub.dist = -0.5 // moved backwards
+      expect(sub.active).toEqual(false)
+    })
+  })
+
+  describe('forEachSubductingNeighbour', () => {
+    it('should call provided callback for every field that is subducting', () => {
+      const field = {
+        forEachNeighbour: (callback) => {
+          const fields = [
+            {subduction: {progress: 0}},
+            {subduction: {progress: 0.5}},
+            {subduction: {progress: 1}},
+            {fieldThatDoesNotSubduct: true}
+          ]
+          fields.forEach(callback)
+        }
+      }
+      const sub = new Subduction(field)
+      const callback = jest.fn()
+      sub.forEachSubductingNeighbour(callback)
+      expect(callback).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('avgProgress', () => {
+    it('should return avg progress of the subducting neighbours', () => {
+      const field = {
+        forEachNeighbour: (callback) => {
+          const fields = [
+            {subduction: {progress: 0}},
+            {subduction: {progress: 0.5}},
+            {subduction: {progress: 1}},
+            {fieldThatDoesNotSubduct: true}
+          ]
+          fields.forEach(callback)
+        }
+      }
+      const sub = new Subduction(field)
+      expect(sub.avgProgress).toEqual(0.5) // (0 + 0.5 + 1) / 3
+    })
+  })
+
+  describe('calcSlabGradient', () => {
+    it('should return null if there are not enough neighbouring fields that are subducting (will not be precise enough)', () => {
+      const field = {
+        absolutePos: new THREE.Vector3(1, 0, 0),
+        forEachNeighbour: (callback) => {
+          const fields = [
+            {
+              absolutePos: new THREE.Vector3(0.8, 0, 0),
+              subduction: {avgProgress: 1}
+            },
+            {absolutePos: new THREE.Vector3(0, 0, 1)},
+            {absolutePos: new THREE.Vector3(0, 0, 1)},
+            {absolutePos: new THREE.Vector3(0, 0, 1)},
+            {absolutePos: new THREE.Vector3(0, 0, 1)}
+          ]
+          fields.forEach(callback)
+        }
+      }
+      const sub = new Subduction(field)
+      expect(sub.calcSlabGradient()).toEqual(null)
+    })
+
+    it('should return gradient of the subduction slope', () => {
+      let field = {
+        absolutePos: new THREE.Vector3(0.5, 0, 0),
+        forEachNeighbour: (callback) => {
+          const fields = [
+            {
+              absolutePos: new THREE.Vector3(1, 0, 0),
+              subduction: {avgProgress: 1}
+            },
+            {
+              absolutePos: new THREE.Vector3(0, 0, 1),
+              subduction: {avgProgress: 0}
+            },
+            {
+              absolutePos: new THREE.Vector3(0, 0, 1),
+              subduction: {avgProgress: 0}
+            },
+            {
+              absolutePos: new THREE.Vector3(0, 0, 1),
+              subduction: {avgProgress: 0}
+            },
+            {
+              absolutePos: new THREE.Vector3(0, 0, 1),
+              subduction: {avgProgress: 0}
+            }
+          ]
+          fields.forEach(callback)
+        }
+      }
+      let sub = new Subduction(field)
+      jest.spyOn(sub, 'avgProgress', 'get').mockImplementation(() => 0)
+      expect(sub.calcSlabGradient().toArray()).toEqual([1, 0, 0])  // result is always normalized
+
+      field = {
+        absolutePos: new THREE.Vector3(1, 0, 0),
+        forEachNeighbour: (callback) => {
+          const fields = [
+            {
+              absolutePos: new THREE.Vector3(0.5, 0, 0),
+              subduction: {avgProgress: 1}
+            },
+            {
+              absolutePos: new THREE.Vector3(0, 0, 1),
+              subduction: {avgProgress: 0.5}
+            },
+            {
+              absolutePos: new THREE.Vector3(0, 0, 1),
+              subduction: {avgProgress: 0.5}
+            },
+            {
+              absolutePos: new THREE.Vector3(0, 0, 1),
+              subduction: {avgProgress: 0.5}
+            },
+            {
+              absolutePos: new THREE.Vector3(0, 0, 1),
+              subduction: {avgProgress: 0.5}
+            }
+          ]
+          fields.forEach(callback)
+        }
+      }
+      sub = new Subduction(field)
+      jest.spyOn(sub, 'avgProgress', 'get').mockImplementation(() => 0.5)
+      expect(sub.calcSlabGradient().toArray()).toEqual([-1, 0, 0]) // result is always normalized
+    })
+  })
+
+  describe('setCollision', () => {
+    it('set topPlate and linearVelocity', () => {
+      const field1 = { linearVelocity: new THREE.Vector3(0.5, 0, 0) }
+      const field2 = { linearVelocity: new THREE.Vector3(1, 0, 0), plate: 'somePlate' }
+      const sub = new Subduction(field1)
+      sub.setCollision(field2)
+      expect(sub.topPlate).toEqual(field2.plate)
+      expect(sub.relativeVelocity.toArray()).toEqual([-0.5, 0, 0])
+    })
+  })
+})

--- a/test/setup-tests.js
+++ b/test/setup-tests.js
@@ -1,5 +1,21 @@
 import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-15'
+import path from 'path'
+import getPixels from 'get-pixels'
 
 // see http://airbnb.io/enzyme/docs/installation/index.html
 configure({ adapter: new Adapter() })
+
+// Helper function that returns test model image data.
+global.getModelImage = (file = 'testModel.png', done) => {
+  getPixels(path.join(__dirname, file), (err, pixels) => {
+    if (err) {
+      throw new Error('getModelImage failed: ', file)
+    }
+    done({
+      data: pixels.data,
+      width: pixels.shape[0],
+      height: pixels.shape[1]
+    })
+  })
+}


### PR DESCRIPTION
[#163767335

I didn't end up adding as many tests as I hoped. But I added some for Subduction class, perhaps setting the pattern how to interact with fake field object. I guess upcoming work will use mostly this helper, so there are some examples at least.

I actually spent some time updating babel, presets, plugins, and also ThreeJS, and refactoring some code that had been copy-pasted (peels dir):
https://github.com/concord-consortium/tectonic-explorer/commit/8d990665c563486cf21d45a12866ede21ec6694f
https://github.com/concord-consortium/tectonic-explorer/commit/3a68512379d17c384cdeace4d06bae73a82c556e
etc.

ThreeJS update is important, as we have custom shaders that depend on its internals, and falling too far behind might get problematic. These changes are already in master, as it was 100% maintenance and I didn't want to obscure diff here. 