### PR TITLE
Earthquakes rendering

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -16,6 +16,8 @@ const DEFAULT_CONFIG = {
   playing: true,
   // If true, the model will show randomly generated earthquakes.
   earthquakes: false,
+  // Lifespan of an earthquake in model time.
+  earthquakeLifespan: 2,
   // If number of steps is provided, model will stop every `stopAfter` steps. This is useful mostly for automated
   // testing, but author could also use that to stop model after some time and focus on some phenomena.
   stopAfter: Infinity,

--- a/js/plates-model/field.js
+++ b/js/plates-model/field.js
@@ -58,6 +58,7 @@ export default class Field extends FieldBase {
     this.volcanicAct = undefined
     this.subduction = undefined
     this.trench = undefined
+    this.earthquake = undefined
     // Used by adjacent fields only (see model.generateNewFields).
     this.noCollisionDist = undefined
 
@@ -69,7 +70,7 @@ export default class Field extends FieldBase {
   }
 
   get serializableProps () {
-    return [ 'id', 'boundary', 'age', '_type', 'baseElevation', 'baseCrustThickness', 'trench', 'marked', 'noCollisionDist', 'originalHue' ]
+    return [ 'id', 'boundary', 'age', '_type', 'baseElevation', 'baseCrustThickness', 'trench', 'earthquake', 'marked', 'noCollisionDist', 'originalHue' ]
   }
 
   serialize () {
@@ -316,6 +317,7 @@ export default class Field extends FieldBase {
     if (this.volcanicAct) {
       this.volcanicAct.update(timestep)
     }
+
     const trenchPossible = this.boundary && this.subductingPlateUnderneath && !this.orogeny
     if (this.trench && !trenchPossible) {
       // Remove trench when field isn't boundary anymore. Or when it collides with other continent and orogeny happens.
@@ -323,6 +325,15 @@ export default class Field extends FieldBase {
     }
     if (!this.trench && trenchPossible) {
       this.trench = true
+    }
+
+    if (this.earthquake) {
+      this.earthquake -= timestep
+      if (this.earthquake <= 0) {
+        this.earthquake = false
+      }
+    } else if ((this.subduction || this.volcanicAct) && Math.random() < 0.01) {
+      this.earthquake = config.earthquakeLifespan
     }
 
     // Age is a travelled distance in fact.

--- a/js/plates-model/field.js
+++ b/js/plates-model/field.js
@@ -7,6 +7,7 @@ import Orogeny from './orogeny'
 import VolcanicActivity from './volcanic-activity'
 import { basicDrag, orogenicDrag } from './physics/forces'
 import { serialize, deserialize } from '../utils'
+import { random } from '../seedrandom'
 
 // Max age of the field defines how fast the new oceanic crust cools down and goes from ridge elevation to its base elevation.
 export const MAX_AGE = config.oceanicRidgeWidth / c.earthRadius
@@ -332,7 +333,7 @@ export default class Field extends FieldBase {
       if (this.earthquake <= 0) {
         this.earthquake = false
       }
-    } else if ((this.subduction || this.volcanicAct) && Math.random() < 0.01) {
+    } else if ((this.subduction || this.volcanicAct) && random() < 0.007) {
       this.earthquake = config.earthquakeLifespan
     }
 

--- a/js/plates-model/model-output.js
+++ b/js/plates-model/model-output.js
@@ -41,6 +41,9 @@ function plateOutput (plate, props, stepIdx, forcedUpdate) {
     if (props.renderBoundaries) {
       fields.boundary = new Int8Array(size)
     }
+    if (props.earthquakes) {
+      fields.earthquake = new Int8Array(size)
+    }
     if (props.renderForces) {
       fields.forceX = new Float32Array(size)
       fields.forceY = new Float32Array(size)
@@ -56,6 +59,9 @@ function plateOutput (plate, props, stepIdx, forcedUpdate) {
       fields.normalizedAge[idx] = field.normalizedAge
       if (props.renderBoundaries) {
         fields.boundary[idx] = field.boundary
+      }
+      if (props.earthquakes) {
+        fields.earthquake[idx] = !!field.earthquake
       }
       if (props.renderForces) {
         const force = field.force

--- a/js/plates-view/earthquake-texture.js
+++ b/js/plates-view/earthquake-texture.js
@@ -1,0 +1,26 @@
+import * as THREE from 'three'
+
+const TEXTURE_SIZE = 64
+
+export default function earthquakeTexture ({ alphaOnly = false }) {
+  const size = TEXTURE_SIZE
+  const strokeWidth = size * 0.06
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+  const ctx = canvas.getContext('2d')
+  if (alphaOnly) {
+    ctx.fillStyle = '#000'
+    ctx.fillRect(0, 0, size, size)
+  }
+  // Point
+  ctx.arc(size / 2, size / 2, size / 2 - strokeWidth / 2, 0, 2 * Math.PI)
+  ctx.fillStyle = alphaOnly ? '#fff' : '#f00'
+  ctx.fill()
+  ctx.lineWidth = strokeWidth
+  ctx.strokeStyle = alphaOnly ? '#fff' : '#000'
+  ctx.stroke()
+  const texture = new THREE.Texture(canvas)
+  texture.needsUpdate = true
+  return texture
+}

--- a/js/plates-view/earthquakes.js
+++ b/js/plates-view/earthquakes.js
@@ -1,10 +1,19 @@
 import * as THREE from 'three'
 
-const SIZE = 0.015
+// Generated using:
+// http://www.timotheegroleau.com/Flash/experiments/easing_function_generator.htm
+function easeOutBounce (t) {
+  let ts = t * t
+  let tc = ts * t
+  return 33 * tc * ts + -106 * ts * ts + 126 * tc + -67 * ts + 15 * t
+}
+const TRANSITION_TIME = 750
+const SIZE = 0.02
 const NULL_POS = { x: 0, y: 0, z: 0 }
 
 export default class Earthquakes {
   constructor (color = 0xff0000, count) {
+    this.count = count
     this.geometry = new THREE.BufferGeometry()
     // * 3 * 3 * 2 =>  2 * 3 vertices per earthquake (2 triangles to form a rectangle),
     // each vertex has 3 coordinates (x, y, z).
@@ -17,6 +26,10 @@ export default class Earthquakes {
 
     this.material = new THREE.MeshBasicMaterial({ color })
     this.root = new THREE.Mesh(this.geometry, this.material)
+
+    this.position = []
+    this.targetVisibility = new Float32Array(count)
+    this.currentVisibility = new Float32Array(count)
   }
 
   set visible (v) {
@@ -36,7 +49,7 @@ export default class Earthquakes {
     pos[idx + 2] = vector.z
   }
 
-  clear (idx) {
+  hide (idx) {
     const vi = idx * 6
     // triangle 1
     this.setPos(vi, NULL_POS)
@@ -50,33 +63,50 @@ export default class Earthquakes {
   }
 
   setVisible (idx, visible, pos) {
+    this.targetVisibility[idx] = visible ? 1 : 0
+    this.position[idx] = pos
+  }
+
+  setSize (idx, size) {
     const vi = idx * 6
-    // pos = pos.clone().setLength(1.01)
-    if (visible) {
-      // Cross product with any random, non-parallel vector will result in a perpendicular vector.
-      const randVec = pos.clone()
-      randVec.y += 0.1
-      const prependVec1 = pos.clone().cross(randVec)
-      // Cross product of two vectors will result in a vector perpendicular to both.
-      const prependVec2 = prependVec1.clone().cross(pos)
-      prependVec1.setLength(SIZE)
-      prependVec2.setLength(SIZE)
-      // Generate square.
-      const p1 = pos.clone().add(prependVec1).add(prependVec2)
-      const p2 = pos.clone().add(prependVec1).sub(prependVec2)
-      const p3 = pos.clone().sub(prependVec1).sub(prependVec2)
-      const p4 = pos.clone().sub(prependVec1).add(prependVec2)
-      // triangle 1
-      this.setPos(vi, p1)
-      this.setPos(vi + 1, p2)
-      this.setPos(vi + 2, p3)
-      // triangle 3
-      this.setPos(vi + 3, p3)
-      this.setPos(vi + 4, p4)
-      this.setPos(vi + 5, p1)
-    } else {
-      this.clear(idx)
-    }
+    const pos = this.position[idx]
+    // Cross product with any random, non-parallel vector will result in a perpendicular vector.
+    const randVec = pos.clone()
+    randVec.y += 0.1
+    const prependVec1 = pos.clone().cross(randVec)
+    // Cross product of two vectors will result in a vector perpendicular to both.
+    const prependVec2 = prependVec1.clone().cross(pos)
+    prependVec1.setLength(size)
+    prependVec2.setLength(size)
+    // Generate square.
+    const p1 = pos.clone().add(prependVec1).add(prependVec2)
+    const p2 = pos.clone().add(prependVec1).sub(prependVec2)
+    const p3 = pos.clone().sub(prependVec1).sub(prependVec2)
+    const p4 = pos.clone().sub(prependVec1).add(prependVec2)
+    // triangle 1
+    this.setPos(vi, p1)
+    this.setPos(vi + 1, p2)
+    this.setPos(vi + 2, p3)
+    // triangle 3
+    this.setPos(vi + 3, p3)
+    this.setPos(vi + 4, p4)
+    this.setPos(vi + 5, p1)
     this.positionAttr.needsUpdate = true
+  }
+
+  updateTransitions (progress) {
+    progress /= TRANSITION_TIME // map to [0, 1]
+    for (let i = 0; i < this.count; i += 1) {
+      if (this.currentVisibility[i] !== this.targetVisibility[i]) {
+        this.currentVisibility[i] += this.currentVisibility[i] < this.targetVisibility[i] ? progress : -progress
+        this.currentVisibility[i] = Math.max(0, Math.min(1, this.currentVisibility[i]))
+        const size = easeOutBounce(this.currentVisibility[i]) * SIZE
+        if (size === 0) {
+          this.hide(i)
+        } else {
+          this.setSize(i, size)
+        }
+      }
+    }
   }
 }

--- a/js/plates-view/earthquakes.js
+++ b/js/plates-view/earthquakes.js
@@ -1,0 +1,82 @@
+import * as THREE from 'three'
+
+const SIZE = 0.015
+const NULL_POS = { x: 0, y: 0, z: 0 }
+
+export default class Earthquakes {
+  constructor (color = 0xff0000, count) {
+    this.geometry = new THREE.BufferGeometry()
+    // * 3 * 3 * 2 =>  2 * 3 vertices per earthquake (2 triangles to form a rectangle),
+    // each vertex has 3 coordinates (x, y, z).
+    const positions = new Float32Array(count * 3 * 3 * 2)
+    this.geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3))
+    this.geometry.attributes.position.dynamic = true
+
+    this.positionAttr = this.geometry.attributes.position
+    this.geometry.computeBoundingSphere()
+
+    this.material = new THREE.MeshBasicMaterial({ color })
+    this.root = new THREE.Mesh(this.geometry, this.material)
+  }
+
+  set visible (v) {
+    this.root.visible = v
+  }
+
+  dispose () {
+    this.geometry.dispose()
+    this.material.dispose()
+  }
+
+  setPos (i, vector) {
+    const pos = this.positionAttr.array
+    const idx = i * 3
+    pos[idx] = vector.x
+    pos[idx + 1] = vector.y
+    pos[idx + 2] = vector.z
+  }
+
+  clear (idx) {
+    const vi = idx * 6
+    // triangle 1
+    this.setPos(vi, NULL_POS)
+    this.setPos(vi + 1, NULL_POS)
+    this.setPos(vi + 2, NULL_POS)
+    // triangle 2
+    this.setPos(vi + 3, NULL_POS)
+    this.setPos(vi + 4, NULL_POS)
+    this.setPos(vi + 5, NULL_POS)
+    this.positionAttr.needsUpdate = true
+  }
+
+  setVisible (idx, visible, pos) {
+    const vi = idx * 6
+    // pos = pos.clone().setLength(1.01)
+    if (visible) {
+      // Cross product with any random, non-parallel vector will result in a perpendicular vector.
+      const randVec = pos.clone()
+      randVec.y += 0.1
+      const prependVec1 = pos.clone().cross(randVec)
+      // Cross product of two vectors will result in a vector perpendicular to both.
+      const prependVec2 = prependVec1.clone().cross(pos)
+      prependVec1.setLength(SIZE)
+      prependVec2.setLength(SIZE)
+      // Generate square.
+      const p1 = pos.clone().add(prependVec1).add(prependVec2)
+      const p2 = pos.clone().add(prependVec1).sub(prependVec2)
+      const p3 = pos.clone().sub(prependVec1).sub(prependVec2)
+      const p4 = pos.clone().sub(prependVec1).add(prependVec2)
+      // triangle 1
+      this.setPos(vi, p1)
+      this.setPos(vi + 1, p2)
+      this.setPos(vi + 2, p3)
+      // triangle 3
+      this.setPos(vi + 3, p3)
+      this.setPos(vi + 4, p4)
+      this.setPos(vi + 5, p1)
+    } else {
+      this.clear(idx)
+    }
+    this.positionAttr.needsUpdate = true
+  }
+}

--- a/js/plates-view/planet-view.js
+++ b/js/plates-view/planet-view.js
@@ -231,8 +231,11 @@ export default class PlanetView {
     this.render()
   }
 
-  render () {
+  render (timestamp = window.performance.now()) {
+    const progress = this._prevTimestamp ? timestamp - this._prevTimestamp : 0
+    this.plateMeshes.forEach(plateMesh => plateMesh.updateTransitions(progress))
     this.light.position.copy(this.camera.position)
     this.renderer.render(this.scene, this.camera)
+    this._prevTimestamp = timestamp
   }
 }

--- a/js/plates-view/plate-mesh.js
+++ b/js/plates-view/plate-mesh.js
@@ -263,9 +263,13 @@ export default class PlateMesh {
           this.forces.clearVector(field.id)
         }
         if (earthquakes) {
-          this.earthquakes.clear(field.id)
+          this.earthquakes.hide(field.id)
         }
       }
     })
+  }
+
+  updateTransitions (progress) {
+    this.earthquakes.updateTransitions(progress)
   }
 }

--- a/js/plates-view/plate-mesh.js
+++ b/js/plates-view/plate-mesh.js
@@ -3,7 +3,8 @@ import vertexShader from './plate-mesh-vertex.glsl'
 import fragmentShader from './plate-mesh-fragment.glsl'
 import VectorField from './vector-field'
 import ForceArrow from './force-arrow'
-import Earthquakes from './earthquakes'
+import TemporalEvents from './temporal-events'
+import earthquakeTexture from './earthquake-texture'
 import PlateLabel from './plate-label'
 import { hueAndElevationToRgb, rgbToHex, topoColor } from '../colormaps'
 import config from '../config'
@@ -72,7 +73,7 @@ export default class PlateMesh {
     this.forces = new VectorField(0xff0000, getGrid().size)
     this.root.add(this.forces.root)
 
-    this.earthquakes = new Earthquakes(this.helpersColor, Math.ceil(getGrid().size))
+    this.earthquakes = new TemporalEvents(Math.ceil(getGrid().size), earthquakeTexture({}), earthquakeTexture({ alphaOnly: true }))
     this.root.add(this.earthquakes.root)
 
     // User-defined force that drives motion of the plate.

--- a/js/plates-view/plate-mesh.js
+++ b/js/plates-view/plate-mesh.js
@@ -3,6 +3,7 @@ import vertexShader from './plate-mesh-vertex.glsl'
 import fragmentShader from './plate-mesh-fragment.glsl'
 import VectorField from './vector-field'
 import ForceArrow from './force-arrow'
+import Earthquakes from './earthquakes'
 import PlateLabel from './plate-label'
 import { hueAndElevationToRgb, rgbToHex, topoColor } from '../colormaps'
 import config from '../config'
@@ -71,6 +72,9 @@ export default class PlateMesh {
     this.forces = new VectorField(0xff0000, getGrid().size)
     this.root.add(this.forces.root)
 
+    this.earthquakes = new Earthquakes(this.helpersColor, Math.ceil(getGrid().size))
+    this.root.add(this.earthquakes.root)
+
     // User-defined force that drives motion of the plate.
     this.forceArrow = new ForceArrow(this.helpersColor)
     this.root.add(this.forceArrow.root)
@@ -129,6 +133,7 @@ export default class PlateMesh {
     this.axis.material.dispose()
     this.velocities.dispose()
     this.forces.dispose()
+    this.earthquakes.dispose()
     this.forceArrow.dispose()
     this.label.dispose()
 
@@ -228,7 +233,7 @@ export default class PlateMesh {
   }
 
   updateFields () {
-    const { renderVelocities, renderForces } = this.store
+    const { renderVelocities, renderForces, earthquakes } = this.store
     const fieldFound = {}
     this.plate.forEachField(field => {
       fieldFound[field.id] = true
@@ -242,6 +247,9 @@ export default class PlateMesh {
       if (renderForces) {
         this.forces.setVector(field.id, field.force, field.absolutePos)
       }
+      if (earthquakes) {
+        this.earthquakes.setVisible(field.id, field.earthquake, field.absolutePos)
+      }
     })
     // Process fields that are still visible, but no longer part of the plate model.
     this.visibleFields.forEach(field => {
@@ -253,6 +261,9 @@ export default class PlateMesh {
         }
         if (renderForces) {
           this.forces.clearVector(field.id)
+        }
+        if (earthquakes) {
+          this.earthquakes.clear(field.id)
         }
       }
     })

--- a/js/plates-view/plate-mesh.js
+++ b/js/plates-view/plate-mesh.js
@@ -100,6 +100,7 @@ export default class PlateMesh {
       SHARED_MATERIAL.wireframe = store.wireframe
       this.velocities.visible = store.renderVelocities
       this.forces.visible = store.renderForces
+      this.earthquakes.visible = store.earthquakes
       this.forceArrow.visible = store.renderHotSpots
       this.label.visible = store.renderPlateLabels
       this.axis.visible = store.renderEulerPoles

--- a/js/stores/field-store.js
+++ b/js/stores/field-store.js
@@ -7,6 +7,7 @@ export default class FieldStore extends FieldBase {
   elevation = null
   normalizedAge = null
   boundary = false
+  earthquake = false
   force = new THREE.Vector3()
   originalHue = null
 
@@ -15,6 +16,9 @@ export default class FieldStore extends FieldBase {
     this.normalizedAge = fieldData.normalizedAge[idx]
     if (fieldData.boundary) {
       this.boundary = fieldData.boundary[idx]
+    }
+    if (fieldData.earthquake) {
+      this.earthquake = fieldData.earthquake[idx]
     }
     if (fieldData.forceX) {
       this.force.set(fieldData.forceX[idx], fieldData.forceY[idx], fieldData.forceZ[idx])

--- a/js/stores/simulation-store.js
+++ b/js/stores/simulation-store.js
@@ -13,7 +13,7 @@ import ModelStore from './model-store'
 // postMessage serialization is expensive. Pass only selected properties.
 const WORKER_PROPS = ['playing', 'timestep', 'crossSectionPoint1', 'crossSectionPoint2', 'crossSectionPoint3',
   'crossSectionPoint4', 'crossSectionSwapped', 'showCrossSectionView', 'colormap', 'renderForces', 'renderHotSpots',
-  'renderBoundaries']
+  'renderBoundaries', 'earthquakes']
 
 const DEFAULT_CROSS_SECTION_CAMERA_ANGLE = 3
 const DEFAULT_PLANET_CAMERA_POSITION = [4.5, 0, 0] // (x, y, z)


### PR DESCRIPTION
Note that this PR is open against https://github.com/concord-consortium/tectonic-explorer/pull/43 as it was based on it.

It adds initial rendering of the earthquakes, following the same shape and style as one used in Seismic Explorer. I've tried to make sure that the code can be reused for volcanoes.

Note that earthquakes are disabled by default and you need to add `earthquakes=true` URL param.

Demo:
http://tectonic-explorer.concord.org/branch/162386261-earthquakes-rendering/index.html?preset=subduction&earthquakes=true