### PR TITLE
Earthquakes cross-section

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -92,6 +92,7 @@ const DEFAULT_CONFIG = {
     'interactions',
     'timestep',
     'colormap',
+    'earthquakes',
     'latLongLines',
     'plateLabels',
     'velocityArrows',

--- a/js/plates-model/get-cross-section.js
+++ b/js/plates-model/get-cross-section.js
@@ -70,7 +70,7 @@ function getFieldRawData (field) {
     result.marked = true
   }
   if (field.earthquake) {
-    result.earthquake = true
+    result.earthquake = field.earthquake
   }
   return result
 }

--- a/js/plates-model/get-cross-section.js
+++ b/js/plates-model/get-cross-section.js
@@ -52,7 +52,8 @@ function getFieldRawData (field) {
     id: field.id,
     elevation: field.elevation,
     crustThickness: field.crustThickness,
-    lithosphereThickness: field.lithosphereThickness
+    lithosphereThickness: field.lithosphereThickness,
+    earthquake: field.earthquake
   }
   // Use conditionals so we transfer minimal amount of data from worker to the main thread.
   // This data is not processed later, it's directly passed to the main thread.
@@ -67,6 +68,9 @@ function getFieldRawData (field) {
   }
   if (field.marked) {
     result.marked = true
+  }
+  if (field.earthquake) {
+    result.earthquake = true
   }
   return result
 }

--- a/js/plates-view/render-cross-section.js
+++ b/js/plates-view/render-cross-section.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import config from '../config'
 import magmaSrc from '../../images/magma.png'
+import depthToColor from './earthquake-helpers'
 
 export const OCEANIC_CRUST_COL = '#27374f'
 export const CONTINENTAL_CRUST_COL = '#643d0c'
@@ -69,16 +70,19 @@ function drawMarker (ctx, crustPos) {
   ctx.fill()
 }
 
-function drawEarthquake (ctx, crustPos) {
-  ctx.fillStyle = '#af3627'
-  const markerWidth = 4
-  const markerHeight = 4
+function drawEarthquake(ctx, crustPos, earthquake) {
+  const earthquakeSize = 1 + Math.ceil(earthquake.magnitude)
+  const strokeWidth = earthquakeSize * 0.1
   const x = scaleX(crustPos.x)
-  const topY = scaleY(crustPos.y) - markerHeight
-  ctx.fillRect(x - markerWidth / 2, topY, markerWidth, markerHeight)
+  const y = scaleY(crustPos.y) // + scaleY(earthquake.depth)
+
+  ctx.fillStyle = '#ff0000' // this will come from depth
+  ctx.strokeStyle = '#000'
+  ctx.lineWidth = strokeWidth
   ctx.beginPath()
-  ctx.arc(x, topY, markerWidth * 1.4, 0, Math.PI * 2)
+  ctx.arc(x, y, earthquakeSize * 1.4, 0, Math.PI * 2)
   ctx.fill()
+  ctx.stroke()
 }
 
 function debugInfo (ctx, p1, p2, info) {
@@ -117,9 +121,6 @@ function renderChunk (ctx, chunkData) {
     if (f1.marked) {
       drawMarker(ctx, t1)
     }
-    if (f1.earthquake) {
-      drawEarthquake(ctx, t1);
-    }
     // Fill crust
     fillPath(ctx, f1.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, t1, tMid, cMid, c1)
     fillPath(ctx, f2.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, tMid, t2, c2, cMid)
@@ -133,6 +134,25 @@ function renderChunk (ctx, chunkData) {
     }
     if (f1.risingMagma) {
       drawMagma(ctx, t1)
+    }
+  }
+}
+
+function renderChunkEarthquakes (ctx, chunkData) {
+  for (let i = 0; i < chunkData.length - 1; i += 1) {
+    const x1 = chunkData[i].dist
+    const x2 = chunkData[i + 1].dist
+    const f1 = chunkData[i].field
+    const f2 = chunkData[i + 1].field
+
+    // Until we implement depth correctly for earthquakes, place them on the boundary beetween crust and lithosphere
+    // Bottom of the crust, top of the lithosphere
+    const c1 = new THREE.Vector2(x1, f1.elevation - f1.crustThickness)
+    const c2 = new THREE.Vector2(x2, f2.elevation - f2.crustThickness)
+    const cMid = new THREE.Vector2((c1.x + c2.x) / 2, (c1.y + c2.y) / 2)
+
+    if (f1.earthquake) {
+      drawEarthquake(ctx, cMid, f1.earthquake);
     }
   }
 }
@@ -158,4 +178,5 @@ export default function renderCrossSection (canvas, data) {
   ctx.clearRect(0, 0, width, HEIGHT + SKY_PADDING)
   renderSkyAndSea(ctx, width)
   data.forEach(chunkData => renderChunk(ctx, chunkData))
+  data.forEach(chunkData => renderChunkEarthquakes(ctx, chunkData))
 }

--- a/js/plates-view/render-cross-section.js
+++ b/js/plates-view/render-cross-section.js
@@ -75,13 +75,14 @@ function drawMarker (ctx, crustPos) {
   ctx.fill()
 }
 
-function drawEarthquake (ctx, crustPos, earthquake) {
+function drawEarthquake (ctx, crustPos, field) {
+  const earthquake = field.earthquake
   const earthquakeSize = (1 + Math.ceil(earthquake.magnitude))
   const strokeWidth = earthquakeSize * 0.1
   const x = scaleX(crustPos.x)
 
   // Not ideal depth calculation until actual depth is in the correct range
-  const adjustedDepth = crustPos.y - (0.2 * earthquake.depth)
+  const adjustedDepth = field.elevation - earthquake.depth
   const y = scaleY(adjustedDepth)
 
   ctx.fillStyle = earthquakeColor(earthquake.depth)
@@ -155,7 +156,7 @@ function renderChunkEarthquakes (ctx, chunkData) {
     const c1 = new THREE.Vector2(x1, f1.elevation - f1.crustThickness)
 
     if (f1.earthquake) {
-      drawEarthquake(ctx, c1, f1.earthquake)
+      drawEarthquake(ctx, c1, f1)
     }
   }
 }

--- a/js/plates-view/render-cross-section.js
+++ b/js/plates-view/render-cross-section.js
@@ -79,10 +79,7 @@ function drawEarthquake (ctx, xPos, elevation, earthquake) {
   const earthquakeSize = (1 + Math.ceil(earthquake.magnitude))
   const strokeWidth = earthquakeSize * 0.1
   const x = scaleX(xPos)
-
-  // Not ideal depth calculation until actual depth is in the correct range
-  const adjustedDepth = elevation - earthquake.depth
-  const y = scaleY(adjustedDepth)
+  const y = scaleY(elevation - earthquake.depth)
 
   ctx.fillStyle = earthquakeColor(earthquake.depth)
   ctx.strokeStyle = '#000'

--- a/js/plates-view/render-cross-section.js
+++ b/js/plates-view/render-cross-section.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three'
 import config from '../config'
 import magmaSrc from '../../images/magma.png'
-import depthToColor from './earthquake-helpers'
 
 export const OCEANIC_CRUST_COL = '#27374f'
 export const CONTINENTAL_CRUST_COL = '#643d0c'
@@ -70,11 +69,12 @@ function drawMarker (ctx, crustPos) {
   ctx.fill()
 }
 
-function drawEarthquake(ctx, crustPos, earthquake) {
+function drawEarthquake (ctx, crustPos, earthquake) {
   const earthquakeSize = 1 + Math.ceil(earthquake.magnitude)
   const strokeWidth = earthquakeSize * 0.1
   const x = scaleX(crustPos.x)
-  const y = scaleY(crustPos.y) // + scaleY(earthquake.depth)
+  const adjustedDepth = crustPos.y + (0.1 * earthquake.depth)
+  const y = scaleY(adjustedDepth)
 
   ctx.fillStyle = '#ff0000' // this will come from depth
   ctx.strokeStyle = '#000'
@@ -152,7 +152,7 @@ function renderChunkEarthquakes (ctx, chunkData) {
     const cMid = new THREE.Vector2((c1.x + c2.x) / 2, (c1.y + c2.y) / 2)
 
     if (f1.earthquake) {
-      drawEarthquake(ctx, cMid, f1.earthquake);
+      drawEarthquake(ctx, cMid, f1.earthquake)
     }
   }
 }

--- a/js/plates-view/render-cross-section.js
+++ b/js/plates-view/render-cross-section.js
@@ -69,6 +69,18 @@ function drawMarker (ctx, crustPos) {
   ctx.fill()
 }
 
+function drawEarthquake (ctx, crustPos) {
+  ctx.fillStyle = '#af3627'
+  const markerWidth = 4
+  const markerHeight = 4
+  const x = scaleX(crustPos.x)
+  const topY = scaleY(crustPos.y) - markerHeight
+  ctx.fillRect(x - markerWidth / 2, topY, markerWidth, markerHeight)
+  ctx.beginPath()
+  ctx.arc(x, topY, markerWidth * 1.4, 0, Math.PI * 2)
+  ctx.fill()
+}
+
 function debugInfo (ctx, p1, p2, info) {
   ctx.strokeStyle = 'black'
   ctx.beginPath()
@@ -104,6 +116,9 @@ function renderChunk (ctx, chunkData) {
 
     if (f1.marked) {
       drawMarker(ctx, t1)
+    }
+    if (f1.earthquake) {
+      drawEarthquake(ctx, t1);
     }
     // Fill crust
     fillPath(ctx, f1.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, t1, tMid, cMid, c1)

--- a/js/plates-view/render-cross-section.js
+++ b/js/plates-view/render-cross-section.js
@@ -75,14 +75,13 @@ function drawMarker (ctx, crustPos) {
   ctx.fill()
 }
 
-function drawEarthquake (ctx, crustPos, field) {
-  const earthquake = field.earthquake
+function drawEarthquake (ctx, xPos, elevation, earthquake) {
   const earthquakeSize = (1 + Math.ceil(earthquake.magnitude))
   const strokeWidth = earthquakeSize * 0.1
-  const x = scaleX(crustPos.x)
+  const x = scaleX(xPos)
 
   // Not ideal depth calculation until actual depth is in the correct range
-  const adjustedDepth = field.elevation - earthquake.depth
+  const adjustedDepth = elevation - earthquake.depth
   const y = scaleY(adjustedDepth)
 
   ctx.fillStyle = earthquakeColor(earthquake.depth)
@@ -149,14 +148,11 @@ function renderChunk (ctx, chunkData) {
 
 function renderChunkEarthquakes (ctx, chunkData) {
   for (let i = 0; i < chunkData.length - 1; i += 1) {
-    const x1 = chunkData[i].dist
     const f1 = chunkData[i].field
-
-    // Until we implement depth correctly for earthquakes, place them on the boundary beetween crust and lithosphere
-    const c1 = new THREE.Vector2(x1, f1.elevation - f1.crustThickness)
+    const x1 = chunkData[i].dist
 
     if (f1.earthquake) {
-      drawEarthquake(ctx, c1, f1)
+      drawEarthquake(ctx, x1, f1.elevation, f1.earthquake)
     }
   }
 }


### PR DESCRIPTION
This initial work will render the earthquakes in cross section view and display them at relative magnitude sizes. The depth calculation may need to be changed at the earthquake level or pending review feedback on how to interpret the data. There is currently an issue with rendering the quakes when using the subduction preset (?preset=subduction&debugCrossSection=true&earthquakes=true) showing them below and to the left of where the top plate meets the subducting plate