### PR TITLE
Volcanoes and earthquakes updated

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -19,18 +19,18 @@ const DEFAULT_CONFIG = {
   // Lifespan of an earthquake in model time.
   earthquakeLifespan: 1,
   // Constant that decides how likely is for an earthquake to show up in the subduction zone.
-  earthquakeInSubductionZoneProbability: 0.75,
+  earthquakeInSubductionZoneProbability: 7.5,
   // Constant that decides how likely is for an earthquake to show up in the divergent boundary zone.
-  earthquakeInDivergentZoneProbability: 2,
+  earthquakeInDivergentZoneProbability: 20,
   // If true, the model will show randomly generated volcanic eruptions.
   volcanicEruptions: false,
   // Lifespan of a volcanic eruption in model time.
   volcanicEruptionLifespan: 2,
   volcanicEruptionColor: 'FF7A00',
   // Constant that decides how likely is for an volcanic eruption to occur on the continent.
-  volcanicEruptionOnContinentProbability: 0.003,
+  volcanicEruptionOnContinentProbability: 0.03,
   // Constant that decides how likely is for an volcanic eruption to occur on island.
-  volcanicEruptionOnIslandProbability: 0.009,
+  volcanicEruptionOnIslandProbability: 0.09,
   // Ease-out transition time when earthquake shows up and disappears.
   tempEventTransitionTime: 750, // ms
   // If number of steps is provided, model will stop every `stopAfter` steps. This is useful mostly for automated

--- a/js/config.js
+++ b/js/config.js
@@ -26,6 +26,7 @@ const DEFAULT_CONFIG = {
   volcanicEruptions: false,
   // Lifespan of a volcanic eruption in model time.
   volcanicEruptionLifespan: 2,
+  volcanicEruptionColor: 'FF7A00',
   // Constant that decides how likely is for an volcanic eruption to occur on the continent.
   volcanicEruptionOnContinentProbability: 0.003,
   // Constant that decides how likely is for an volcanic eruption to occur on island.

--- a/js/plates-model/earthquake.js
+++ b/js/plates-model/earthquake.js
@@ -11,13 +11,13 @@ export default class Earthquake {
     //    is progressing faster (relative speed between plates is higher). Also, don't show earthqyakes at the beginning
     //    of the subduction zone, as that's likely to be a trench and it wouldn't look good in the cross-section.
     if (field.subductingFieldUnderneath && field.subductingFieldUnderneath.subduction.progress > 0.15) {
-      if (random() < field.subductingFieldUnderneath.subduction.relativeVelocity.length() * config.earthquakeInSubductionZoneProbability) {
+      if (random() < field.subductingFieldUnderneath.subduction.relativeVelocity.length() * config.earthquakeInSubductionZoneProbability * config.timestep) {
         return true
       }
     }
     // B. Field is next to the divergent boundary. Then, the earthquake should be more likely to show up when the
     //    plate is moving faster and divergent boundary is more visible.
-    return field.divergentBoundaryZone && random() < field.linearVelocity.length() * config.earthquakeInDivergentZoneProbability
+    return field.divergentBoundaryZone && random() < field.linearVelocity.length() * config.earthquakeInDivergentZoneProbability * config.timestep
   }
 
   constructor (field) {

--- a/js/plates-model/get-cross-section.js
+++ b/js/plates-model/get-cross-section.js
@@ -53,7 +53,6 @@ function getFieldRawData (field) {
     elevation: field.elevation,
     crustThickness: field.crustThickness,
     lithosphereThickness: field.lithosphereThickness,
-    earthquake: field.earthquake
   }
   // Use conditionals so we transfer minimal amount of data from worker to the main thread.
   // This data is not processed later, it's directly passed to the main thread.
@@ -70,7 +69,13 @@ function getFieldRawData (field) {
     result.marked = true
   }
   if (field.earthquake) {
-    result.earthquake = field.earthquake
+    result.earthquake = {
+      magnitude: field.earthquake.magnitude,
+      depth: field.earthquake.depth
+    }
+  }
+  if (field.volcanicEruption) {
+    result.volcanicEruption = true
   }
   return result
 }

--- a/js/plates-model/get-cross-section.js
+++ b/js/plates-model/get-cross-section.js
@@ -16,11 +16,11 @@ function shouldSmoothFieldData (field) {
 }
 
 // Look at 3 nearest fields. If the nearest one is an ocean, look at it's neighbours and smooth out data a bit.
-function getFieldAvgData (plate, pos) {
+function getFieldAvgData (plate, pos, props) {
   const data = plate.nearestFields(pos, 3)
   if (data.length === 0) return null
   const nearestField = data[0].field
-  const result = getFieldRawData(nearestField)
+  const result = getFieldRawData(nearestField, props)
   if (!shouldSmoothFieldData(nearestField)) {
     return result // just raw data
   }
@@ -47,12 +47,12 @@ function getFieldAvgData (plate, pos) {
 }
 
 // Returns copy of field data necessary to draw a cross section.
-function getFieldRawData (field) {
+function getFieldRawData (field, props) {
   const result = {
     id: field.id,
     elevation: field.elevation,
     crustThickness: field.crustThickness,
-    lithosphereThickness: field.lithosphereThickness,
+    lithosphereThickness: field.lithosphereThickness
   }
   // Use conditionals so we transfer minimal amount of data from worker to the main thread.
   // This data is not processed later, it's directly passed to the main thread.
@@ -68,13 +68,13 @@ function getFieldRawData (field) {
   if (field.marked) {
     result.marked = true
   }
-  if (field.earthquake) {
+  if (props.earthquakes && field.earthquake) {
     result.earthquake = {
       magnitude: field.earthquake.magnitude,
       depth: field.earthquake.depth
     }
   }
-  if (field.volcanicEruption) {
+  if (props.volcanicEruptions && field.volcanicEruption) {
     result.volcanicEruption = true
   }
   return result
@@ -240,7 +240,7 @@ function calculatePointCenters (result) {
 
 // Returns cross section data for given plates, between point1 and point2.
 // Result is an array of arrays. Each array corresponds to one plate.
-export default function getCrossSection (plates, point1, point2) {
+export default function getCrossSection (plates, point1, point2, props) {
   const result = []
 
   let p1 = (new THREE.Vector3(point1.x, point1.y, point1.z)).normalize()
@@ -277,9 +277,9 @@ export default function getCrossSection (plates, point1, point2) {
         }
         let fieldData = null
         if (config.smoothCrossSection) {
-          fieldData = getFieldAvgData(plate, pos)
+          fieldData = getFieldAvgData(plate, pos, props)
         } else {
-          fieldData = getFieldRawData(field)
+          fieldData = getFieldRawData(field, props)
         }
         const prevData = currentData[currentData.length - 1]
         if (!prevData || !equalFields(prevData.field, fieldData) || i === steps) {

--- a/js/plates-model/model-output.js
+++ b/js/plates-model/model-output.js
@@ -118,11 +118,11 @@ export default function modelOutput (model, props = {}, forcedUpdate) {
     const p2 = props.crossSectionPoint2
     const p3 = props.crossSectionPoint3
     const p4 = props.crossSectionPoint4
-    result.crossSection.dataFront = getCrossSection(model.plates, swap ? p2 : p1, swap ? p1 : p2)
+    result.crossSection.dataFront = getCrossSection(model.plates, swap ? p2 : p1, swap ? p1 : p2, props)
     if (config.crossSection3d) {
-      result.crossSection.dataRight = getCrossSection(model.plates, swap ? p1 : p2, swap ? p4 : p3)
-      result.crossSection.dataBack = getCrossSection(model.plates, swap ? p4 : p3, swap ? p3 : p4)
-      result.crossSection.dataLeft = getCrossSection(model.plates, swap ? p3 : p4, swap ? p2 : p1)
+      result.crossSection.dataRight = getCrossSection(model.plates, swap ? p1 : p2, swap ? p4 : p3, props)
+      result.crossSection.dataBack = getCrossSection(model.plates, swap ? p4 : p3, swap ? p3 : p4, props)
+      result.crossSection.dataLeft = getCrossSection(model.plates, swap ? p3 : p4, swap ? p2 : p1, props)
     }
   }
   return result

--- a/js/plates-model/volcanic-eruption.js
+++ b/js/plates-model/volcanic-eruption.js
@@ -5,7 +5,7 @@ import { random } from '../seedrandom'
 export default class VolcanicEruption {
   static shouldCreateVolcanicEruption (field) {
     return field.risingMagma &&
-           random() < (field.isIsland ? config.volcanicEruptionOnIslandProbability : config.volcanicEruptionOnContinentProbability)
+           random() < (field.isIsland ? config.volcanicEruptionOnIslandProbability : config.volcanicEruptionOnContinentProbability) * config.timestep
   }
 
   constructor () {

--- a/js/plates-view/earthquake-helpers.js
+++ b/js/plates-view/earthquake-helpers.js
@@ -2,23 +2,27 @@ import * as THREE from 'three'
 
 const TEXTURE_SIZE = 64
 
-export function earthquakeTexture () {
-  const size = TEXTURE_SIZE
+export function drawEarthquakeShape (ctx, x, y, size, color) {
   const strokeWidth = size * 0.06
-  const canvas = document.createElement('canvas')
-  canvas.width = size
-  canvas.height = size
-  const ctx = canvas.getContext('2d')
   // Point
-  ctx.arc(size / 2, size / 2, size / 2 - strokeWidth / 2, 0, 2 * Math.PI)
-  // Why is the color white? Note that in the temporal-event.js and temporal-event-fragment.glsl we set
-  // custom color attribute. In the fragment shader, we multiply texture color by this custom color.
-  // So, if the texture color is white, it will end up being the custom color after multiplication.
-  ctx.fillStyle = '#fff'
+  ctx.beginPath()
+  ctx.arc(x, y, size / 2 - strokeWidth / 2, 0, 2 * Math.PI)
+  ctx.fillStyle = color
   ctx.fill()
   ctx.lineWidth = strokeWidth
   ctx.strokeStyle = '#000'
   ctx.stroke()
+}
+
+export function earthquakeTexture () {
+  const canvas = document.createElement('canvas')
+  canvas.width = TEXTURE_SIZE
+  canvas.height = TEXTURE_SIZE
+  const ctx = canvas.getContext('2d')
+  // Why is the color white? Note that in the temporal-event.js and temporal-event-fragment.glsl we set
+  // custom color attribute. In the fragment shader, we multiply texture color by this custom color.
+  // So, if the texture color is white, it will end up being the custom color after multiplication.
+  drawEarthquakeShape(ctx, TEXTURE_SIZE * 0.5, TEXTURE_SIZE * 0.5, TEXTURE_SIZE, '#fff')
   const texture = new THREE.Texture(canvas)
   texture.needsUpdate = true
   return texture

--- a/js/plates-view/plate-mesh.js
+++ b/js/plates-view/plate-mesh.js
@@ -174,8 +174,6 @@ export default class PlateMesh {
   updatePlateAndFields () {
     this.radius = PlateMesh.getRadius(this.plate.density)
     this.basicMesh.setRotationFromQuaternion(this.plate.quaternion)
-    this.earthquakes.root.setRotationFromQuaternion(this.plate.quaternion)
-    this.volcanicEruptions.root.setRotationFromQuaternion(this.plate.quaternion)
     if (this.store.renderEulerPoles) {
       if (this.plate.angularSpeed > MIN_SPEED_TO_RENDER_POLE) {
         this.axis.visible = true
@@ -262,24 +260,23 @@ export default class PlateMesh {
       if (renderForces) {
         this.forces.setVector(field.id, field.force, field.absolutePos)
       }
-      if (earthquakes && field.earthquakeMagnitude > 0) {
+      if (earthquakes) {
+        const visible = field.earthquakeMagnitude > 0
         this.earthquakes.setProps(field.id, {
-          visible: true,
-          position: field.localPos.clone().setLength(EARTHQUAKE_RADIUS), // just a bit above surface
-          color: depthToColor(field.earthquakeDepth),
-          size: magnitudeToSize(field.earthquakeMagnitude)
+          visible,
+          // Note that we still need to update position if earthquake is invisible, as there might be an ease-out transition in progress.
+          position: field.absolutePos.clone().setLength(EARTHQUAKE_RADIUS),
+          color: visible ? depthToColor(field.earthquakeDepth) : null,
+          size: visible ? magnitudeToSize(field.earthquakeMagnitude) : null
         })
-      } else if (earthquakes && field.earthquakeMagnitude === 0) {
-        this.earthquakes.setProps(field.id, { visible: false })
       }
-      if (volcanicEruptions && field.volcanicEruption) {
+      if (volcanicEruptions) {
         this.volcanicEruptions.setProps(field.id, {
-          visible: true,
-          position: field.localPos.clone().setLength(VOLCANIC_ERUPTION_RADIUS),
-          size: 0.012
+          visible: field.volcanicEruption,
+          // Note that we still need to update position if eruption is invisible, as there might be an ease-out transition in progress.
+          position: field.absolutePos.clone().setLength(VOLCANIC_ERUPTION_RADIUS),
+          size: 0.014
         })
-      } else if (volcanicEruptions && !field.volcanicEruption) {
-        this.volcanicEruptions.setProps(field.id, { visible: false })
       }
     })
     // Process fields that are still visible, but no longer part of the plate model.

--- a/js/plates-view/plate-mesh.js
+++ b/js/plates-view/plate-mesh.js
@@ -275,7 +275,7 @@ export default class PlateMesh {
           visible: field.volcanicEruption,
           // Note that we still need to update position if eruption is invisible, as there might be an ease-out transition in progress.
           position: field.absolutePos.clone().setLength(VOLCANIC_ERUPTION_RADIUS),
-          size: 0.014
+          size: field.volcanicEruption ? 0.016 : null
         })
       }
     })

--- a/js/plates-view/plate-mesh.js
+++ b/js/plates-view/plate-mesh.js
@@ -79,7 +79,7 @@ export default class PlateMesh {
     this.forces = new VectorField(0xff0000, getGrid().size)
     this.root.add(this.forces.root)
 
-    this.earthquakes = new TemporalEvents(Math.ceil(getGrid().size), earthquakeTexture())
+    this.earthquakes = new TemporalEvents(Math.ceil(getGrid().size), earthquakeTexture(), true)
     this.root.add(this.earthquakes.root)
 
     this.volcanicEruptions = new TemporalEvents(Math.ceil(getGrid().size), volcanicEruptionTexture())
@@ -276,7 +276,6 @@ export default class PlateMesh {
         this.volcanicEruptions.setProps(field.id, {
           visible: true,
           position: field.localPos.clone().setLength(VOLCANIC_ERUPTION_RADIUS),
-          color: 0xFF7A00,
           size: 0.012
         })
       } else if (volcanicEruptions && !field.volcanicEruption) {

--- a/js/plates-view/temporal-events.js
+++ b/js/plates-view/temporal-events.js
@@ -119,10 +119,6 @@ export default class TemporalEvents {
     colorHelper.toArray(this.customColorAttr.array, i * 3)
   }
 
-  transitionInProgress (idx) {
-    return this.currentVisibility[idx] !== this.targetVisibility[idx]
-  }
-
   setProps (idx, { visible, position = null, color = null, size = null }) {
     this.targetVisibility[idx] = visible ? 1 : 0
     if (position) {

--- a/js/plates-view/temporal-events.js
+++ b/js/plates-view/temporal-events.js
@@ -119,6 +119,10 @@ export default class TemporalEvents {
     colorHelper.toArray(this.customColorAttr.array, i * 3)
   }
 
+  transitionInProgress (idx) {
+    return this.currentVisibility[idx] !== this.targetVisibility[idx]
+  }
+
   setProps (idx, { visible, position = null, color = null, size = null }) {
     this.targetVisibility[idx] = visible ? 1 : 0
     if (position) {
@@ -135,9 +139,12 @@ export default class TemporalEvents {
   setSize (idx, size) {
     const vi = idx * 6
     const pos = this.position[idx]
+    if (!pos) {
+      return
+    }
     // Cross product with any random, non-parallel vector will result in a perpendicular vector.
-    const randVec = pos.clone()
-    randVec.y += 0.1
+    // Adding some value to Y component ensures it's not parallel and the resulting vector will point towards north.
+    const randVec = new THREE.Vector3(pos.x, pos.y + 1, pos.z).applyAxisAngle(pos, -Math.PI * 0.5)
     const prependVec1 = pos.clone().cross(randVec)
     // Cross product of two vectors will result in a vector perpendicular to both.
     const prependVec2 = prependVec1.clone().cross(pos)

--- a/js/plates-view/temporal-events.js
+++ b/js/plates-view/temporal-events.js
@@ -40,7 +40,7 @@ function generateUVs (count) {
 // Helper class that accepts any texture (and alpha map) and lets you easily show and hide it with a nice transition.
 // Used to render earthquakes and volcanic eruptions.
 export default class TemporalEvents {
-  constructor (count, texture) {
+  constructor (count, texture, customColorPerObject) {
     this.count = count
     this.texture = texture
 
@@ -51,25 +51,40 @@ export default class TemporalEvents {
     this.geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3))
     this.positionAttr = this.geometry.attributes.position
     this.positionAttr.dynamic = true
-    // * 3 * 3 * 2 =>  2 * 3 vertices per rectangle (2 triangles to form a rectangle),
-    // each vertex has 3 values (r, g, b).
-    const customColors = new Float32Array(count * 3 * 3 * 2)
-    this.geometry.addAttribute('customColor', new THREE.BufferAttribute(customColors, 3))
-    this.customColorAttr = this.geometry.attributes.customColor
-    this.customColorAttr.dynamic = true
+
     // UVs to map texture onto rectangle.
     const uvs = generateUVs(count)
     this.geometry.addAttribute('uv', new THREE.BufferAttribute(uvs, 2))
 
+    // If customColorPerObject is equal to true, every object can have different color provided via #setProps.
+    // This color will be multiplied by texture colors, so the texture should have white areas in spots where
+    // the custom color should be applied.
+    if (customColorPerObject) {
+      // * 3 * 3 * 2 =>  2 * 3 vertices per rectangle (2 triangles to form a rectangle),
+      // each vertex has 3 values (r, g, b).
+      const customColors = new Float32Array(count * 3 * 3 * 2)
+      this.geometry.addAttribute('customColor', new THREE.BufferAttribute(customColors, 3))
+      this.customColorAttr = this.geometry.attributes.customColor
+      this.customColorAttr.dynamic = true
+
+      // Use custom shaders that handle custom color per object.
+      this.material = new THREE.ShaderMaterial({
+        uniforms: { texture: { type: 't', value: this.texture } },
+        vertexShader,
+        fragmentShader,
+        transparent: true,
+        alphaTest: 0.5
+      })
+    } else {
+      this.material = new THREE.MeshBasicMaterial({
+        map: this.texture,
+        transparent: true,
+        alphaTest: 0.5
+      })
+    }
+
     this.geometry.computeBoundingSphere()
 
-    this.material = new THREE.ShaderMaterial({
-      uniforms: { texture: { type: 't', value: this.texture } },
-      vertexShader,
-      fragmentShader,
-      transparent: true,
-      alphaTest: 0.5
-    })
     this.root = new THREE.Mesh(this.geometry, this.material)
 
     this.position = []
@@ -97,6 +112,9 @@ export default class TemporalEvents {
   }
 
   setVertexColor (i, value) {
+    if (!this.customColorAttr) {
+      throw new Error('Custom color per object mode is not available.')
+    }
     colorHelper.setHex(value)
     colorHelper.toArray(this.customColorAttr.array, i * 3)
   }

--- a/js/plates-view/volcanic-eruption-helpers.js
+++ b/js/plates-view/volcanic-eruption-helpers.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three'
+import config from '../config'
 
 const TEXTURE_SIZE = 64
 
@@ -12,7 +13,7 @@ export function drawVolcanicEruptionShape (ctx, x, y, size) {
   ctx.lineTo(x, y - size + halfStrokeWidth)
   ctx.lineTo(x + halfSize - halfStrokeWidth, y - halfStrokeWidth)
   ctx.lineTo(x - halfSize + halfStrokeWidth, y - halfStrokeWidth)
-  ctx.fillStyle = '#FF7A00'
+  ctx.fillStyle = '#' + config.volcanicEruptionColor
   ctx.fill()
   ctx.lineWidth = strokeWidth
   ctx.strokeStyle = '#000'

--- a/js/plates-view/volcanic-eruption-helpers.js
+++ b/js/plates-view/volcanic-eruption-helpers.js
@@ -2,26 +2,26 @@ import * as THREE from 'three'
 
 const TEXTURE_SIZE = 64
 
-export function volcanicEruptionTexture () {
-  const size = TEXTURE_SIZE
-  const strokeWidth = size * 0.06
-  const canvas = document.createElement('canvas')
-  canvas.width = size
-  canvas.height = size
-  const ctx = canvas.getContext('2d')
+export function drawVolcanicEruptionShape (ctx, x, y, size) {
+  // Triangle.
   ctx.beginPath()
-  // Equilateral triangle.
-  ctx.moveTo(0.5 * size, 0)
-  ctx.lineTo(0, size * 0.866)
-  ctx.lineTo(size, size * 0.866)
-  ctx.lineTo(0.5 * size, 0)
-
-  ctx.fillStyle = '#fff'
+  ctx.moveTo(x - size * 0.5, y)
+  ctx.lineTo(x, y - size)
+  ctx.lineTo(x + size * 0.5, y)
+  ctx.lineTo(x - size * 0.5, y)
+  ctx.fillStyle = '#FF7A00'
   ctx.fill()
-
-  ctx.lineWidth = strokeWidth
+  ctx.lineWidth = size * 0.06
   ctx.strokeStyle = '#000'
   ctx.stroke()
+}
+
+export function volcanicEruptionTexture () {
+  const canvas = document.createElement('canvas')
+  canvas.width = TEXTURE_SIZE
+  canvas.height = TEXTURE_SIZE
+  const ctx = canvas.getContext('2d')
+  drawVolcanicEruptionShape(ctx, TEXTURE_SIZE * 0.5, TEXTURE_SIZE, TEXTURE_SIZE)
   const texture = new THREE.Texture(canvas)
   texture.needsUpdate = true
   return texture

--- a/js/plates-view/volcanic-eruption-helpers.js
+++ b/js/plates-view/volcanic-eruption-helpers.js
@@ -3,15 +3,18 @@ import * as THREE from 'three'
 const TEXTURE_SIZE = 64
 
 export function drawVolcanicEruptionShape (ctx, x, y, size) {
+  const strokeWidth = size * 0.04
+  const halfStrokeWidth = strokeWidth * 0.5
+  const halfSize = size * 0.5
   // Triangle.
   ctx.beginPath()
-  ctx.moveTo(x - size * 0.5, y)
-  ctx.lineTo(x, y - size)
-  ctx.lineTo(x + size * 0.5, y)
-  ctx.lineTo(x - size * 0.5, y)
+  ctx.moveTo(x - halfSize + halfStrokeWidth, y - halfStrokeWidth)
+  ctx.lineTo(x, y - size + halfStrokeWidth)
+  ctx.lineTo(x + halfSize - halfStrokeWidth, y - halfStrokeWidth)
+  ctx.lineTo(x - halfSize + halfStrokeWidth, y - halfStrokeWidth)
   ctx.fillStyle = '#FF7A00'
   ctx.fill()
-  ctx.lineWidth = size * 0.06
+  ctx.lineWidth = strokeWidth
   ctx.strokeStyle = '#000'
   ctx.stroke()
 }


### PR DESCRIPTION
Changes:
1. Volcanic eruptions are now being rendering in cross-section view
2. Eruptions symbol are pointing north (requested by Sarah)
3. Eruptions symbol color is now configurable (so Amy and Sarah can play with it)
4. Fixed a bug that was causing timestep change to generate a different number of earthquakes and eruptions
5. Fixed a bug that was causing earthquakes and eruptions always being rendered in the cross-section (regardless of the side menu settings)