### PR TITLE
Fix density selector UI and remove canvas outline

### DIFF
--- a/css/cross-section-3d.less
+++ b/css/cross-section-3d.less
@@ -7,4 +7,8 @@
     top: 50px;
     left: 0;
   }
+
+  canvas {
+    outline: none;
+  }
 }

--- a/css/planet-view.less
+++ b/css/planet-view.less
@@ -18,6 +18,10 @@
     top: 0;
     left: 0;
   }
+
+  canvas {
+    outline: none;
+  }
 }
 
 .time-display {

--- a/js/components/sortable-densities.tsx
+++ b/js/components/sortable-densities.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { inject, observer } from "mobx-react";
-import { SortableContainer, SortableElement, SortableHandle, arrayMove } from "react-sortable-hoc";
+import { SortableContainer, SortableElement, SortableHandle } from "react-sortable-hoc";
+import arrayMove from "array-move";
 import { hsv } from "d3-hsv";
 import FontIcon from "react-toolbox/lib/font_icon";
 import config from "../config";
+import { BaseComponent, IBaseProps } from "./base";
+import PlateStore from "../stores/plate-store";
 
 import "../../css/sortable-densities.less";
-import { BaseComponent, IBaseProps } from "./base";
 
 function hueToBackground(hue: any) {
   const rgb = hsv(hue, 1, 0.4).rgb();
@@ -47,28 +49,23 @@ export default class SortableDensities extends BaseComponent<IBaseProps, IState>
 
   get plateInfos() {
     // Convert props into an array of object that works with react-sortable component.
-    const plates = this.props.simulationStore?.model.plates;
-    const plateInfos = plates?.map((plate: any) => {
-      return {
-        id: plate.id,
-        hue: plate.hue,
-        density: plate.density,
-        label: "Plate " + (plate.id + 1)
-      };
-    }) || [];
-    plateInfos.sort((infoA: any, infoB: any) => infoA.density - infoB.density);
-    return plateInfos;
+    return this.props.simulationStore?.model.sortedPlates.map((plate: PlateStore) => ({
+      id: plate.id,
+      hue: plate.hue,
+      density: plate.density,
+      label: "Plate " + (plate.id + 1)
+    })) || [];
   }
 
   updateDensities(newPlateInfos: any) {
     const newDensities: Record<string, any> = {};
-    newPlateInfos.forEach((plateInfo: any, index: any) => {
+    newPlateInfos.forEach((plateInfo: any, index: number) => {
       newDensities[plateInfo.id] = index;
     });
     this.simulationStore.setDensities(newDensities);
   }
 
-  onSortEnd({ oldIndex, newIndex }: any) {
+  onSortEnd({ oldIndex, newIndex }: { oldIndex: number, newIndex: number }) {
     this.updateDensities(arrayMove(this.plateInfos, oldIndex, newIndex));
   }
 

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -85,6 +85,8 @@ export class SimulationStore {
     if (config.modelId) {
       this.loadCloudModel(config.modelId);
     }
+    // For debugging purposes
+    (window as any).s = this;
   }
 
   // Computed (and cached!) properties.
@@ -283,6 +285,8 @@ export class SimulationStore {
     this.model.plates.forEach(plate => {
       plate.density = densities[plate.id];
     });
+    // Recreate platesMap to update all its observers (e.g. SortableDensities component).
+    this.model.platesMap = new Map(this.model.platesMap);
     workerController.postMessageToModel({
       type: "setDensities",
       densities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tectonic-explorer",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3317,6 +3317,11 @@
         "get-intrinsic": "^1.0.1",
         "is-string": "^1.0.5"
       }
+    },
+    "array-move": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
+      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg=="
     },
     "array-union": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/concord-consortium/tectonic-explorer#readme",
   "dependencies": {
+    "array-move": "^3.0.1",
     "d3-color": "^2.0.0",
     "d3-hsv": "^0.1.0",
     "d3-interpolate": "^2.0.1",

--- a/test/components/sortable-densities.test.tsx
+++ b/test/components/sortable-densities.test.tsx
@@ -10,7 +10,7 @@ describe("SortableDensities component", () => {
     (global as any).resetConfig();
     store = {
       model: {
-        plates: []
+        sortedPlates: []
       }
     };
   });


### PR DESCRIPTION
This PR fixes Step 4 in the planet wizard:
https://tectonic-explorer.concord.org/branch/master/index.html?planetWizard=true
If you get there, you should notice that densities are draggable, but once dragging stops, they always go back to their initial positions.

Also, there's a tiny fix that removes canvas outline. When user clicks anywhere in the main view or cross-section, a blue outline is added. It doesn't seem useful, so I just removed that.