### PR TITLE
Add basic rock layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ While working on input data, HSV colors should be used:
   - 0.4 is the deepest possible ocean (0.0 value would be black, so plates couldn't be distinguished from each other)
   - 0.7 is the sea level
   - 1.0 is the highest possible mountain
-  - [0.4, 0.55] is assumed to be oceanic crust
-  - (0.55, 1.0] is assumed to be continental crust (note that part of the continent is below the sea level)
+  - values around 0.4 are assumed to be oceanic crust
+  - values > 0.4 are assumed to be continental crust (note that part of the continent is below the sea level)
   
 Sometimes **V** component might have values from 0 to 100 instead of [0, 1], it depends on the graphics editor.
 The same rules will apply, but everything above should be multiplied by 100.

--- a/js/colormaps.ts
+++ b/js/colormaps.ts
@@ -2,9 +2,11 @@ import { scaleLinear } from "d3-scale";
 import { interpolateHcl } from "d3-interpolate";
 import { hsv } from "d3-hsv";
 import { rgb } from "d3-color";
+import { HIGHEST_MOUNTAIN_ELEVATION, BASE_OCEAN_ELEVATION } from "./plates-model/field";
+import { BASE_OCEAN_HSV_V } from "./plates-model/generate-plates";
 
 const MIN_ELEVATION = -1;
-const MAX_ELEVATION = 1;
+const MAX_ELEVATION = HIGHEST_MOUNTAIN_ELEVATION;
 
 // Color object used internally by 3D rendering.
 const toF = 1 / 255;
@@ -42,7 +44,7 @@ function d3Colormap(desc: any, shadesCount: number | null = null) {
 // https://en.wikipedia.org/wiki/Wikipedia:WikiProject_Maps/Conventions#Topographic_maps
 const topoColormap = d3Colormap({
   [MIN_ELEVATION]: "#2f85bf",
-  0.00: "#3696d8",
+  [BASE_OCEAN_ELEVATION]: "#3696d8",
   0.49: "#b5ebfe",
   0.50: "#A7DFD2",
   0.55: "#94BF8B",
@@ -57,17 +59,17 @@ const topoColormap = d3Colormap({
   [MAX_ELEVATION]: "#FFFFFF"
 }, 1000);
 
-export function topoColor(elevation: any) {
+export function topoColor(elevation: number) {
   const elevationNorm = (Math.max(MIN_ELEVATION, Math.min(MAX_ELEVATION, elevation)) - MIN_ELEVATION) / (MAX_ELEVATION - MIN_ELEVATION);
   const shade = Math.floor(elevationNorm * (topoColormap.length - 1));
   return topoColormap[shade];
 }
 
 // Hue should be within [0, 360] range and elevation will be clamped to [-1, 1] range.
-export function hueAndElevationToRgb(hue: any, elevation = 0) {
-  const trenchVal = 0.3;
-  const deepestOceanVal = 0.4;
-  const highestMountainsVal = 1;
+export function hueAndElevationToRgb(hue: number, elevation = 0) {
+  const trenchVal = BASE_OCEAN_HSV_V - 0.1; // anything below BASE_OCEAN_HSV_V
+  const deepestOceanVal = BASE_OCEAN_HSV_V;
+  const highestMountainsVal = HIGHEST_MOUNTAIN_ELEVATION;
   let value;
   if (elevation < 0) {
     // Map elevation [-1, 0] to [trenchVal, deepestOceanVal]

--- a/js/colormaps.ts
+++ b/js/colormaps.ts
@@ -43,7 +43,8 @@ function d3Colormap(desc: any, shadesCount: number | null = null) {
 // https://gist.github.com/hugolpz/4351d8f1b3da93de2c61
 // https://en.wikipedia.org/wiki/Wikipedia:WikiProject_Maps/Conventions#Topographic_maps
 const topoColormap = d3Colormap({
-  [MIN_ELEVATION]: "#2f85bf",
+  [MIN_ELEVATION]: "#15364d",
+  [-0.05]: "#173e5c",
   [BASE_OCEAN_ELEVATION]: "#3696d8",
   0.49: "#b5ebfe",
   0.50: "#A7DFD2",

--- a/js/components/color-key.tsx
+++ b/js/components/color-key.tsx
@@ -4,8 +4,9 @@ import { topoColor, hueAndElevationToRgb } from "../colormaps";
 import { EARTHQUAKE_COLORS } from "../plates-view/earthquake-helpers";
 import FontIcon from "react-toolbox/lib/font_icon";
 import { Button } from "react-toolbox/lib/button";
-import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, OCEAN_COL, SKY_COL_1 } from "../cross-section-colors";
+import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, OCEAN_COL, SKY_COL_1, ROCKS_COL } from "../cross-section-colors";
 import { BaseComponent, IBaseProps } from "./base";
+import { Rock, ROCK_LABEL } from "../plates-model/crust";
 
 import css from "../../css-modules/color-key.less";
 
@@ -88,7 +89,7 @@ export default class ColorKey extends BaseComponent<IBaseProps, IState> {
   }
 
   renderKeyContent() {
-    const { colormap, model, earthquakes, volcanicEruptions, crossSectionVisible } = this.simulationStore;
+    const { colormap, model, earthquakes, volcanicEruptions, crossSectionVisible, crossSectionRockLayers } = this.simulationStore;
     this.plateCanvas = {};
     const keyTitle = colormap === "topo" ? "Elevation" : colormap === "plate" ? "Plate Density" : "Crust Age";
     return (
@@ -193,19 +194,30 @@ export default class ColorKey extends BaseComponent<IBaseProps, IState> {
               </tr>
               <tr>
                 <td colSpan={2}>&nbsp;</td>
-                <td>{ rect(CONTINENTAL_CRUST_COL) }</td>
-                <td className={css.crossSectionColor}>Continental Crust</td>
-              </tr>
-              <tr>
-                <td colSpan={2}>&nbsp;</td>
                 <td>{ rect(OCEAN_COL) }</td>
                 <td className={css.crossSectionColor}>Ocean</td>
               </tr>
-              <tr>
-                <td colSpan={2}>&nbsp;</td>
-                <td>{ rect(OCEANIC_CRUST_COL) }</td>
-                <td className={css.crossSectionColor}>Oceanic Crust</td>
-              </tr>
+              { crossSectionRockLayers ?
+                Object.keys(ROCK_LABEL).map((rock: Rock) => (
+                  <tr key={rock}>
+                    <td colSpan={2}>&nbsp;</td>
+                    <td>{ rect(ROCKS_COL[rock]) }</td>
+                    <td className={css.crossSectionColor}>{ ROCK_LABEL[rock] }</td>
+                  </tr>
+                )) :
+                <>
+                  <tr>
+                    <td colSpan={2}>&nbsp;</td>
+                    <td>{ rect(OCEANIC_CRUST_COL) }</td>
+                    <td className={css.crossSectionColor}>Oceanic Crust</td>
+                  </tr>
+                  <tr>
+                    <td colSpan={2}>&nbsp;</td>
+                    <td>{ rect(CONTINENTAL_CRUST_COL) }</td>
+                    <td className={css.crossSectionColor}>Continental Crust</td>
+                  </tr>
+                </>
+              }
               <tr>
                 <td colSpan={2}>&nbsp;</td>
                 <td>{ rect(LITHOSPHERE_COL) }</td>

--- a/js/components/cross-section-2d.tsx
+++ b/js/components/cross-section-2d.tsx
@@ -17,7 +17,7 @@ export default class CrossSection2D extends BaseComponent<IBaseProps, IState> {
   componentDidMount() {
     this.disposeObserver = autorun(() => {
       const store = this.simulationStore;
-      renderCrossSection(this.canvas, store.crossSectionOutput.dataFront);
+      renderCrossSection(this.canvas, store.crossSectionOutput.dataFront, { rockLayers: store.crossSectionRockLayers });
     });
   }
 

--- a/js/components/cross-section-3d.tsx
+++ b/js/components/cross-section-3d.tsx
@@ -14,7 +14,7 @@ interface IState {}
 @observer
 export default class CrossSection3D extends BaseComponent<IBaseProps, IState> {
   disposeObserver: any;
-  view: any;
+  view: CrossSection3DView;
   view3dContainer: any;
 
   constructor(props: IBaseProps) {
@@ -25,7 +25,7 @@ export default class CrossSection3D extends BaseComponent<IBaseProps, IState> {
     // Keep observers separate, as we don't want to re-render the whole cross-section each time the camera angle is changed.
     this.disposeObserver.push(autorun(() => {
       this.view.setScreenWidth(store.screenWidth);
-      this.view.setCrossSectionData(store.crossSectionOutput, store.crossSectionSwapped);
+      this.view.setCrossSectionData(store.crossSectionOutput, store.crossSectionSwapped, { rockLayers: store.crossSectionRockLayers });
     }));
     this.disposeObserver.push(autorun(() => {
       this.view.setCameraAngle(store.crossSectionCameraAngle);

--- a/js/config.ts
+++ b/js/config.ts
@@ -99,6 +99,8 @@ const DEFAULT_CONFIG = {
   renderLatLongLines: false,
   renderPlateLabels: true,
   crossSection3d: true,
+  // Shows extended version of the cross-section with separate rock layers.
+  crossSectionRockLayers: true,
   bumpMapping: true,
   sidebar: [
     "interactions",

--- a/js/config.ts
+++ b/js/config.ts
@@ -80,7 +80,7 @@ const DEFAULT_CONFIG = {
   oceanicRidgeElevation: 0.47,
   oceanicRidgeWidth: 650, // km
   // Width of the area around continent which acts as it's bumper / buffer. When this area is about to subduct,
-  // drag forces will be applied to stop relative motion of the plates and prevent subduction of the neighbouring continent.
+  // drag forces will be applied to stop relative motion of the plates and prevent subduction of the neighboring continent.
   continentBufferWidth: 1000,
   // Keeps model running. When all the plates reach the point when they move in the same direction, with the same speed,
   // model will add some random forces and divide big plates (see minSizeRatioForDivision).

--- a/js/config.ts
+++ b/js/config.ts
@@ -69,7 +69,7 @@ const DEFAULT_CONFIG = {
   oceanDensity: 1,
   continentDensity: 3,
   // How fast continent is stretching along divergent boundary. Bigger value means it would turn into ocean / see faster.
-  continentalStretchingRatio: 3,
+  continentalStretchingRatio: 8,
   // Max length of the cross-section line
   maxCrossSectionLength: 4000, // km
   // Horizontal scaling of cross-section data.

--- a/js/cross-section-colors.ts
+++ b/js/cross-section-colors.ts
@@ -14,4 +14,5 @@ export const ROCKS_COL: Record<Rock, string> = {
   [Rock.Gabbro]: "#5d5243",
   [Rock.AndesiticRocks]: "#585c5d",
   [Rock.MaficRocks]: "#373633",
+  [Rock.Sediment]: "#a87d05",
 };

--- a/js/cross-section-colors.ts
+++ b/js/cross-section-colors.ts
@@ -1,3 +1,5 @@
+import { Rock } from "./plates-model/crust";
+
 export const OCEANIC_CRUST_COL = "#27374f";
 export const CONTINENTAL_CRUST_COL = "#643d0c";
 export const LITHOSPHERE_COL = "#666";
@@ -5,3 +7,11 @@ export const MANTLE_COL = "#033f19";
 export const SKY_COL_1 = "#4375be";
 export const SKY_COL_2 = "#c0daeb";
 export const OCEAN_COL = "#1da2d8";
+
+export const ROCKS_COL: Record<Rock, string> = {
+  [Rock.Granite]: "#4b1e01",
+  [Rock.Basalt]: "#06151b",
+  [Rock.Gabbro]: "#5d5243",
+  [Rock.AndesiticRocks]: "#585c5d",
+  [Rock.MaficRocks]: "#373633",
+};

--- a/js/peels/sphere/to-cg.ts
+++ b/js/peels/sphere/to-cg.ts
@@ -55,7 +55,7 @@ function barycenterVerticesAndFaces(sphere: any, options: IOptions) {
 
   const indices = sphere._interfieldTriangles;
 
-  const colors = new Float32Array(indices.length * 3);
+  const colors = new Float32Array(indices.length * 4);
 
   for (let f = 0; f < sphere._Fields.length; f += 1) {
     const field = sphere._Fields[f];
@@ -73,6 +73,7 @@ function barycenterVerticesAndFaces(sphere: any, options: IOptions) {
     colors[f * 3 + 0] = color.r;
     colors[f * 3 + 1] = color.g;
     colors[f * 3 + 2] = color.b;
+    colors[f * 4 + 3] = color.a != null ? color.a : 1.0;
   }
 
   // normals are exactly positions, as long as radius is 1

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -8,6 +8,15 @@ export enum Rock {
   AndesiticRocks = "AnR",
 }
 
+// Labels used in UI.
+export const ROCK_LABEL: Record<Rock, string> = {
+  [Rock.Granite]: "Granite",
+  [Rock.Basalt]: "Basalt",
+  [Rock.Gabbro]: "Gabbro",
+  [Rock.MaficRocks]: "Mafic Rocks",
+  [Rock.AndesiticRocks]: "Andesitic Rocks"
+};
+
 export interface IRockLayer { 
   rock: Rock; 
   thickness: number; // model units, meaningless
@@ -23,6 +32,10 @@ export interface ISerializedCrust {
   }
 }
 
+export function rockLayerFinalThickness(rockLayer: IRockLayer) {
+  return rockLayer.thickness * (1 + rockLayer.folding);
+}
+
 export default class Crust {
   // Rock layers, ordered from the top to the bottom (of the crust).
   rockLayers: IRockLayer[] = [];
@@ -36,7 +49,7 @@ export default class Crust {
   get thickness() {
     let result = 0;
     for (const layer of this.rockLayers) {
-      result += layer.thickness * (1 + layer.folding);
+      result += rockLayerFinalThickness(layer);
     }
     return result;
   }
@@ -77,6 +90,10 @@ export default class Crust {
     return crust;
   }
 
+  clone() {
+    return Crust.deserialize(this.serialize());
+  }
+
   setInitialRockLayers(fieldType: FieldType, thickness: number) {
     if (fieldType === "ocean") {
       this.rockLayers = [
@@ -109,8 +126,8 @@ export default class Crust {
   }
 
   addBasaltAndGabbro(totalAmount: number) {
-    this.increaseLayerThickness(Rock.Basalt, totalAmount * 0.5);
     this.increaseLayerThickness(Rock.Gabbro, totalAmount * 0.5);
+    this.increaseLayerThickness(Rock.Basalt, totalAmount * 0.5);
   }
 
   addVolcanicRocks(totalAmount: number) {

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -1,0 +1,121 @@
+import { FieldType } from "./field";
+
+export enum Rock {
+  Granite = "Gr",
+  Basalt = "Ba",
+  Gabbro = "Ga",
+  MaficRocks = "MaR",
+  AndesiticRocks = "AnR",
+}
+
+export interface IRockLayer { 
+  rock: Rock; 
+  thickness: number; // model units, meaningless
+  folding: number; // if value is > 0, its effective thickness will equal to: thickness * (1 + folding)
+}
+
+export interface ISerializedCrust {
+  // Format of rock layers is destructed to arrays as it should take much less space when serialized to JSON.
+  rockLayers: {
+    rock: Rock[],
+    thickness: number[],
+    folding: number[]
+  }
+}
+
+export default class Crust {
+  // Rock layers, ordered from the top to the bottom (of the crust).
+  rockLayers: IRockLayer[] = [];
+
+  constructor(fieldType?: FieldType, thickness?: number) {
+    if (fieldType && thickness) {
+      this.setInitialRockLayers(fieldType, thickness);
+    }
+  }
+
+  get thickness() {
+    let result = 0;
+    for (const layer of this.rockLayers) {
+      result += layer.thickness * (1 + layer.folding);
+    }
+    return result;
+  }
+
+  serialize(): ISerializedCrust {
+    const result: ISerializedCrust = {
+      rockLayers: {
+        rock: [],
+        thickness: [],
+        folding: []
+      }
+    };
+    for (const layer of this.rockLayers) {
+      result.rockLayers.rock.push(layer.rock);
+      result.rockLayers.thickness.push(layer.thickness);
+      result.rockLayers.folding.push(layer.folding);
+    }
+    return result;
+  }
+
+  static deserialize(props: ISerializedCrust): Crust {
+    const crust = new Crust();
+    const len = props.rockLayers.rock.length;
+    for (let i = 0; i < len; i += 1) {
+      crust.rockLayers.push({ 
+        rock: props.rockLayers.rock[i],
+        thickness: props.rockLayers.thickness[i],
+        folding: props.rockLayers.folding[i]
+      });
+    }
+    return crust;
+  }
+
+  setInitialRockLayers(fieldType: FieldType, thickness: number) {
+    if (fieldType === "ocean") {
+      this.rockLayers = [
+        { rock: Rock.Basalt, thickness: thickness * 0.5, folding: 0 },
+        { rock: Rock.Gabbro, thickness: thickness * 0.5, folding: 0 }
+      ];
+    } else if (fieldType === "continent" || fieldType === "island") {
+      this.rockLayers = [
+        { rock: Rock.Granite, thickness, folding: 0 }
+      ];
+    }
+  }
+
+  getLayer(rock: Rock) {
+    for (const layer of this.rockLayers) {
+      if (layer.rock === rock) {
+        return layer;
+      }
+    }
+    return null;
+  }
+
+  increaseLayerThickness(rock: Rock, value: number) {
+    const layer = this.getLayer(rock);
+    if (layer) {
+      layer.thickness += value;
+    } else {
+      this.rockLayers.unshift({ rock, thickness: value, folding: 0 });
+    }
+  }
+
+  addBasaltAndGabbro(totalAmount: number) {
+    this.increaseLayerThickness(Rock.Basalt, totalAmount * 0.5);
+    this.increaseLayerThickness(Rock.Gabbro, totalAmount * 0.5);
+  }
+
+  addVolcanicRocks(totalAmount: number) {
+    this.increaseLayerThickness(Rock.MaficRocks, totalAmount * 0.5);
+    this.increaseLayerThickness(Rock.AndesiticRocks, totalAmount * 0.5);
+  }
+
+  setFolding(value: number) {
+    for (const layer of this.rockLayers) {
+      if (layer.folding < value) {
+        layer.folding = value;
+      }
+    }
+  }
+}

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -41,6 +41,13 @@ export default class Crust {
     return result;
   }
 
+  setThickness(value: number) {
+    const ratio = value / this.thickness;
+    for (const layer of this.rockLayers) {
+      layer.thickness *= ratio;
+    }
+  }
+
   serialize(): ISerializedCrust {
     const result: ISerializedCrust = {
       rockLayers: {

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -175,24 +175,22 @@ export default class Crust {
     }
   }
 
-  spreadSediment(timestep: number, neighbouringCrust: Crust[]) {
+  spreadSediment(timestep: number, neighboringCrust: Crust[]) {
     const sedimentLayer = this.getLayer(Rock.Sediment);
-    const totalThickness = this.thickness;
-    const finalNeighbouringCrust = neighbouringCrust.filter(c => c.thickness < totalThickness);
     const kSpreadingFactor = 0.5;
     // Damping factor ensures that excess sediments don't travel forever. They'll slowly disappear over time.
     const kDampingFactor = Math.pow(0.9, timestep);
-    if (sedimentLayer && sedimentLayer.thickness > MAX_REGULAR_SEDIMENT_THICKNESS && neighbouringCrust.length > 0) {
+    if (sedimentLayer && sedimentLayer.thickness > MAX_REGULAR_SEDIMENT_THICKNESS && neighboringCrust.length > 0) {
       const removedSediment = Math.min(sedimentLayer.thickness, kSpreadingFactor * (sedimentLayer.thickness - MAX_REGULAR_SEDIMENT_THICKNESS) * timestep);
-      const increasePerNeigh = kDampingFactor * removedSediment / neighbouringCrust.length;
-      finalNeighbouringCrust.forEach(neighCrust => {
+      const increasePerNeigh = kDampingFactor * removedSediment / neighboringCrust.length;
+      neighboringCrust.forEach(neighCrust => {
         neighCrust.addExcessSediment(increasePerNeigh);
       });
       sedimentLayer.thickness -= removedSediment;
     }
   }
 
-  subduct(timestep: number, neighbouringCrust: Crust[]) {
+  subduct(timestep: number, neighboringCrust: Crust[]) {
     let sedimentLayer = null;
     const kThicknessMult = Math.pow(0.4, timestep);
 
@@ -205,12 +203,12 @@ export default class Crust {
       }
     }
 
-    // Move crust to non-subducting neighbours. This will create accretionary wedge.
+    // Move crust to non-subducting neighbors. This will create accretionary wedge.
     if (sedimentLayer && sedimentLayer.thickness > 0) {
-      if (neighbouringCrust.length > 0) {
+      if (neighboringCrust.length > 0) {
         const removedSediment = Math.min(sedimentLayer.thickness, sedimentLayer.thickness * timestep);
-        const increasePerNeigh = removedSediment / neighbouringCrust.length;
-        neighbouringCrust.forEach(neighCrust => {
+        const increasePerNeigh = removedSediment / neighboringCrust.length;
+        neighboringCrust.forEach(neighCrust => {
           neighCrust.addExcessSediment(increasePerNeigh);
         });
       } else {

--- a/js/plates-model/divide-plate.ts
+++ b/js/plates-model/divide-plate.ts
@@ -12,7 +12,7 @@ function randomVec3() {
 function getBoundaryField(plate: Plate) {
   const adjField = plate.adjacentFields.values().next().value;
   if (adjField) {
-    // Some neighbours of plate adjacent field is a boundary field. Pick any.
+    // Some neighbors of plate adjacent field is a boundary field. Pick any.
     for (const neighborId of adjField.adjacentFields) {
       if (plate.fields.has(neighborId)) {
         return plate.fields.get(neighborId);
@@ -42,7 +42,7 @@ export default function dividePlate(plate: Plate) {
 
   while (queue.length > 0 && newPlate.size < halfPlateSize) {
     const field = queue.shift();
-    field.forEachNeighbour((adjField: Field) => {
+    field.forEachNeighbor((adjField: Field) => {
       if (!visited[adjField.id]) {
         queue.push(adjField);
         visited[adjField.id] = true;

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -119,7 +119,7 @@ export default class Field extends FieldBase {
   crust: Crust;
   
   adjacentFields: number[];
-  // Used by adjacent fields only (see model.generateTrenchesAndNewFields).
+  // Used by adjacent fields only (see model.generateNewFields).
   noCollisionDist = 0;
 
   // Properties that are not serialized and can be derived from other properties and model state.

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -396,6 +396,9 @@ export default class Field extends FieldBase {
 
   performGeologicalProcesses(timestep: number) {
     if (this.subduction) {
+      // Make sure that when plate is subducting, it's only oceanic crust (no islands and volcanic rocks).
+      // TODO performance optimization - probably we don't have to reset the whole array each time.
+      this.crust.setInitialRockLayers("ocean", BASE_OCEANIC_CRUST_THICKNESS);
       this.subduction.update(timestep);
       if (!this.subduction.active) {
         // Don't keep old subduction objects.

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -340,7 +340,7 @@ export default class Field extends FieldBase {
   }
 
   // Fields belonging to the parent plate.
-  forEachNeighbour(callback: (field: Field) => void) {
+  forEachNeighbor(callback: (field: Field) => void) {
     for (const adjId of this.adjacentFields) {
       const field = this.plate.fields.get(adjId);
       if (field) {
@@ -349,7 +349,7 @@ export default class Field extends FieldBase {
     }
   }
 
-  anyNeighbour(condition: (field: Field) => boolean) {
+  anyNeighbor(condition: (field: Field) => boolean) {
     for (const adjId of this.adjacentFields) {
       const field = this.plate.fields.get(adjId);
       if (field && condition(field)) {
@@ -359,7 +359,7 @@ export default class Field extends FieldBase {
     return false;
   }
 
-  avgNeighbour(property: keyof Field) {
+  avgNeighbor(property: keyof Field) {
     let val = 0;
     let count = 0;
     for (const adjId of this.adjacentFields) {
@@ -373,14 +373,14 @@ export default class Field extends FieldBase {
     return val / count;
   }
 
-  // One of the neighbouring fields, pointed by linear velocity vector.
-  neighbourAlongVector(direction: THREE.Vector3) {
-    const posOfNeighbour = this.absolutePos.clone().add(direction.clone().setLength(getGrid().fieldDiameter));
-    return this.plate.fieldAtAbsolutePos(posOfNeighbour);
+  // One of the neighboring fields, pointed by linear velocity vector.
+  neighborAlongVector(direction: THREE.Vector3) {
+    const posOfNeighbor = this.absolutePos.clone().add(direction.clone().setLength(getGrid().fieldDiameter));
+    return this.plate.fieldAtAbsolutePos(posOfNeighbor);
   }
 
   // Number of adjacent fields that actually belong to the plate.
-  neighboursCount() {
+  neighborsCount() {
     let count = 0;
     for (const adjId of this.adjacentFields) {
       if (this.plate.fields.has(adjId)) {
@@ -390,9 +390,9 @@ export default class Field extends FieldBase {
     return count;
   }
 
-  getNeighbouringCrust() {
+  getNeighboringCrust() {
     const result: Crust[] = [];
-    this.forEachNeighbour(neigh => {
+    this.forEachNeighbor(neigh => {
       // Skip fields that are already subducting, as we never want to interact with them / transfer some rocks there.
       if (!neigh.subduction) {
         result.push(neigh.crust);
@@ -406,12 +406,12 @@ export default class Field extends FieldBase {
   }
 
   performGeologicalProcesses(timestep: number) {
-    const neighbouringCrust = this.getNeighbouringCrust();
+    const neighboringCrust = this.getNeighboringCrust();
 
     if (this.subduction) {
       this.subduction.update(timestep);
       // Make sure that when plate is subducting, it's only oceanic crust left (no islands and volcanic rocks).
-      this.crust.subduct(timestep, neighbouringCrust);
+      this.crust.subduct(timestep, neighboringCrust);
       if (!this.subduction.active) {
         // Don't keep old subduction objects.
         this.subduction = undefined;
@@ -459,8 +459,8 @@ export default class Field extends FieldBase {
       this.crust.addSediment(0.005 * timestep);
     }
     
-    // When crust layer is too thick, sediments will be transferred to neighbours.
-    this.crust.spreadSediment(timestep, neighbouringCrust);
+    // When crust layer is too thick, sediments will be transferred to neighbors.
+    this.crust.spreadSediment(timestep, neighboringCrust);
     this.crust.sortLayers();
   }
 

--- a/js/plates-model/fields-collision.ts
+++ b/js/plates-model/fields-collision.ts
@@ -12,15 +12,17 @@ function applyDragForces(bottomField: Field, topField: Field) {
   topField.draggingPlate = bottomField.plate;
 }
 
-function subduction(bottomField: Field, topField: Field) {
+export function subduction(bottomField: Field, topField: Field, addVolcanicActivity = true) {
   if (!bottomField.subduction) {
     bottomField.subduction = new Subduction(bottomField);
   }
-  if (!topField.volcanicAct) {
-    topField.volcanicAct = new VolcanicActivity(topField);
-  }
   bottomField.subduction.setCollision(topField);
-  topField.volcanicAct.setCollision(bottomField);
+  if (addVolcanicActivity) { 
+    if (!topField.volcanicAct) {
+      topField.volcanicAct = new VolcanicActivity(topField);
+    }
+    topField.volcanicAct.setCollision(bottomField);
+  }
 }
 
 function islandCollision(bottomField: Field, topField: Field) {

--- a/js/plates-model/fields-collision.ts
+++ b/js/plates-model/fields-collision.ts
@@ -12,7 +12,7 @@ function applyDragForces(bottomField: Field, topField: Field) {
   topField.draggingPlate = bottomField.plate;
 }
 
-export function subduction(bottomField: Field, topField: Field, addVolcanicActivity = true) {
+function subduction(bottomField: Field, topField: Field, addVolcanicActivity = true) {
   if (!bottomField.subduction) {
     bottomField.subduction = new Subduction(bottomField);
   }

--- a/js/plates-model/generate-plates.ts
+++ b/js/plates-model/generate-plates.ts
@@ -2,17 +2,21 @@ import { hsv } from "d3-hsv";
 import Sphere from "../peels/sphere";
 import config from "../config";
 import Plate from "./plate";
-import { MAX_AGE } from "./field";
+import { elevationToCrustThickness, MAX_AGE, BASE_OCEAN_ELEVATION, HIGHEST_MOUNTAIN_ELEVATION } from "./field";
 
 type HSV = { h: number; s: number; v: number; };
 
+const ELEVATION_RANGE = HIGHEST_MOUNTAIN_ELEVATION - BASE_OCEAN_ELEVATION;
+
+// Remember to update presets section in README if anything here is changed.
+export const BASE_OCEAN_HSV_V = 0.4;
 function getElevation(col: HSV) {
-  // Map [0.4, 1.0] range to [0, 1].
-  return (col.v - 0.4) / 0.6;
+  // Map [0.4, 1.0] range to [BASE_OCEAN_ELEVATION, HIGHEST_MOUNTAIN_ELEVATION].
+  return ((col.v - BASE_OCEAN_HSV_V) / (1 - BASE_OCEAN_HSV_V)) * ELEVATION_RANGE + BASE_OCEAN_ELEVATION;
 }
 
 function getType(elevation: number) {
-  return elevation > 0.25 ? "continent" : "ocean";
+  return elevation > BASE_OCEAN_ELEVATION + HIGHEST_MOUNTAIN_ELEVATION * 0.05 ? "continent" : "ocean";
 }
 
 export default function generatePlates(imgData: ImageData, initFunction?: ((plates: Record<number, Plate>) => void) | null) {
@@ -30,7 +34,7 @@ export default function generatePlates(imgData: ImageData, initFunction?: ((plat
     if (plates[key] === undefined) {
       plates[key] = new Plate({ hue: color.h, density: Object.keys(plates).length });
     }
-    plates[key].addField({ id: fieldId, age: MAX_AGE, type, elevation });
+    plates[key].addField({ id: fieldId, age: MAX_AGE, type, crustThickness: elevationToCrustThickness(elevation) });
   });
   Object.keys(plates).map(key => plates[key]).forEach(plate => {
     plate.updateInertiaTensor();

--- a/js/plates-model/get-cross-section.ts
+++ b/js/plates-model/get-cross-section.ts
@@ -59,7 +59,7 @@ function shouldSmoothFieldData(field: Field) {
   return field.oceanicCrust;
 }
 
-// Look at 3 nearest fields. If the nearest one is an ocean, look at it's neighbours and smooth out data a bit.
+// Look at 3 nearest fields. If the nearest one is an ocean, look at it's neighbors and smooth out data a bit.
 function getFieldAvgData(plate: Plate | Subplate, pos: THREE.Vector3, props: IWorkerProps): IFieldData | null {
   const data = plate.nearestFields(pos, 3);
   if (data.length === 0) {
@@ -161,7 +161,7 @@ function smoothSubductionAreas(chunkData: IChunkArray) {
     const firstOrLast = idx === 0 || idx === chunkData.chunks.length - 1;
     if (!firstOrLast && point.field && (point.field.subduction || (point.field.oceanicCrust && subductionLine.length > 0))) {
       // `subductionLine` is a continuous line of points that are subducting (or oceanic crust to ignore small artifacts).
-      // Don't smooth out first and last point to make sure that it matches neighbouring cross-section in the 3D mode.
+      // Don't smooth out first and last point to make sure that it matches neighboring cross-section in the 3D mode.
       subductionLine.push(point);
     } else if (subductionLine.length > 0) {
       // Other point (e.g. continent or break in data) has been found, so it's time to smooth out last line data.
@@ -368,9 +368,9 @@ export default function getCrossSection(plates: Plate[], point1: THREE.Vector3, 
         if (!prevData || !equalFields(prevData.field, fieldData) || i === steps) {
           // Keep one data point per one field. Otherwise, rough steps between fields would be visible.
           // Always add the last point in the cross-section (i === step) to make sure that it matches
-          // the first point of the neighbouring cross-section wall (in 3D mode). It's important only when
+          // the first point of the neighboring cross-section wall (in 3D mode). It's important only when
           // `getFieldAvgData` is being used. It might return different results for the same field, depending on exact
-          // sampling position (it might take into account different neighbours).
+          // sampling position (it might take into account different neighbors).
           currentData.chunks.push({ field: fieldData, distStart: dist, distEnd: dist, dist: -1 });
         } else if (prevData) {
           prevData.distEnd = dist;

--- a/js/plates-model/grid.ts
+++ b/js/plates-model/grid.ts
@@ -96,7 +96,7 @@ class Grid {
     return fields;
   }
 
-  neighboursCount(fieldId: number) {
+  neighborsCount(fieldId: number) {
     return this.fields[fieldId].adjacentFields.length;
   }
 

--- a/js/plates-model/mark-islands.ts
+++ b/js/plates-model/mark-islands.ts
@@ -2,7 +2,7 @@ import Field from "./field";
 import Plate from "./plate";
 
 // Any bigger landform is considered to be a continent, not island.
-const MAX_ISLAND_SIZE = 300000; // km^2
+const MAX_ISLAND_SIZE = 400000; // km^2
 
 // DFS-based algorithm which calculates area of continents and mark small ones as islands.
 // It accepts either array of plates or single field. When array is provided, it'll process all the available fields.

--- a/js/plates-model/mark-islands.ts
+++ b/js/plates-model/mark-islands.ts
@@ -2,7 +2,7 @@ import Field from "./field";
 import Plate from "./plate";
 
 // Any bigger landform is considered to be a continent, not island.
-const MAX_ISLAND_SIZE = 400000; // km^2
+const MAX_ISLAND_SIZE = 500000; // km^2
 
 // DFS-based algorithm which calculates area of continents and mark small ones as islands.
 // It accepts either array of plates or single field. When array is provided, it'll process all the available fields.

--- a/js/plates-model/mark-islands.ts
+++ b/js/plates-model/mark-islands.ts
@@ -20,10 +20,10 @@ export default function markIslands(platesOrField: Plate[] | Field) {
         processedFields.push(field);
         const cId = continentId[field.id];
         area[cId] += field.area;
-        field.forEachNeighbour((neighbour: Field) => {
-          if (neighbour.continentalCrust && continentId[neighbour.id] === undefined) {
-            stack.push(neighbour);
-            continentId[neighbour.id] = cId;
+        field.forEachNeighbor((neighbor: Field) => {
+          if (neighbor.continentalCrust && continentId[neighbor.id] === undefined) {
+            stack.push(neighbor);
+            continentId[neighbor.id] = cId;
           }
         });
       }

--- a/js/plates-model/model-output.ts
+++ b/js/plates-model/model-output.ts
@@ -155,8 +155,8 @@ function plateOutput(plate: Plate, props: IWorkerProps | null, stepIdx: number, 
     // Rendering code won't know difference between normal and adjacent fields anyway.
     visibleAdjacentFields.forEach((field: Field) => {
       fields.id[idx] = field.id;
-      fields.elevation[idx] = field.avgNeighbour("elevation");
-      fields.normalizedAge[idx] = field.avgNeighbour("normalizedAge");
+      fields.elevation[idx] = field.avgNeighbor("elevation");
+      fields.normalizedAge[idx] = field.avgNeighbor("normalizedAge");
       idx += 1;
     });
   }

--- a/js/plates-model/model.ts
+++ b/js/plates-model/model.ts
@@ -318,7 +318,6 @@ export default class Model {
               if (neighbour?.crustCanBeStretched) {
                 props.type = "continent";
                 props.crustThickness = neighbour.crustThickness - config.continentalStretchingRatio * grid.fieldDiameter;
-                props.elevation = neighbour.elevation - config.continentalStretchingRatio * grid.fieldDiameter;
                 props.age = neighbour.age;
                 // When continent is being stretched, move field marker to the new field to emphasise this effect.
                 props.marked = neighbour.marked;

--- a/js/plates-model/model.ts
+++ b/js/plates-model/model.ts
@@ -218,12 +218,12 @@ export default class Model {
     const fieldsPossiblyColliding = new Set();
     if (optimize) {
       // Optimization can be applied once we know which fields have collided in the previous step.
-      // Only those fields and boundaries (plus their neighbours) can collide in this step.
+      // Only those fields and boundaries (plus their neighbors) can collide in this step.
       // There's an obvious assumption that fields won't move more than their own diameter in a single step.
       this.forEachField((field: Field) => {
         if (field.boundary || field.colliding) {
           fieldsPossiblyColliding.add(field);
-          field.forEachNeighbour((neigh: Field) => fieldsPossiblyColliding.add(neigh));
+          field.forEachNeighbor((neigh: Field) => fieldsPossiblyColliding.add(neigh));
         }
         field.resetCollisions();
       });
@@ -298,30 +298,30 @@ export default class Model {
           // It ensures that divergent boundaries will stay in place more or less and new crust will be building
           // only when plate is moving.
           if (field.noCollisionDist > grid.fieldDiameter * 0.9) {
-            const neighboursCount = field.neighboursCount();
-            // Make sure that new field has at least two existing neighbours. It prevents from creating
+            const neighborsCount = field.neighborsCount();
+            // Make sure that new field has at least two existing neighbors. It prevents from creating
             // awkward, narrow shapes of the continents.
-            if (neighboursCount > 1) {
-              let neighbour = field.neighbourAlongVector(field.linearVelocity);
-              if (!neighbour) {
+            if (neighborsCount > 1) {
+              let neighbor = field.neighborAlongVector(field.linearVelocity);
+              if (!neighbor) {
                 // Sometimes there will be no field along velocity vector (depends of angle between vector and boundary).
-                // Use other neighbour instead. Pick one which is closest to the position of the missing field.
+                // Use other neighbor instead. Pick one which is closest to the position of the missing field.
                 const perfectPos = field.absolutePos.clone().add(field.linearVelocity.clone().setLength(grid.fieldDiameter));
                 const minDist = Infinity;
-                field.forEachNeighbour((otherField: Field) => {
+                field.forEachNeighbor((otherField: Field) => {
                   if (otherField.absolutePos.distanceTo(perfectPos) < minDist) {
-                    neighbour = otherField;
+                    neighbor = otherField;
                   }
                 });
               }
               const props: Omit<IFieldOptions, "id" | "plate"> = {};
-              if (neighbour?.crustCanBeStretched) {
+              if (neighbor?.crustCanBeStretched) {
                 props.type = "continent";
-                props.crustThickness = neighbour.crustThickness - config.continentalStretchingRatio * grid.fieldDiameter;
-                props.age = neighbour.age;
+                props.crustThickness = neighbor.crustThickness - config.continentalStretchingRatio * grid.fieldDiameter;
+                props.age = neighbor.age;
                 // When continent is being stretched, move field marker to the new field to emphasise this effect.
-                props.marked = neighbour.marked;
-                neighbour.marked = false;
+                props.marked = neighbor.marked;
+                neighbor.marked = false;
               } else {
                 props.type = "ocean";
                 // `age` is a distance travelled by field. When a new field is added next to the divergent boundary,

--- a/js/plates-model/model.ts
+++ b/js/plates-model/model.ts
@@ -4,7 +4,7 @@ import Plate, { ISerializedPlate, resetIds } from "./plate";
 import getGrid from "./grid";
 import config from "../config";
 import markIslands from "./mark-islands";
-import fieldsCollision, { subduction } from "./fields-collision";
+import fieldsCollision from "./fields-collision";
 import addRelativeMotion from "./add-relative-motion";
 import dividePlate from "./divide-plate";
 import eulerStep from "./physics/euler-integrator";
@@ -198,7 +198,7 @@ export default class Model {
     this.forEachField((field: Field) => field.performGeologicalProcesses(timestep));
     this.forEachPlate((plate: Plate) => plate.removeUnnecessaryFields()); // e.g. fields that subducted
     this.removeEmptyPlates();
-    this.generateTrenchesAndNewFields(timestep);
+    this.generateNewFields(timestep);
     // Some fields might have been added or removed, so update calculated physical properties.
     this.forEachPlate((plate: Plate) => {
       plate.updateInertiaTensor();
@@ -276,10 +276,7 @@ export default class Model {
     }
   }
 
-  // This method processes plate.adjacentFields which in fact are plate "margins". They're neighboring with plate
-  // fields. They're used to generate trenches (but initiating subduction early) and generating new fields around
-  // oceanic ridges.
-  generateTrenchesAndNewFields(timestep: number) {
+  generateNewFields(timestep: number) {
     const grid = getGrid();
     for (let i = 0, len = this.plates.length; i < len; i++) {
       const plate = this.plates[i];
@@ -290,16 +287,8 @@ export default class Model {
             continue;
           }
           const otherPlate = this.plates[j];
-          const collidingField = otherPlate.fieldAtAbsolutePos(field.absolutePos);
-          if (collidingField) {
+          if (otherPlate.fieldAtAbsolutePos(field.absolutePos)) {
             collision = true;
-            // Note that plates are ordered by density.
-            const collidingPlateBelowAdjField = j > i;
-            if (collidingPlateBelowAdjField && collidingField.isOcean) {
-              // This will result in visible trench. Subduction will be initialized even before
-              // the bottom plate goes under the top one (it's only under the adjacent field / margin).
-              subduction(collidingField, field, false);
-            }
             break;
           }
         }

--- a/js/plates-model/orogeny.ts
+++ b/js/plates-model/orogeny.ts
@@ -64,7 +64,7 @@ export default class Orogeny {
     if (adjStress < 0.1) {
       return;
     }
-    this.field.forEachNeighbour((field: Field) => {
+    this.field.forEachNeighbor((field: Field) => {
       if (field.isOcean) {
         return;
       }

--- a/js/plates-model/orogeny.ts
+++ b/js/plates-model/orogeny.ts
@@ -13,6 +13,7 @@ export interface ISerializedOrogeny {
 export default class Orogeny {
   field: Field;
   maxFoldingStress: number;
+  active = false;
 
   constructor(field: Field) {
     this.field = field;
@@ -20,7 +21,6 @@ export default class Orogeny {
   }
 
   serialize(): ISerializedOrogeny {
-    // return serialize(this);
     return {
       maxFoldingStress: this.maxFoldingStress
     };
@@ -30,6 +30,10 @@ export default class Orogeny {
     const orogeny = new Orogeny(field);
     orogeny.maxFoldingStress = props.maxFoldingStress;
     return orogeny;
+  }
+
+  resetCollision() {
+    this.active = false;
   }
 
   setCollision(field: Field) {
@@ -48,6 +52,8 @@ export default class Orogeny {
 
   setFoldingStress(foldingStress: number) {
     if (this.maxFoldingStress < foldingStress) {
+      // Orogeny is active only if the new folding stress is higher than the previous max.
+      this.active = true;
       this.maxFoldingStress = foldingStress;
       this.spreadFoldingStress();
     }

--- a/js/plates-model/plate-draw-tool.ts
+++ b/js/plates-model/plate-draw-tool.ts
@@ -23,7 +23,7 @@ function smoothAreaAroundShelves(shelfFields: Field[]) {
     const field = queue.shift() as Field;
     const newDist = distance[field.id] + 1;
     if (newDist < maxDistance) {
-      field.forEachNeighbour((neigh: Field) => {
+      field.forEachNeighbor((neigh: Field) => {
         if (!visited[neigh.id]) {
           visited[neigh.id] = true;
           distance[neigh.id] = newDist;
@@ -78,7 +78,7 @@ export default function plateDrawTool(plate: Plate, fieldId: number, type: Field
     const newDistance = type === "continent" ? distance[field.id] + 1 + 3 * random() : distance[field.id] + 2;
     const continentAreaWithinLimit = type === "ocean" || (continentSize + 1) / plateSize <= MAX_CONTINENTAL_CRUST_RATIO;
     if (newDistance <= MAX_DIST && continentAreaWithinLimit) {
-      field.forEachNeighbour((otherField: Field) => {
+      field.forEachNeighbor((otherField: Field) => {
         if (!visited[otherField.id]) {
           visited[otherField.id] = true;
           distance[otherField.id] = newDistance;
@@ -88,14 +88,14 @@ export default function plateDrawTool(plate: Plate, fieldId: number, type: Field
           distance[otherField.id] = newDistance;
         }
       });
-    } else if (type === "continent" && field.anyNeighbour((otherField: Field) => otherField.elevation < SHELF_ELEVATION * 0.95)) {
+    } else if (type === "continent" && field.anyNeighbor((otherField: Field) => otherField.elevation < SHELF_ELEVATION * 0.95)) {
       // Continent drawing mode. The edge of the continent should have a bit lower elevation, so the transition
       // between ocean and continent is smooth.
       field.setCrustThickness(elevationToCrustThickness(SHELF_ELEVATION));
       shelf.add(field);
     } else if (type === "ocean") {
       // Continent erasing mode. The same idea - making sure that the transition between ocean and continent is smooth.
-      field.forEachNeighbour((otherField: Field) => {
+      field.forEachNeighbor((otherField: Field) => {
         if (otherField.isContinent) {
           const finalElevation = Math.min(SHELF_ELEVATION, otherField.elevation);
           otherField.setCrustThickness(elevationToCrustThickness(finalElevation));

--- a/js/plates-model/plate.ts
+++ b/js/plates-model/plate.ts
@@ -228,13 +228,14 @@ export default class Plate extends PlateBase<Field> {
   addField(props: Omit<IFieldOptions, "plate">) {
     const field = new Field({ ...props, plate: this });
     this.addExistingField(field);
+    return field;
   }
 
   addFieldAt(props: Omit<IFieldOptions, "id" | "plate">, absolutePos: THREE.Vector3) {
     const localPos = this.localPosition(absolutePos);
     const id = getGrid().nearestFieldId(localPos);
     if (!this.fields.has(id)) {
-      this.addField({ ...props, id });
+      return this.addField({ ...props, id });
     }
   }
 
@@ -256,6 +257,7 @@ export default class Plate extends PlateBase<Field> {
       }
     });
     field.boundary = field.isBoundary();
+    return field;
   }
 
   deleteField(id: number) {
@@ -352,19 +354,18 @@ export default class Plate extends PlateBase<Field> {
       }
     }
     if (bestFieldId) {
-      // Sometimes island can be placed at the boundary and become a trench. Make sure that trench elevation modifier
-      // is not applied to the new field.
-      this.addField({
+      const newField = this.addField({
         id: bestFieldId,
         age: island.age,
         type: "continent",
-        crustThickness: island.crust.thickness,
         originalHue: island.plate.hue,
         marked: island.marked
       });
+      newField.crust = island.crust.clone();
     }
     // Remove the old island field.
-    island.alive = false;
+    island.type = "ocean";
+    island.setDefaultProps();
     island.marked = false;
   }
 

--- a/js/plates-model/plate.ts
+++ b/js/plates-model/plate.ts
@@ -360,7 +360,7 @@ export default class Plate extends PlateBase<Field> {
         age: island.age,
         type: "continent",
         elevation: island.elevation,
-        crustThickness: island.baseCrustThickness,
+        crustThickness: island.crust.thickness,
         originalHue: island.plate.hue,
         marked: island.marked
       });

--- a/js/plates-model/plate.ts
+++ b/js/plates-model/plate.ts
@@ -354,7 +354,6 @@ export default class Plate extends PlateBase<Field> {
     if (bestFieldId) {
       // Sometimes island can be placed at the boundary and become a trench. Make sure that trench elevation modifier
       // is not applied to the new field.
-      island.trench = false;
       this.addField({
         id: bestFieldId,
         age: island.age,

--- a/js/plates-model/plate.ts
+++ b/js/plates-model/plate.ts
@@ -359,7 +359,6 @@ export default class Plate extends PlateBase<Field> {
         id: bestFieldId,
         age: island.age,
         type: "continent",
-        elevation: island.elevation,
         crustThickness: island.crust.thickness,
         originalHue: island.plate.hue,
         marked: island.marked

--- a/js/plates-model/plate.ts
+++ b/js/plates-model/plate.ts
@@ -143,7 +143,7 @@ export default class Plate extends PlateBase<Field> {
         let safe = true;
         // Some subducting fields do not get marked because they move so slowly
         // Ignore fields adjacent to subducting fields just to be safe
-        field.forEachNeighbour((neighbor: Field) => {
+        field.forEachNeighbor((neighbor: Field) => {
           if (neighbor.subduction) {
             safe = false;
           }
@@ -289,7 +289,7 @@ export default class Plate extends PlateBase<Field> {
     }
   }
 
-  neighboursCount(absolutePos: THREE.Vector3) {
+  neighborsCount(absolutePos: THREE.Vector3) {
     const localPos = this.localPosition(absolutePos);
     const id = getGrid().nearestFieldId(localPos);
     let count = 0;
@@ -315,7 +315,7 @@ export default class Plate extends PlateBase<Field> {
     this.forEachField((field: Field) => {
       field.isContinentBuffer = false;
       if (field.isContinent) {
-        field.forEachNeighbour((adjField: Field) => {
+        field.forEachNeighbor((adjField: Field) => {
           if (adjField.isOcean && getDist(adjField) > grid.fieldDiameterInKm) {
             dist[adjField.id] = grid.fieldDiameterInKm;
             queue.push(adjField);
@@ -328,7 +328,7 @@ export default class Plate extends PlateBase<Field> {
       field.isContinentBuffer = true;
       const newDist = getDist(field) + grid.fieldDiameterInKm;
       if (newDist < config.continentBufferWidth) {
-        field.forEachNeighbour((adjField: Field) => {
+        field.forEachNeighbor((adjField: Field) => {
           if (adjField.isOcean && getDist(adjField) > newDist) {
             dist[adjField.id] = newDist;
             queue.push(adjField);
@@ -346,8 +346,8 @@ export default class Plate extends PlateBase<Field> {
       const adjField = this.adjacentFields.get(adjId);
       if (adjField) {
         const dist = adjField.absolutePos.distanceTo(perfectPosition);
-        // neighboursCount() > 1 check is here to make sure that islands are not collected in some kind of narrow spike.
-        if (dist < minDist && adjField.neighboursCount() > 1) {
+        // neighborsCount() > 1 check is here to make sure that islands are not collected in some kind of narrow spike.
+        if (dist < minDist && adjField.neighborsCount() > 1) {
           bestFieldId = adjField.id;
           minDist = dist;
         }

--- a/js/plates-model/subduction.ts
+++ b/js/plates-model/subduction.ts
@@ -20,7 +20,7 @@ const MIN_SPEED_TO_DETACH = 0.0005;
 const MIN_ANGLE_TO_DETACH = Math.PI * 0.55;
 
 // MIN_PROGRESS !== 0 ensures that subducting plate creates a visible trench.
-export const MIN_PROGRESS = 0.1;
+export const MIN_PROGRESS = 0;
 
 // Set of properties related to subduction. Used by Field instances.
 export default class Subduction {

--- a/js/plates-model/subduction.ts
+++ b/js/plates-model/subduction.ts
@@ -59,7 +59,7 @@ export default class Subduction {
   get avgProgress() {
     let sum = 0;
     let count = 0;
-    this.forEachSubductingNeighbour((otherField) => {
+    this.forEachSubductingNeighbor((otherField) => {
       sum += otherField.subduction.progress || 0;
       count += 1;
     });
@@ -69,8 +69,8 @@ export default class Subduction {
     return 0;
   }
 
-  forEachSubductingNeighbour(callback: (field: FieldWithSubduction) => void) {
-    this.field.forEachNeighbour((otherField: Field) => {
+  forEachSubductingNeighbor(callback: (field: FieldWithSubduction) => void) {
+    this.field.forEachNeighbor((otherField: Field) => {
       if (otherField.subduction) {
         callback(otherField as FieldWithSubduction);
       }
@@ -80,13 +80,13 @@ export default class Subduction {
   calcSlabGradient() {
     let count = 0;
     const gradient = new THREE.Vector3();
-    this.forEachSubductingNeighbour((otherField: FieldWithSubduction) => {
+    this.forEachSubductingNeighbor((otherField: FieldWithSubduction) => {
       const progressDiff = otherField.subduction.avgProgress - this.avgProgress;
       gradient.add(otherField.absolutePos.clone().sub(this.field.absolutePos).multiplyScalar(progressDiff));
       count += 1;
     });
     if (count > 4) {
-      // Require at least 5 neighbours, as otherwise gradient might not be reliable.
+      // Require at least 5 neighbors, as otherwise gradient might not be reliable.
       return gradient.normalize();
     } else {
       return null;
@@ -108,9 +108,9 @@ export default class Subduction {
     this.relativeVelocity = undefined;
   }
 
-  getMinNeighbouringSubductionDist() {
+  getMinNeighboringSubductionDist() {
     let min = Infinity;
-    this.field.forEachNeighbour((neigh: Field) => {
+    this.field.forEachNeighbor((neigh: Field) => {
       const dist = neigh.subduction ? neigh.subduction.dist : 0;
       if (dist < min) {
         min = dist;
@@ -120,14 +120,14 @@ export default class Subduction {
   }
 
   update(timestep: number) {
-    // Continue subduction. Make sure that subduction progress isn't too different from neighbouring fields.
+    // Continue subduction. Make sure that subduction progress isn't too different from neighboring fields.
     // It might happen next to transform-like boundaries where plates move almost parallel to each other.
     const diff = this.relativeVelocity ? this.relativeVelocity.length() * timestep : REVERT_SUBDUCTION_VEL;
-    this.dist = Math.min(this.getMinNeighbouringSubductionDist() + getGrid().fieldDiameter, this.dist + diff);
+    this.dist = Math.min(this.getMinNeighboringSubductionDist() + getGrid().fieldDiameter, this.dist + diff);
     if (this.dist > MAX_SUBDUCTION_DIST) {
       this.field.alive = false;
     }
-    // This is a bit incorrect. tryToDetachFromPlate depends on neighbouring fields subduction progress.
+    // This is a bit incorrect. tryToDetachFromPlate depends on neighboring fields subduction progress.
     // It should be called after all the update() calls are made. However, it shouldn't have significant impact
     // on the simulation and simplifies code a bit.
     this.tryToDetachFromPlate();
@@ -143,7 +143,7 @@ export default class Subduction {
     if (this.relativeVelocity && this.relativeVelocity.length() > MIN_SPEED_TO_DETACH &&
       slabGradient && slabGradient.angleTo(this.relativeVelocity) > MIN_ANGLE_TO_DETACH) {
       this.moveToTopPlate();
-      this.forEachSubductingNeighbour(otherField => {
+      this.forEachSubductingNeighbor(otherField => {
         otherField.subduction.moveToTopPlate();
       });
     }

--- a/js/plates-model/subduction.ts
+++ b/js/plates-model/subduction.ts
@@ -20,7 +20,7 @@ const MIN_SPEED_TO_DETACH = 0.0005;
 const MIN_ANGLE_TO_DETACH = Math.PI * 0.55;
 
 // MIN_PROGRESS !== 0 ensures that subducting plate creates a visible trench.
-export const MIN_PROGRESS = 0.04;
+export const MIN_PROGRESS = 0.1;
 
 // Set of properties related to subduction. Used by Field instances.
 export default class Subduction {

--- a/js/plates-model/subduction.ts
+++ b/js/plates-model/subduction.ts
@@ -19,6 +19,9 @@ const MIN_PROGRESS_TO_DETACH = 0.3;
 const MIN_SPEED_TO_DETACH = 0.0005;
 const MIN_ANGLE_TO_DETACH = Math.PI * 0.55;
 
+// MIN_PROGRESS !== 0 ensures that subducting plate creates a visible trench.
+export const MIN_PROGRESS = 0.04;
+
 // Set of properties related to subduction. Used by Field instances.
 export default class Subduction {
   dist: number;
@@ -46,7 +49,7 @@ export default class Subduction {
   }
 
   get progress() {
-    return Math.min(1, Math.pow(this.dist / MAX_SUBDUCTION_DIST, 2));
+    return Math.min(1, MIN_PROGRESS + Math.pow(this.dist / MAX_SUBDUCTION_DIST, 2));
   }
 
   get active() {

--- a/js/plates-model/volcanic-activity.ts
+++ b/js/plates-model/volcanic-activity.ts
@@ -89,7 +89,6 @@ export default class VolcanicActivity {
 
     if (this.field.isOcean && random() < this.islandProbability * timestep) {
       this.field.type = "island";
-      this.field.baseElevation += 0.25;
       // Make sure that this is still an island. If it's placed next to other islands, their total area
       // might exceed maximal area of the island and we should treat it as a continent.
       markIslands(this.field);

--- a/js/plates-model/volcanic-activity.ts
+++ b/js/plates-model/volcanic-activity.ts
@@ -54,7 +54,7 @@ export default class VolcanicActivity {
   }
 
   get islandProbability() {
-    if (!this.active || this.field.trench) return 0;
+    if (!this.active) return 0;
     return this.value / 20;
   }
 

--- a/js/plates-model/volcanic-activity.ts
+++ b/js/plates-model/volcanic-activity.ts
@@ -92,6 +92,7 @@ export default class VolcanicActivity {
       // Make sure that this is still an island. If it's placed next to other islands, their total area
       // might exceed maximal area of the island and we should treat it as a continent.
       markIslands(this.field);
+      this.deformingCapacity = MAX_DEFORMING_TIME;
     }
 
     this.deformingCapacity -= timestep;

--- a/js/plates-view/cross-section-3d.ts
+++ b/js/plates-view/cross-section-3d.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
-import renderCrossSection from "./render-cross-section";
+import renderCrossSection, { ICrossSectionOptions } from "./render-cross-section";
 import getThreeJSRenderer from "../get-threejs-renderer";
 
 const HORIZONTAL_MARGIN = 200; // px
@@ -170,14 +170,14 @@ export default class CrossSection3D {
     this.screenWidth = value;
   }
 
-  setCrossSectionData(data: any, swapped: any) {
-    renderCrossSection(this.frontWallCanvas, data.dataFront);
+  setCrossSectionData(data: any, swapped: boolean, options: ICrossSectionOptions) {
+    renderCrossSection(this.frontWallCanvas, data.dataFront, options);
     this.frontWallTexture.needsUpdate = true;
-    renderCrossSection(this.rightWallCanvas, data.dataRight);
+    renderCrossSection(this.rightWallCanvas, data.dataRight, options);
     this.rightWallTexture.needsUpdate = true;
-    renderCrossSection(this.backWallCanvas, data.dataBack);
+    renderCrossSection(this.backWallCanvas, data.dataBack, options);
     this.backWallTexture.needsUpdate = true;
-    renderCrossSection(this.leftWallCanvas, data.dataLeft);
+    renderCrossSection(this.leftWallCanvas, data.dataLeft, options);
     this.leftWallTexture.needsUpdate = true;
 
     const width = this.frontWallCanvas.width;

--- a/js/plates-view/plate-mesh.ts
+++ b/js/plates-view/plate-mesh.ts
@@ -229,7 +229,7 @@ export default class PlateMesh {
   updateFieldAttributes(field: any) {
     const colors = this.colorAttr.array;
     const vBumpScale = this.vertexBumpScaleAttr.array;
-    const sides = getGrid().neighboursCount(field.id);
+    const sides = getGrid().neighborsCount(field.id);
     const color = this.fieldColor(field);
     if (!color || equalColors(color, this.currentColor[field.id])) {
       return;
@@ -260,7 +260,7 @@ export default class PlateMesh {
   hideField(field: any) {
     const colors = this.colorAttr.array;
     this.currentColor[field.id] = null;
-    const sides = getGrid().neighboursCount(field.id);
+    const sides = getGrid().neighborsCount(field.id);
     const c = getGrid().getFirstVertex(field.id);
     for (let s = 0; s < sides; s += 1) {
       const cc = (c + s);

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -6,6 +6,7 @@ import { drawVolcanicEruptionShape } from "./volcanic-eruption-helpers";
 import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, OCEAN_COL, SKY_COL_1, SKY_COL_2 }
   from "../cross-section-colors";
 import { IChunkArray, IEarthquake } from "../plates-model/get-cross-section";
+import { SEA_LEVEL } from "../plates-model/field";
 
 const HEIGHT = 160; // px
 const SKY_PADDING = 30; // px, area above the dynamic cross-section view, filled with sky gradient
@@ -25,7 +26,7 @@ function earthquakeColor(depth: number) {
   return "#" + depthToColor(depth).toString(16).padStart(6, "0");
 }
 
-const SEA_LEVEL = scaleY(0.5); // 0.5 is a sea level in model units
+const SEA_LEVEL_SCALED = scaleY(SEA_LEVEL); // 0.5 is a sea level in model units
 
 const magmaImg = (function() {
   const img = new window.Image();
@@ -155,14 +156,14 @@ function renderChunkOverlay(ctx: CanvasRenderingContext2D, chunkData: IChunkArra
 
 function renderSkyAndSea(ctx: CanvasRenderingContext2D, width: number) {
   // Sky.
-  const sky = ctx.createLinearGradient(0, 0, 0, SEA_LEVEL);
+  const sky = ctx.createLinearGradient(0, 0, 0, SEA_LEVEL_SCALED);
   sky.addColorStop(0, SKY_COL_1);
   sky.addColorStop(1, SKY_COL_2);
   ctx.fillStyle = sky;
-  ctx.fillRect(0, 0, width, SEA_LEVEL);
+  ctx.fillRect(0, 0, width, SEA_LEVEL_SCALED);
   // Ocean.
   ctx.fillStyle = OCEAN_COL;
-  ctx.fillRect(0, SEA_LEVEL, width, HEIGHT);
+  ctx.fillRect(0, SEA_LEVEL_SCALED, width, HEIGHT);
 }
 
 export default function renderCrossSection(canvas: HTMLCanvasElement, data: IChunkArray[]) {

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -3,12 +3,16 @@ import config from "../config";
 import magmaSrc from "../../images/magma.png";
 import { depthToColor, drawEarthquakeShape } from "./earthquake-helpers";
 import { drawVolcanicEruptionShape } from "./volcanic-eruption-helpers";
-import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, OCEAN_COL, SKY_COL_1, SKY_COL_2 }
+import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, OCEAN_COL, SKY_COL_1, SKY_COL_2, ROCKS_COL }
   from "../cross-section-colors";
-import { IChunkArray, IEarthquake } from "../plates-model/get-cross-section";
+import { IChunkArray, IEarthquake, IFieldData } from "../plates-model/get-cross-section";
 import { SEA_LEVEL } from "../plates-model/field";
 
-const HEIGHT = 160; // px
+export interface ICrossSectionOptions {
+  rockLayers: boolean;
+}
+
+const HEIGHT = 240; // px
 const SKY_PADDING = 30; // px, area above the dynamic cross-section view, filled with sky gradient
 const MAX_ELEVATION = 1;
 const MIN_ELEVATION = config.crossSectionMinElevation;
@@ -97,7 +101,23 @@ function debugInfo(ctx: CanvasRenderingContext2D, p1: THREE.Vector2, p2: THREE.V
   });
 }
 
-function renderChunk(ctx: CanvasRenderingContext2D, chunkData: IChunkArray) {
+function renderCrust(ctx: CanvasRenderingContext2D, field: IFieldData, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2, options: ICrossSectionOptions) {
+  if (options.rockLayers) {
+    let currentThickness = 0;
+    field.rockLayers.forEach(rl => {
+      const p1tmp = p1.clone().lerp(p4, currentThickness);
+      const p2tmp = p2.clone().lerp(p3, currentThickness);
+      const p3tmp = p2.clone().lerp(p3, currentThickness + rl.relativeThickness);
+      const p4tmp = p1.clone().lerp(p4, currentThickness + rl.relativeThickness);
+      fillPath(ctx, ROCKS_COL[rl.rock], p1tmp, p2tmp, p3tmp, p4tmp);
+      currentThickness += rl.relativeThickness;
+    });
+  } else {
+    fillPath(ctx, field.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, p1, p2, p3, p4);
+  }
+}
+
+function renderChunk(ctx: CanvasRenderingContext2D, chunkData: IChunkArray, options: ICrossSectionOptions) {
   for (let i = 0; i < chunkData.chunks.length - 1; i += 1) {
     const x1 = chunkData.chunks[i].dist;
     const x2 = chunkData.chunks[i + 1].dist;
@@ -125,8 +145,8 @@ function renderChunk(ctx: CanvasRenderingContext2D, chunkData: IChunkArray) {
       drawMarker(ctx, t1);
     }
     // Fill crust
-    fillPath(ctx, f1.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, t1, tMid, cMid, c1);
-    fillPath(ctx, f2.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, tMid, t2, c2, cMid);
+    renderCrust(ctx, f1, t1, tMid, cMid, c1, options);
+    renderCrust(ctx, f2, tMid, t2, c2, cMid, options);
     // Fill lithosphere
     fillPath(ctx, LITHOSPHERE_COL, c1, c2, l2, l1);
     // Fill mantle
@@ -166,7 +186,7 @@ function renderSkyAndSea(ctx: CanvasRenderingContext2D, width: number) {
   ctx.fillRect(0, SEA_LEVEL_SCALED, width, HEIGHT);
 }
 
-export default function renderCrossSection(canvas: HTMLCanvasElement, data: IChunkArray[]) {
+export default function renderCrossSection(canvas: HTMLCanvasElement, data: IChunkArray[], options: ICrossSectionOptions) {
   const ctx = canvas.getContext("2d");
   if (!ctx) {
     return;
@@ -177,7 +197,7 @@ export default function renderCrossSection(canvas: HTMLCanvasElement, data: IChu
   canvas.height = HEIGHT + SKY_PADDING;
   ctx.clearRect(0, 0, width, HEIGHT + SKY_PADDING);
   renderSkyAndSea(ctx, width);
-  data.forEach((chunkData: IChunkArray) => renderChunk(ctx, chunkData));
+  data.forEach((chunkData: IChunkArray) => renderChunk(ctx, chunkData, options));
   // Second pass of rendering that will be drawn on top of existing plates. E.g. in some cases z-index of
   // some object should be independent of z-index of its plate (earthquakes, volcanic eruptions).
   data.forEach((chunkData: IChunkArray) => renderChunkOverlay(ctx, chunkData));

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -59,6 +59,7 @@ export class SimulationStore {
   @observable renderPlateLabels = config.renderPlateLabels;
   @observable planetCameraPosition = DEFAULT_PLANET_CAMERA_POSITION;
   @observable crossSectionCameraAngle = DEFAULT_CROSS_SECTION_CAMERA_ANGLE;
+  @observable crossSectionRockLayers = config.crossSectionRockLayers;
   @observable lastStoredModel: string | null = null;
   @observable savingModel = false;
   @observable debugMarker = new THREE.Vector3();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tectonic-explorer",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/model-serialization.test.ts
+++ b/test/model-serialization.test.ts
@@ -75,7 +75,6 @@ function compareSubplates(p1: Subplate, p2: Subplate) {
 
 function compareFields(f1: Field, f2: Field) {
   expect(f1.elevation).toEqual(f2.elevation);
-  expect(f1.baseElevation).toEqual(f2.baseElevation);
   expect(f1.crustThickness).toEqual(f2.crustThickness);
   expect(f1.absolutePos).toEqual(f2.absolutePos);
   expect(f1.force).toEqual(f2.force);

--- a/test/model-serialization.test.ts
+++ b/test/model-serialization.test.ts
@@ -77,7 +77,6 @@ function compareFields(f1: Field, f2: Field) {
   expect(f1.elevation).toEqual(f2.elevation);
   expect(f1.baseElevation).toEqual(f2.baseElevation);
   expect(f1.crustThickness).toEqual(f2.crustThickness);
-  expect(f1.baseCrustThickness).toEqual(f2.baseCrustThickness);
   expect(f1.absolutePos).toEqual(f2.absolutePos);
   expect(f1.force).toEqual(f2.force);
   expect(f1.age).toEqual(f2.age);
@@ -93,6 +92,7 @@ function compareFields(f1: Field, f2: Field) {
   compareHelpers(f1.volcanicAct, f2.volcanicAct);
   compareHelpers(f1.earthquake, f2.earthquake);
   compareHelpers(f1.volcanicEruption, f2.volcanicEruption);
+  compareHelpers(f1.crust, f2.crust);
 }
 
 function compareHelpers(h1: any, h2: any) {

--- a/test/plates-model/crust.test.ts
+++ b/test/plates-model/crust.test.ts
@@ -7,8 +7,9 @@ describe("Crust model", () => {
 
     crust = new Crust("ocean", 0.2);
     expect(crust.rockLayers).toEqual([
-      { rock: Rock.Basalt, thickness: 0.1, folding: 0 },
-      { rock: Rock.Gabbro, thickness: 0.1, folding: 0 }
+      { rock: Rock.Sediment, thickness: 0.05, folding: 0 },
+      { rock: Rock.Basalt, thickness: 0.045000000000000005, folding: 0 },
+      { rock: Rock.Gabbro, thickness: 0.10500000000000001, folding: 0 }
     ]);
 
     crust = new Crust("continent", 0.5);

--- a/test/plates-model/crust.test.ts
+++ b/test/plates-model/crust.test.ts
@@ -1,0 +1,65 @@
+import Crust, { Rock } from "../../js/plates-model/crust";
+
+describe("Crust model", () => {
+  it("can be initialized empty, or as ocean, continent or island", () => {
+    let crust = new Crust();
+    expect(crust.rockLayers.length).toEqual(0);
+
+    crust = new Crust("ocean", 0.2);
+    expect(crust.rockLayers).toEqual([
+      { rock: Rock.Basalt, thickness: 0.1, folding: 0 },
+      { rock: Rock.Gabbro, thickness: 0.1, folding: 0 }
+    ]);
+
+    crust = new Crust("continent", 0.5);
+    expect(crust.rockLayers).toEqual([
+      { rock: Rock.Granite, thickness: 0.5, folding: 0 }
+    ]);
+  });
+
+  it("returns total thickness of all the layers", () => {
+    const crust = new Crust();
+    crust.rockLayers = [
+      { rock: Rock.MaficRocks, thickness: 0.25, folding: 0 },
+      { rock: Rock.Basalt, thickness: 0.25, folding: 0 },
+      { rock: Rock.Gabbro, thickness: 0.5, folding: 0 }
+    ];
+    expect(crust.thickness).toEqual(1);
+  });
+
+  it("can add new rock type or increase its thickness", () => {
+    const crust = new Crust();
+    crust.increaseLayerThickness(Rock.Gabbro, 0.1);
+    expect(crust.rockLayers).toEqual([
+      { rock: Rock.Gabbro, thickness: 0.1, folding: 0 }
+    ]);
+    crust.increaseLayerThickness(Rock.Gabbro, 0.1);
+    expect(crust.rockLayers).toEqual([
+      { rock: Rock.Gabbro, thickness: 0.2, folding: 0 }
+    ]);
+    crust.increaseLayerThickness(Rock.MaficRocks, 0.123);
+    expect(crust.rockLayers).toEqual([
+      { rock: Rock.MaficRocks, thickness: 0.123, folding: 0 },
+      { rock: Rock.Gabbro, thickness: 0.2, folding: 0 }
+    ]);
+  });
+
+  it("can fold rock layers what results in larger thickness", () => {
+    const crust = new Crust();
+    crust.rockLayers = [
+      { rock: Rock.MaficRocks, thickness: 0.25, folding: 0 },
+      { rock: Rock.Basalt, thickness: 0.25, folding: 0 },
+      { rock: Rock.Gabbro, thickness: 0.5, folding: 0 }
+    ];
+    const oldThickness = crust.thickness;
+    const folding = 0.5;
+    crust.setFolding(folding);
+    expect(crust.thickness).toEqual((1 + folding) * oldThickness);
+    expect(crust.rockLayers).toEqual([
+      { rock: Rock.MaficRocks, thickness: 0.25, folding: 0.5 },
+      { rock: Rock.Basalt, thickness: 0.25, folding: 0.5 },
+      { rock: Rock.Gabbro, thickness: 0.5, folding: 0.5 }
+    ]);
+  });
+
+});

--- a/test/plates-model/field.test.ts
+++ b/test/plates-model/field.test.ts
@@ -9,7 +9,8 @@ describe("Field model", () => {
     it("should try to create earthquakes and volcanic eruptions", () => {
       const plate = {
         linearVelocity: () => new THREE.Vector3(1, 0, 0),
-        absolutePosition: (pos: THREE.Vector3) => pos
+        absolutePosition: (pos: THREE.Vector3) => pos,
+        fields: new Map()
       } as unknown as Plate;
       const field = new Field({ id: 0, plate });
       jest.spyOn(Earthquake, "shouldCreateEarthquake").mockImplementation(() => true);

--- a/test/plates-model/subduction.test.ts
+++ b/test/plates-model/subduction.test.ts
@@ -35,10 +35,10 @@ describe("Subduction model", () => {
     });
   });
 
-  describe("forEachSubductingNeighbour", () => {
+  describe("forEachSubductingNeighbor", () => {
     it("should call provided callback for every field that is subducting", () => {
       const field = {
-        forEachNeighbour: (callback: (field: any) => void) => {
+        forEachNeighbor: (callback: (field: any) => void) => {
           const fields = [
             { subduction: { progress: 0 } },
             { subduction: { progress: 0.5 } },
@@ -50,15 +50,15 @@ describe("Subduction model", () => {
       };
       const sub = new Subduction(field as Field);
       const callbackFn = jest.fn();
-      sub.forEachSubductingNeighbour(callbackFn);
+      sub.forEachSubductingNeighbor(callbackFn);
       expect(callbackFn).toHaveBeenCalledTimes(3);
     });
   });
 
   describe("avgProgress", () => {
-    it("should return avg progress of the subducting neighbours", () => {
+    it("should return avg progress of the subducting neighbors", () => {
       const field = {
-        forEachNeighbour: (callback: (field: any) => void) => {
+        forEachNeighbor: (callback: (field: any) => void) => {
           const fields = [
             { subduction: { progress: 0 } },
             { subduction: { progress: 0.5 } },
@@ -74,10 +74,10 @@ describe("Subduction model", () => {
   });
 
   describe("calcSlabGradient", () => {
-    it("should return null if there are not enough neighbouring fields that are subducting (will not be precise enough)", () => {
+    it("should return null if there are not enough neighboring fields that are subducting (will not be precise enough)", () => {
       const field = {
         absolutePos: new THREE.Vector3(1, 0, 0),
-        forEachNeighbour: (callback: (field: any) => void) => {
+        forEachNeighbor: (callback: (field: any) => void) => {
           const fields = [
             {
               absolutePos: new THREE.Vector3(0.8, 0, 0),
@@ -98,7 +98,7 @@ describe("Subduction model", () => {
     it("should return gradient of the subduction slope", () => {
       let field = {
         absolutePos: new THREE.Vector3(0.5, 0, 0),
-        forEachNeighbour: (callback: (field: any) => void) => {
+        forEachNeighbor: (callback: (field: any) => void) => {
           const fields = [
             {
               absolutePos: new THREE.Vector3(1, 0, 0),
@@ -130,7 +130,7 @@ describe("Subduction model", () => {
 
       field = {
         absolutePos: new THREE.Vector3(1, 0, 0),
-        forEachNeighbour: (callback) => {
+        forEachNeighbor: (callback) => {
           const fields = [
             {
               absolutePos: new THREE.Vector3(0.5, 0, 0),

--- a/test/plates-model/subduction.test.ts
+++ b/test/plates-model/subduction.test.ts
@@ -1,4 +1,4 @@
-import Subduction, { MAX_SUBDUCTION_DIST } from "../../js/plates-model/subduction";
+import Subduction, { MAX_SUBDUCTION_DIST, MIN_PROGRESS } from "../../js/plates-model/subduction";
 import Field from "../../js/plates-model/field";
 import * as THREE from "three";
 
@@ -15,7 +15,7 @@ describe("Subduction model", () => {
   describe("progress", () => {
     it("should be based on current distance traveled by field", () => {
       const sub = new Subduction({} as Field);
-      expect(sub.progress).toEqual(0);
+      expect(sub.progress).toEqual(MIN_PROGRESS);
       sub.dist = MAX_SUBDUCTION_DIST * 0.5;
       expect(sub.progress).toBeGreaterThan(0.1);
       expect(sub.progress).toBeLessThan(0.9);


### PR DESCRIPTION
To see these updates, open:
https://tectonic-explorer.concord.org/branch/176906271-rock-layers/index.html?preset=subduction
Let the model run for a bit, and try to draw a cross-section.
You can compare it with the old version:
https://tectonic-explorer.concord.org/?preset=subduction

The cross-section now shows rock layers that are building oceanic or continental crust.
Implemented logic covers:
 - oceanic rifting: basalt and gabbro increases over time)
 - orogeny: rocks get folded and increase their thickness
 - volcanic activity: volcanic rocks added 
 - sedimentation: everything submerged in the ocean is covered with a layer of sediments over time
 - accretionary wedge formation: it happens around the convergent boundary