### PR TITLE
Render the top rock layer in 3D view

### DIFF
--- a/css/planet-view.less
+++ b/css/planet-view.less
@@ -9,7 +9,7 @@
     height: calc(100% - @bottomBarHeight);
   }
   &.small {
-    height: calc(~"100% - 270px");
+    height: calc(~"100% - 350px");
   }
 
   .camera-reset {

--- a/js/colormaps.ts
+++ b/js/colormaps.ts
@@ -4,13 +4,16 @@ import { hsv } from "d3-hsv";
 import { rgb } from "d3-color";
 import { HIGHEST_MOUNTAIN_ELEVATION, BASE_OCEAN_ELEVATION } from "./plates-model/field";
 import { BASE_OCEAN_HSV_V } from "./plates-model/generate-plates";
+import { Rock } from "./plates-model/crust";
 
 const MIN_ELEVATION = -1;
 const MAX_ELEVATION = HIGHEST_MOUNTAIN_ELEVATION;
 
+type RGBA = { r: number; g: number; b: number; a: number; };
+
 // Color object used internally by 3D rendering.
 const toF = 1 / 255;
-function colorObj(rgbVal: any) {
+function colorObj(rgbVal: any): RGBA {
   return { r: rgbVal.r * toF, g: rgbVal.g * toF, b: rgbVal.b * toF, a: rgbVal.opacity };
 }
 
@@ -81,4 +84,30 @@ export function hueAndElevationToRgb(hue: number, elevation = 0) {
   }
   const rgbVal = hsv(hue, 1, value).rgb();
   return colorObj(rgbVal);
+}
+
+export const ROCKS_COL: Record<Rock, string> = {
+  [Rock.Granite]: "#4b1e01",
+  [Rock.Basalt]: "#06151b",
+  [Rock.Gabbro]: "#5d5243",
+  [Rock.AndesiticRocks]: "#585c5d",
+  [Rock.MaficRocks]: "#373633",
+  [Rock.Sediment]: "#a87d05",
+};
+
+export const ROCKS_COL_RGBA: Record<Rock, RGBA> = (() => {
+  const result: Partial<Record<Rock, RGBA>> = {};
+  Object.keys(ROCKS_COL).forEach((key: string) => {
+    const rock = Number(key) as Rock;
+    result[rock] = colorObj(rgb(ROCKS_COL[rock]));
+  });
+  return result as Record<Rock, RGBA>;
+})();
+
+export function rockColor(rockType: Rock) {
+  return ROCKS_COL[rockType];
+}
+
+export function rockColorRGBA(rockType: Rock) {
+  return ROCKS_COL_RGBA[rockType];
 }

--- a/js/components/sidebar-menu.tsx
+++ b/js/components/sidebar-menu.tsx
@@ -6,7 +6,7 @@ import { Dialog } from "react-toolbox/lib/dialog";
 import { List, ListItem, ListCheckbox } from "react-toolbox/lib/list";
 import Slider from "react-toolbox/lib/slider";
 import Dropdown from "react-toolbox/lib/dropdown";
-import config from "../config";
+import config, { Colormap } from "../config";
 import { BaseComponent, IBaseProps } from "./base";
 
 import css from "../../css-modules/sidebar-menu.less";
@@ -24,10 +24,11 @@ const INTERACTION_OPTIONS: Option[] = [
   { value: "fieldInfo", label: "Log Field Data" }
 ];
 
-const COLORMAP_OPTIONS: Option[] = [
+const COLORMAP_OPTIONS: { label: string, value: Colormap }[] = [
   { value: "topo", label: "Topographic" },
   { value: "plate", label: "Plate Color" },
-  { value: "age", label: "Crust Age" }
+  { value: "age", label: "Crust Age" },
+  { value: "rock", label: "Rock Type" }
 ];
 
 interface IProps extends IBaseProps {

--- a/js/config.ts
+++ b/js/config.ts
@@ -1,5 +1,7 @@
 import { getURLParam } from "./utils";
 
+export type Colormap = "topo" | "plate" | "age" | "rock";
+
 const DEFAULT_CONFIG = {
   // Authoring mode that lets user pick a planet layout and put continents on them.
   // Usually it is overwritten using URL param: planetWizard=true.
@@ -88,7 +90,7 @@ const DEFAULT_CONFIG = {
   // Divide plates that occupy more than X of the planet area.
   minSizeRatioForDivision: 0.65,
   // Rendering:
-  colormap: "topo", // 'topo' or 'plate'
+  colormap: "topo", // 'topo', 'age', 'plate', or 'rock'
   // Defines interaction that can be selected using top bar.
   selectableInteractions: ["crossSection", "force", "none"],
   wireframe: false,

--- a/js/cross-section-colors.ts
+++ b/js/cross-section-colors.ts
@@ -1,5 +1,3 @@
-import { Rock } from "./plates-model/crust";
-
 export const OCEANIC_CRUST_COL = "#27374f";
 export const CONTINENTAL_CRUST_COL = "#643d0c";
 export const LITHOSPHERE_COL = "#666";
@@ -7,12 +5,3 @@ export const MANTLE_COL = "#033f19";
 export const SKY_COL_1 = "#4375be";
 export const SKY_COL_2 = "#c0daeb";
 export const OCEAN_COL = "#1da2d8";
-
-export const ROCKS_COL: Record<Rock, string> = {
-  [Rock.Granite]: "#4b1e01",
-  [Rock.Basalt]: "#06151b",
-  [Rock.Gabbro]: "#5d5243",
-  [Rock.AndesiticRocks]: "#585c5d",
-  [Rock.MaficRocks]: "#373633",
-  [Rock.Sediment]: "#a87d05",
-};

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -1,12 +1,14 @@
 import { BASE_OCEANIC_CRUST_THICKNESS, FieldType } from "./field";
 
+// Do not use automatic enum values, as if we ever remove one rock type, other values shouldn't change.
+// It would break deserialization of the previously saved models.
 export enum Rock {
-  Granite = "Gr",
-  Basalt = "Ba",
-  Gabbro = "Ga",
-  MaficRocks = "MaR",
-  AndesiticRocks = "AnR",
-  Sediment = "Se"
+  Sediment = 0,
+  Granite = 1,
+  Basalt = 2,
+  Gabbro = 3,
+  MaficRocks = 4,
+  AndesiticRocks = 5,
 }
 
 // Labels used in UI.
@@ -50,8 +52,8 @@ export default class Crust {
   rockLayers: IRockLayer[] = [];
 
   constructor(fieldType?: FieldType, thickness?: number, withSediments = true) {
-    if (fieldType && thickness) {
-      this.setInitialRockLayers(fieldType, thickness, withSediments);
+    if (fieldType) {
+      this.setInitialRockLayers(fieldType, thickness || 0, withSediments);
     }
   }
 
@@ -61,6 +63,10 @@ export default class Crust {
       result += rockLayerFinalThickness(layer);
     }
     return result;
+  }
+
+  get topRockType() {
+    return this.rockLayers[0]?.rock || 0;
   }
 
   thicknessAboveZeroElevation() {

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -66,7 +66,8 @@ export default class Crust {
   }
 
   get topRockType() {
-    return this.rockLayers[0]?.rock || 0;
+    // Fallback to Rock.Sediment is pretty random. It should never happen, but just in case and to make TypeScript happy.
+    return this.rockLayers[0]?.rock || Rock.Sediment;
   }
 
   thicknessAboveZeroElevation() {

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -10,7 +10,7 @@ import VolcanicActivity, { ISerializedVolcanicAct } from "./volcanic-activity";
 import { basicDrag, orogenicDrag } from "./physics/forces";
 import Plate from "./plate";
 import Subplate from "./subplate";
-import Crust, { ISerializedCrust, MAX_REGULAR_SEDIMENT_THICKNESS, Rock } from "./crust";
+import Crust, { ISerializedCrust, MAX_REGULAR_SEDIMENT_THICKNESS } from "./crust";
 
 export type FieldType = "ocean" | "continent" | "island";
 
@@ -247,6 +247,10 @@ export default class Field extends FieldBase {
 
   get normalizedAge() {
     return Math.min(1, this.age / MAX_AGE);
+  }
+  
+  get rockType() {
+    return this.crust.topRockType;
   }
 
   get divergentBoundaryZone() {

--- a/js/plates-model/model-output.ts
+++ b/js/plates-model/model-output.ts
@@ -19,6 +19,7 @@ export interface IFieldsOutput {
   forceY?: Float32Array;
   forceZ?: Float32Array;
   originalHue?: Int16Array;
+  rockType?: Int16Array;
 }
 
 export interface IHotSpotOutput {
@@ -125,6 +126,9 @@ function plateOutput(plate: Plate, props: IWorkerProps | null, stepIdx: number, 
     if (props?.colormap === "plate") {
       fields.originalHue = new Int16Array(size);
     }
+    if (props?.colormap === "rock") {
+      fields.rockType = new Int16Array(size);
+    }
     let idx = 0;
     plate.fields.forEach((field: Field) => {
       fields.id[idx] = field.id;
@@ -150,6 +154,9 @@ function plateOutput(plate: Plate, props: IWorkerProps | null, stepIdx: number, 
         // We can't pass null in Int16 array so use -1.
         fields.originalHue[idx] = field.originalHue != null ? field.originalHue : -1;
       }
+      if (fields.rockType) {
+        fields.rockType[idx] = field.rockType;
+      }
       idx += 1;
     });
     // Rendering code won't know difference between normal and adjacent fields anyway.
@@ -157,6 +164,9 @@ function plateOutput(plate: Plate, props: IWorkerProps | null, stepIdx: number, 
       fields.id[idx] = field.id;
       fields.elevation[idx] = field.avgNeighbor("elevation");
       fields.normalizedAge[idx] = field.avgNeighbor("normalizedAge");
+      if (fields.rockType) {
+        fields.rockType[idx] = field.rockType;
+      }
       idx += 1;
     });
   }

--- a/js/plates-model/model-worker.ts
+++ b/js/plates-model/model-worker.ts
@@ -4,7 +4,7 @@ import modelOutput, { IFieldsOutput, IModelOutput, IPlateOutput } from "./model-
 import plateDrawTool from "./plate-draw-tool";
 import markIslands from "./mark-islands";
 import Model, { ISerializedModel } from "./model";
-import config from "../config";
+import config, { Colormap } from "../config";
 import Field from "./field";
 import { IVector3 } from "../types";
 
@@ -53,7 +53,7 @@ export interface IWorkerProps {
   crossSectionPoint4: THREE.Vector3 | null;
   crossSectionSwapped: boolean;
   showCrossSectionView: boolean;
-  colormap: "topo" | "plate";
+  colormap: Colormap;
   renderForces: boolean;
   renderHotSpots: boolean;
   renderBoundaries: boolean;

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -3,10 +3,11 @@ import config from "../config";
 import magmaSrc from "../../images/magma.png";
 import { depthToColor, drawEarthquakeShape } from "./earthquake-helpers";
 import { drawVolcanicEruptionShape } from "./volcanic-eruption-helpers";
-import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, OCEAN_COL, SKY_COL_1, SKY_COL_2, ROCKS_COL }
+import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, OCEAN_COL, SKY_COL_1, SKY_COL_2 }
   from "../cross-section-colors";
 import { IChunkArray, IEarthquake, IFieldData } from "../plates-model/get-cross-section";
 import { SEA_LEVEL } from "../plates-model/field";
+import { rockColor } from "../colormaps";
 
 export interface ICrossSectionOptions {
   rockLayers: boolean;
@@ -109,7 +110,7 @@ function renderCrust(ctx: CanvasRenderingContext2D, field: IFieldData, p1: THREE
       const p2tmp = p2.clone().lerp(p3, currentThickness);
       const p3tmp = p2.clone().lerp(p3, currentThickness + rl.relativeThickness);
       const p4tmp = p1.clone().lerp(p4, currentThickness + rl.relativeThickness);
-      fillPath(ctx, ROCKS_COL[rl.rock], p1tmp, p2tmp, p3tmp, p4tmp);
+      fillPath(ctx, rockColor(rl.rock), p1tmp, p2tmp, p3tmp, p4tmp);
       currentThickness += rl.relativeThickness;
     });
   } else {

--- a/js/stores/field-store.ts
+++ b/js/stores/field-store.ts
@@ -1,18 +1,20 @@
 import * as THREE from "three";
+import { Rock } from "../plates-model/crust";
 import FieldBase from "../plates-model/field-base";
 import { IFieldsOutput } from "../plates-model/model-output";
 
 export default class FieldStore extends FieldBase {
   // Never ever use @observable decorator here. There are too many fields being used and simple setting of a property
   // value will take too much time (it's been tested).
-  elevation: number | null = null;
-  normalizedAge: number | null = null;
+  elevation = 0;
+  normalizedAge = 0;
   boundary = false;
   earthquakeMagnitude = 0;
   earthquakeDepth = 0;
   volcanicEruption = false;
   force = new THREE.Vector3();
   originalHue: number | null = null;
+  rockType: Rock = 0;
 
   handleDataFromWorker(idx: number, fieldData: IFieldsOutput) {
     this.elevation = fieldData.elevation[idx];
@@ -32,6 +34,9 @@ export default class FieldStore extends FieldBase {
     }
     if (fieldData.originalHue) {
       this.originalHue = fieldData.originalHue[idx] !== -1 ? fieldData.originalHue[idx] : null;
+    }
+    if (fieldData.rockType) {
+      this.rockType = fieldData.rockType[idx];
     }
   }
 }

--- a/js/stores/field-store.ts
+++ b/js/stores/field-store.ts
@@ -14,7 +14,8 @@ export default class FieldStore extends FieldBase {
   volcanicEruption = false;
   force = new THREE.Vector3();
   originalHue: number | null = null;
-  rockType: Rock = 0;
+  // Fallback to Rock.Sediment is pretty random. It should never happen, but just in case and to make TypeScript happy.
+  rockType: Rock = Rock.Sediment;
 
   handleDataFromWorker(idx: number, fieldData: IFieldsOutput) {
     this.elevation = fieldData.elevation[idx];

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -1,5 +1,5 @@
 import { observable, computed, action, runInAction, autorun, makeObservable } from "mobx";
-import config from "../config";
+import config, { Colormap } from "../config";
 import * as THREE from "three";
 import isEqual from "lodash/isEqual";
 import { getCrossSectionRectangle, shouldSwapDirection } from "../plates-model/cross-section-utils";
@@ -46,7 +46,7 @@ export class SimulationStore {
   @observable crossSectionPoint2: THREE.Vector3 | null = null; // THREE.Vector3
   @observable playing = config.playing;
   @observable timestep = config.timestep;
-  @observable colormap = config.colormap;
+  @observable colormap: Colormap = config.colormap;
   @observable wireframe = config.wireframe;
   @observable earthquakes = config.earthquakes;
   @observable volcanicEruptions = config.volcanicEruptions;


### PR DESCRIPTION
This PR lets users change color scheme (using menu) in 3D view and show the top rock layer. Demo:
https://tectonic-explorer.concord.org/branch/177477605-rock-3d/index.html?preset=subduction

Note that this PR nicely predents how to transfer new property from Web Worker to the main thread.
The new array is added in `model-output.ts` and then it's handled in `field-store.ts` while this class is processing post message from the worker. 

I changed `Rock` enum to use numbers, as that lets us transfer values easily using post message transferrable properties (Int16Array). String can't be transported that way.