### PR TITLE
Render elevation in the 3D view

### DIFF
--- a/js/colormaps.ts
+++ b/js/colormaps.ts
@@ -9,7 +9,7 @@ import { Rock } from "./plates-model/crust";
 export const MIN_ELEVATION = -1;
 export const MAX_ELEVATION = HIGHEST_MOUNTAIN_ELEVATION;
 
-type RGBA = { r: number; g: number; b: number; a: number; };
+export type RGBA = { r: number; g: number; b: number; a: number; };
 
 // Color object used internally by 3D rendering.
 const toF = 1 / 255;

--- a/js/colormaps.ts
+++ b/js/colormaps.ts
@@ -6,8 +6,8 @@ import { HIGHEST_MOUNTAIN_ELEVATION, BASE_OCEAN_ELEVATION } from "./plates-model
 import { BASE_OCEAN_HSV_V } from "./plates-model/generate-plates";
 import { Rock } from "./plates-model/crust";
 
-const MIN_ELEVATION = -1;
-const MAX_ELEVATION = HIGHEST_MOUNTAIN_ELEVATION;
+export const MIN_ELEVATION = -1;
+export const MAX_ELEVATION = HIGHEST_MOUNTAIN_ELEVATION;
 
 type RGBA = { r: number; g: number; b: number; a: number; };
 
@@ -63,10 +63,16 @@ const topoColormap = d3Colormap({
   [MAX_ELEVATION]: "#FFFFFF"
 }, 1000);
 
+export function normalizeElevation(elevation: number) {
+  return (Math.max(MIN_ELEVATION, Math.min(MAX_ELEVATION, elevation)) - MIN_ELEVATION) / (MAX_ELEVATION - MIN_ELEVATION);
+}
+
+export function topoColorFromNormalized(normalizedElevation: number) {
+  return topoColormap[Math.floor(normalizedElevation * (topoColormap.length - 1))];
+}
+
 export function topoColor(elevation: number) {
-  const elevationNorm = (Math.max(MIN_ELEVATION, Math.min(MAX_ELEVATION, elevation)) - MIN_ELEVATION) / (MAX_ELEVATION - MIN_ELEVATION);
-  const shade = Math.floor(elevationNorm * (topoColormap.length - 1));
-  return topoColormap[shade];
+  return topoColormap[Math.floor(normalizeElevation(elevation) * (topoColormap.length - 1))];
 }
 
 // Hue should be within [0, 360] range and elevation will be clamped to [-1, 1] range.

--- a/js/colormaps.ts
+++ b/js/colormaps.ts
@@ -67,10 +67,6 @@ export function normalizeElevation(elevation: number) {
   return (Math.max(MIN_ELEVATION, Math.min(MAX_ELEVATION, elevation)) - MIN_ELEVATION) / (MAX_ELEVATION - MIN_ELEVATION);
 }
 
-export function topoColorFromNormalized(normalizedElevation: number) {
-  return topoColormap[Math.floor(normalizedElevation * (topoColormap.length - 1))];
-}
-
 export function topoColor(elevation: number) {
   return topoColormap[Math.floor(normalizeElevation(elevation) * (topoColormap.length - 1))];
 }

--- a/js/components/color-key.tsx
+++ b/js/components/color-key.tsx
@@ -8,9 +8,9 @@ import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, 
 import { BaseComponent, IBaseProps } from "./base";
 import { Rock, ROCK_LABEL } from "../plates-model/crust";
 import PlateStore from "../stores/plate-store";
+import { Colormap } from "../config";
 
 import css from "../../css-modules/color-key.less";
-import { Colormap } from "../config";
 
 function colToHex(c: any) {
   return `rgba(${Math.round(c.r * 255)}, ${Math.round(c.g * 255)}, ${Math.round(c.b * 255)}, ${c.a})`;

--- a/js/config.ts
+++ b/js/config.ts
@@ -101,8 +101,9 @@ const DEFAULT_CONFIG = {
   renderLatLongLines: false,
   renderPlateLabels: true,
   crossSection3d: true,
-  hexagonalFields: false,
   flatShading: true,
+  // Smaller number (16-64) will make topo scale less smooth and look closer to a real topographic map.
+  // Large values (128-256) will smooth out the rendering.
   topoColormapShades: 64,
   // Shows extended version of the cross-section with separate rock layers.
   crossSectionRockLayers: true,

--- a/js/config.ts
+++ b/js/config.ts
@@ -101,6 +101,8 @@ const DEFAULT_CONFIG = {
   renderLatLongLines: false,
   renderPlateLabels: true,
   crossSection3d: true,
+  hexagonalFields: true,
+  flatShading: false,
   // Shows extended version of the cross-section with separate rock layers.
   crossSectionRockLayers: true,
   bumpMapping: true,

--- a/js/config.ts
+++ b/js/config.ts
@@ -101,8 +101,9 @@ const DEFAULT_CONFIG = {
   renderLatLongLines: false,
   renderPlateLabels: true,
   crossSection3d: true,
-  hexagonalFields: true,
-  flatShading: false,
+  hexagonalFields: false,
+  flatShading: true,
+  topoColormapShades: 64,
   // Shows extended version of the cross-section with separate rock layers.
   crossSectionRockLayers: true,
   bumpMapping: true,

--- a/js/peels/sphere/to-cg.ts
+++ b/js/peels/sphere/to-cg.ts
@@ -37,7 +37,7 @@ interface IAttributesResult {
   normals: Float32Array;
   indices: Uint16Array | Uint32Array | Array<number>;
   colors: Float32Array;
-  uvs?: Float32Array;
+  uvs: Float32Array;
 }
 
 /**
@@ -57,6 +57,8 @@ function barycenterVerticesAndFaces(sphere: any, options: IOptions) {
 
   const colors = new Float32Array(indices.length * 4);
 
+  const uvs = new Float32Array(n * 2);
+
   for (let f = 0; f < sphere._Fields.length; f += 1) {
     const field = sphere._Fields[f];
 
@@ -66,14 +68,21 @@ function barycenterVerticesAndFaces(sphere: any, options: IOptions) {
 
     const color = options.colorFn.call(field);
 
-    positions[f * 3 + 0] = cos(fφ) * cos(fλ); // x
-    positions[f * 3 + 2] = cos(fφ) * sin(fλ); // z
-    positions[f * 3 + 1] = sin(fφ); // y
+    const x = cos(fφ) * cos(fλ);
+    const z = cos(fφ) * sin(fλ);
+    const y = sin(fφ);
+
+    positions[f * 3 + 0] = x;
+    positions[f * 3 + 1] = y;
+    positions[f * 3 + 2] = z;
 
     colors[f * 3 + 0] = color.r;
     colors[f * 3 + 1] = color.g;
     colors[f * 3 + 2] = color.b;
     colors[f * 4 + 3] = color.a != null ? color.a : 1.0;
+
+    uvs[f * 2 + 0] = 0.5 + Math.atan2(z, x) / (2 * Math.PI);
+    uvs[f * 2 + 1] = 0.5 - Math.asin(y) / Math.PI;
   }
 
   // normals are exactly positions, as long as radius is 1
@@ -83,7 +92,8 @@ function barycenterVerticesAndFaces(sphere: any, options: IOptions) {
     positions,
     normals,
     indices,
-    colors
+    colors,
+    uvs
   };
 }
 

--- a/js/plates-model/grid.ts
+++ b/js/plates-model/grid.ts
@@ -24,16 +24,12 @@ function dist(a: IKDTreeNode, b: IKDTreeNode) {
 class Grid {
   fieldDiameter: number;
   fieldDiameterInKm: number;
-  firstVertex: Record<number, number>;
   kdTree: kdTree<IKDTreeNode>;
   sphere: Sphere;
   voronoiSphere: VoronoiSphere;
 
   constructor() {
     this.sphere = new Sphere({ divisions: config.divisions });
-    // firstVertex[field.id] returns index of the first vertex of given field.
-    // Since both hexagons and pentagons are used, it's impossible to calculate it on the fly.
-    this.firstVertex = {};
     this.processFields();
     this.fieldDiameter = this.calcFieldDiameter();
     this.fieldDiameterInKm = this.fieldDiameter * c.earthRadius;
@@ -56,19 +52,11 @@ class Grid {
     return this.fields.length * 6 - 12;
   }
 
-  getFirstVertex(fieldId: number) {
-    return this.firstVertex[fieldId];
-  }
-
   // Pre-calculate additional information.
   processFields() {
-    let count = 0;
     this.fields.forEach((field: IGridField) => {
       field.localPos = toCartesian(field.position);
       field.adjacentFields = field._adjacentFields.map((f: PeelsField) => f.id);
-      // Populate firstVertex hash.
-      this.firstVertex[field.id] = count;
-      count += field.adjacentFields.length;
     });
   }
 
@@ -118,7 +106,8 @@ class Grid {
 
   getGeometryAttributes() {
     const transparent = { r: 0, g: 0, b: 0, a: 0 };
-    return this.sphere.toCG({ colorFn: () => transparent, type: config.hexagonalFields ? "poly-per-field" : "vertex-per-field" });
+    // Another option: "poly-per-field"
+    return this.sphere.toCG({ colorFn: () => transparent, type: "vertex-per-field" });
   }
 }
 

--- a/js/plates-model/grid.ts
+++ b/js/plates-model/grid.ts
@@ -118,7 +118,7 @@ class Grid {
 
   getGeometryAttributes() {
     const transparent = { r: 0, g: 0, b: 0, a: 0 };
-    return this.sphere.toCG({ colorFn: () => transparent, type: "poly-per-field" });
+    return this.sphere.toCG({ colorFn: () => transparent, type: config.hexagonalFields ? "poly-per-field" : "vertex-per-field" });
   }
 }
 

--- a/js/plates-model/model-output.ts
+++ b/js/plates-model/model-output.ts
@@ -134,7 +134,7 @@ function plateOutput(plate: Plate, props: IWorkerProps | null, stepIdx: number, 
       fields.id[idx] = field.id;
       fields.elevation[idx] = field.elevation;
       fields.normalizedAge[idx] = field.normalizedAge;
-      if (fields.boundary && field.boundary) {
+      if (fields.boundary) {
         fields.boundary[idx] = field.boundary ? 1 : 0;
       }
       if (fields.earthquakeMagnitude && fields.earthquakeDepth && field.earthquake) {
@@ -166,6 +166,9 @@ function plateOutput(plate: Plate, props: IWorkerProps | null, stepIdx: number, 
       fields.normalizedAge[idx] = field.avgNeighbor("normalizedAge");
       if (fields.rockType) {
         fields.rockType[idx] = field.rockType;
+      }
+      if (fields.boundary) {
+        fields.boundary[idx] = field.boundary ? 1 : 0;
       }
       idx += 1;
     });

--- a/js/plates-view/cross-section-markers.ts
+++ b/js/plates-view/cross-section-markers.ts
@@ -6,9 +6,7 @@ import { getCrossSectionLinesVisibility } from "../plates-model/cross-section-ut
 
 const ARC_SEGMENTS = 16;
 const ARC_WIDTH = 0.01;
-
-// Hexagonal field are rendered without elevation data, so lines can be closer to the planet surface.
-const RADIUS = config.hexagonalFields ? 1.01 : 1.07;
+const RADIUS = 1.07;
 
 export default class CrossSectionMarkers {
   cylinder1: any;

--- a/js/plates-view/cross-section-markers.ts
+++ b/js/plates-view/cross-section-markers.ts
@@ -7,7 +7,8 @@ import { getCrossSectionLinesVisibility } from "../plates-model/cross-section-ut
 const ARC_SEGMENTS = 16;
 const ARC_WIDTH = 0.01;
 
-const RADIUS = 1.01;
+// Hexagonal field are rendered without elevation data, so lines can be closer to the planet surface.
+const RADIUS = config.hexagonalFields ? 1.01 : 1.07;
 
 export default class CrossSectionMarkers {
   cylinder1: any;

--- a/js/plates-view/planet-view.ts
+++ b/js/plates-view/planet-view.ts
@@ -200,14 +200,7 @@ export default class PlanetView {
   }
 
   adjustLatLongLinesRadius() {
-    // Makes sure that lat long lines are always visible, but also not too far away from the plant surface.
-    let maxRadius = 0;
-    this.plateMeshes.forEach((plateMesh: any) => {
-      if (maxRadius < plateMesh.radius) {
-        maxRadius = plateMesh.radius;
-      }
-    });
-    this.latLongLines.radius = maxRadius + 0.002;
+    this.latLongLines.radius = PLATE_RADIUS + 0.002;
   }
 
   setFieldMarkers(markers: any) {

--- a/js/plates-view/planet-view.ts
+++ b/js/plates-view/planet-view.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { autorun, observe } from "mobx";
-import PlateMesh from "./plate-mesh";
+import PlateMesh, { PLATE_RADIUS } from "./plate-mesh";
 import FieldMarker from "./field-marker";
 import ForceArrow from "./force-arrow";
 import CrossSectionMarkers from "./cross-section-markers";
@@ -151,7 +151,7 @@ export default class PlanetView {
   addStaticMantle() {
     // Add "mantle". It won't be visible most of the time (only divergent boundaries).
     const material = new THREE.MeshPhongMaterial({ color: MANTLE_COLOR });
-    const geometry = new THREE.SphereGeometry(0.985, 64, 64);
+    const geometry = new THREE.SphereGeometry(PLATE_RADIUS * 0.985, 64, 64);
     const mesh = new THREE.Mesh(geometry, material);
     this.scene.add(mesh);
   }

--- a/js/plates-view/planet-view.ts
+++ b/js/plates-view/planet-view.ts
@@ -142,9 +142,8 @@ export default class PlanetView {
     this.controls.minDistance = 1.8;
     this.controls.maxDistance = 10;
 
-    this.scene.add(new THREE.AmbientLight(0x4f5359));
-    this.scene.add(new THREE.HemisphereLight(0xC6C2B6, 0x3A403B, 0.75));
-    this.light = new THREE.PointLight(0xffffff, 0.3);
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.5));
+    this.light = new THREE.PointLight(0xffffff, 0.5);
     this.scene.add(this.light);
   }
 

--- a/js/plates-view/plate-label.ts
+++ b/js/plates-view/plate-label.ts
@@ -3,8 +3,7 @@ import { hueAndElevationToRgb } from "../colormaps";
 import PointLabel from "./point-label";
 import config from "../config";
 
-// Hexagonal field are rendered without elevation data, so label can be closer to the planet surface.
-const RADIUS = config.hexagonalFields ? 1.025 : 1.05;
+const RADIUS = 1.05;
 
 export default class PlateLabel {
   label: any;

--- a/js/plates-view/plate-label.ts
+++ b/js/plates-view/plate-label.ts
@@ -3,7 +3,8 @@ import { hueAndElevationToRgb } from "../colormaps";
 import PointLabel from "./point-label";
 import config from "../config";
 
-const RADIUS = 1.025;
+// Hexagonal field are rendered without elevation data, so label can be closer to the planet surface.
+const RADIUS = config.hexagonalFields ? 1.025 : 1.05;
 
 export default class PlateLabel {
   label: any;

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -4,7 +4,9 @@
 
 // --- CUSTOM:
 varying vec4 vColor;
-varying float vNormElevation;
+varying float vHidden;
+varying float vColormapValue;
+
 uniform sampler2D colormap;
 uniform float HIDDEN_FIELD_ALPHA_VAL;
 // ---
@@ -32,6 +34,7 @@ uniform float opacity;
 #include <lights_pars_begin>
 #include <lights_phong_pars_fragment>
 #include <shadowmap_pars_fragment>
+
 // #include <bumpmap_pars_fragment>
 // Use custom bump map helpers that use bumpScale attribute instead of uniform.
 #ifdef USE_BUMPMAP
@@ -75,6 +78,7 @@ uniform float opacity;
 
 #endif
 // --- CUSTOM
+
 #include <normalmap_pars_fragment>
 #include <specularmap_pars_fragment>
 #include <logdepthbuf_pars_fragment>
@@ -87,19 +91,21 @@ void main() {
 	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	#include <color_fragment>
-  // --- CUSTOM:  
-  if (vColor.a == HIDDEN_FIELD_ALPHA_VAL) {
+
+  // --- CUSTOM:
+  if (vHidden == 1.0) {
     // Hide pixel.
     diffuseColor = vec4(0.0, 0.0, 0.0, 0.0);
-  } else if (vColor.a > 0.75) {
+  } else if (vColor.a > 0.85) {
     // Use specific color provided in color attribute. For example plate boundary color.
-    // Note that rendering only for alpha > 0.75 makes this color line more sharp.
+    // Note that rendering only for alpha > X (e.g. 0.75 or 0.5) makes this color line more sharp.
     diffuseColor *= vec4(vColor.r, vColor.g, vColor.b, 1.0);
   } else {
     // Use the default colormap if vColor is transparent.
-    diffuseColor *= texture2D(colormap, vec2(0.5, vNormElevation));
+    diffuseColor *= texture2D(colormap, vec2(0.5, vColormapValue));
   }
   // ---
+
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
 	#include <specularmap_fragment>

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -4,6 +4,9 @@
 
 // --- CUSTOM:
 varying vec4 vColor;
+varying float vNormElevation;
+uniform sampler2D colormap;
+uniform float HIDDEN_FIELD_ALPHA_VAL;
 // ---
 #define PHONG
 uniform vec3 diffuse;
@@ -84,9 +87,19 @@ void main() {
 	#include <logdepthbuf_fragment>
 	#include <map_fragment>
 	#include <color_fragment>
-    // --- CUSTOM:
-    diffuseColor *= vColor;
-    // ---
+  // --- CUSTOM:  
+  if (vColor.a == HIDDEN_FIELD_ALPHA_VAL) {
+    // Hide pixel.
+    diffuseColor = vec4(0.0, 0.0, 0.0, 0.0);
+  } else if (vColor.a > 0.75) {
+    // Use specific color provided in color attribute. For example plate boundary color.
+    // Note that rendering only for alpha > 0.75 makes this color line more sharp.
+    diffuseColor *= vec4(vColor.r, vColor.g, vColor.b, 1.0);
+  } else {
+    // Use the default colormap if vColor is transparent.
+    diffuseColor *= texture2D(colormap, vec2(0.5, vNormElevation));
+  }
+  // ---
 	#include <alphamap_fragment>
 	#include <alphatest_fragment>
 	#include <specularmap_fragment>

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -1,6 +1,7 @@
 // Slightly modified Phong shader taken from THREE.ShaderLib:
 // https://github.com/mrdoob/three.js/blob/0c51e577afd011aea8d635db2eeb9185b3999889/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
-// It supports alpha channel in color attribute. vec4 is used instead of vec3.
+// It supports alpha channel in color attribut (vec4 is used instead of vec3) + a few custom features like 
+// hiding vertices, colormap texture, and so on. Custom code is always enclosed in // --- CUSTOM comment.
 
 // --- CUSTOM:
 varying vec4 vColor;
@@ -8,7 +9,6 @@ varying float vHidden;
 varying float vColormapValue;
 
 uniform sampler2D colormap;
-uniform float HIDDEN_FIELD_ALPHA_VAL;
 // ---
 #define PHONG
 uniform vec3 diffuse;
@@ -96,9 +96,9 @@ void main() {
   if (vHidden == 1.0) {
     // Hide pixel.
     diffuseColor = vec4(0.0, 0.0, 0.0, 0.0);
-  } else if (vColor.a > 0.85) {
+  } else if (vColor.a > 0.5) {
     // Use specific color provided in color attribute. For example plate boundary color.
-    // Note that rendering only for alpha > X (e.g. 0.75 or 0.5) makes this color line more sharp.
+    // Note that rendering only for alpha > X (e.g. 0.75 or 0.5) makes this color line thinner.
     diffuseColor *= vec4(vColor.r, vColor.g, vColor.b, 1.0);
   } else {
     // Use the default colormap if vColor is transparent.

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -32,7 +32,7 @@ uniform float opacity;
 #include <lights_pars_begin>
 #include <lights_phong_pars_fragment>
 #include <shadowmap_pars_fragment>
-//#include <bumpmap_pars_fragment>
+// #include <bumpmap_pars_fragment>
 // Use custom bump map helpers that use bumpScale attribute instead of uniform.
 #ifdef USE_BUMPMAP
 	uniform sampler2D bumpMap;

--- a/js/plates-view/plate-mesh-vertex.glsl
+++ b/js/plates-view/plate-mesh-vertex.glsl
@@ -3,22 +3,18 @@
 // It supports alpha channel in color attribute. vec4 is used instead of vec3.
 
 // --- CUSTOM:
-attribute vec4 color;
-varying vec4 vColor;
-
-attribute float vertexBumpScale;
 attribute float vertexElevation;
+attribute vec4 color;
+attribute float vertexHidden;
+attribute float vertexBumpScale;
+attribute float colormapValue;
+
+varying vec4 vColor;
+varying float vHidden;
 varying float vBumpScale;
-varying float vNormElevation;
+varying float vColormapValue;
 
-uniform float ELEVATION_SCALE;
-uniform float MIN_ELEVATION;
-uniform float MAX_ELEVATION;
 uniform bool USE_ELEVATION_DISPLACEMENT;
-
-float normalizeViewElevation(float viewElevation) {
-  return (max(MIN_ELEVATION, min(MAX_ELEVATION, viewElevation / ELEVATION_SCALE)) - MIN_ELEVATION) / (MAX_ELEVATION - MIN_ELEVATION);
-}
 // ---
 
 #define PHONG
@@ -39,11 +35,14 @@ varying vec3 vViewPosition;
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
 void main() {
+
   // --- CUSTOM:
   vColor = color;
-  vNormElevation = normalizeViewElevation(vertexElevation);
   vBumpScale = vertexBumpScale;
+  vHidden = vertexHidden;
+  vColormapValue = colormapValue;
   // ---
+
 	#include <uv_vertex>
 	#include <uv2_vertex>
 	#include <color_vertex>
@@ -59,9 +58,11 @@ void main() {
 	#include <morphtarget_vertex>
 	#include <skinning_vertex>
 	#include <displacementmap_vertex>
+
   // --- CUSTOM:
   transformed += normalize(objectNormal) * vertexElevation;
   // ---
+
 	#include <project_vertex>
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>

--- a/js/plates-view/plate-mesh-vertex.glsl
+++ b/js/plates-view/plate-mesh-vertex.glsl
@@ -7,6 +7,7 @@ attribute vec4 color;
 varying vec4 vColor;
 
 attribute float vertexBumpScale;
+attribute float vertexElevation;
 varying float vBumpScale;
 // ---
 
@@ -28,10 +29,10 @@ varying vec3 vViewPosition;
 #include <logdepthbuf_pars_vertex>
 #include <clipping_planes_pars_vertex>
 void main() {
-    // --- CUSTOM:
-    vColor = color;
-    vBumpScale = vertexBumpScale;
-    // ---
+  // --- CUSTOM:
+  vColor = color;
+  vBumpScale = vertexBumpScale;
+  // ---
 	#include <uv_vertex>
 	#include <uv2_vertex>
 	#include <color_vertex>
@@ -47,6 +48,9 @@ void main() {
 	#include <morphtarget_vertex>
 	#include <skinning_vertex>
 	#include <displacementmap_vertex>
+  // --- CUSTOM:
+  transformed += normalize(objectNormal) * vertexElevation;
+  // ---
 	#include <project_vertex>
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>

--- a/js/plates-view/plate-mesh-vertex.glsl
+++ b/js/plates-view/plate-mesh-vertex.glsl
@@ -14,6 +14,7 @@ varying float vNormElevation;
 uniform float ELEVATION_SCALE;
 uniform float MIN_ELEVATION;
 uniform float MAX_ELEVATION;
+uniform bool USE_ELEVATION_DISPLACEMENT;
 
 float normalizeViewElevation(float viewElevation) {
   return (max(MIN_ELEVATION, min(MAX_ELEVATION, viewElevation / ELEVATION_SCALE)) - MIN_ELEVATION) / (MAX_ELEVATION - MIN_ELEVATION);
@@ -59,7 +60,7 @@ void main() {
 	#include <skinning_vertex>
 	#include <displacementmap_vertex>
   // --- CUSTOM:
-  transformed += normalize(objectNormal) * sign(vertexElevation) * pow(vertexElevation, 1.0);
+  transformed += normalize(objectNormal) * vertexElevation;
   // ---
 	#include <project_vertex>
 	#include <logdepthbuf_vertex>

--- a/js/plates-view/plate-mesh-vertex.glsl
+++ b/js/plates-view/plate-mesh-vertex.glsl
@@ -1,11 +1,12 @@
 // Slightly modified Phong shader taken from THREE.ShaderLib.
 // https://github.com/mrdoob/three.js/blob/0c51e577afd011aea8d635db2eeb9185b3999889/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
-// It supports alpha channel in color attribute. vec4 is used instead of vec3.
+// It supports alpha channel in color attribut (vec4 is used instead of vec3) + a few custom features like 
+// hiding vertices, colormap texture, and so on. Custom code is always enclosed in // --- CUSTOM comment.
 
 // --- CUSTOM:
-attribute float vertexElevation;
+attribute float elevation;
 attribute vec4 color;
-attribute float vertexHidden;
+attribute float hidden;
 attribute float vertexBumpScale;
 attribute float colormapValue;
 
@@ -13,8 +14,6 @@ varying vec4 vColor;
 varying float vHidden;
 varying float vBumpScale;
 varying float vColormapValue;
-
-uniform bool USE_ELEVATION_DISPLACEMENT;
 // ---
 
 #define PHONG
@@ -39,7 +38,7 @@ void main() {
   // --- CUSTOM:
   vColor = color;
   vBumpScale = vertexBumpScale;
-  vHidden = vertexHidden;
+  vHidden = hidden;
   vColormapValue = colormapValue;
   // ---
 
@@ -60,7 +59,7 @@ void main() {
 	#include <displacementmap_vertex>
 
   // --- CUSTOM:
-  transformed += normalize(objectNormal) * vertexElevation;
+  transformed += normalize(objectNormal) * elevation;
   // ---
 
 	#include <project_vertex>

--- a/js/plates-view/plate-mesh-vertex.glsl
+++ b/js/plates-view/plate-mesh-vertex.glsl
@@ -9,6 +9,15 @@ varying vec4 vColor;
 attribute float vertexBumpScale;
 attribute float vertexElevation;
 varying float vBumpScale;
+varying float vNormElevation;
+
+uniform float ELEVATION_SCALE;
+uniform float MIN_ELEVATION;
+uniform float MAX_ELEVATION;
+
+float normalizeViewElevation(float viewElevation) {
+  return (max(MIN_ELEVATION, min(MAX_ELEVATION, viewElevation / ELEVATION_SCALE)) - MIN_ELEVATION) / (MAX_ELEVATION - MIN_ELEVATION);
+}
 // ---
 
 #define PHONG
@@ -31,6 +40,7 @@ varying vec3 vViewPosition;
 void main() {
   // --- CUSTOM:
   vColor = color;
+  vNormElevation = normalizeViewElevation(vertexElevation);
   vBumpScale = vertexBumpScale;
   // ---
 	#include <uv_vertex>
@@ -49,7 +59,7 @@ void main() {
 	#include <skinning_vertex>
 	#include <displacementmap_vertex>
   // --- CUSTOM:
-  transformed += normalize(objectNormal) * vertexElevation;
+  transformed += normalize(objectNormal) * sign(vertexElevation) * pow(vertexElevation, 1.0);
   // ---
 	#include <project_vertex>
 	#include <logdepthbuf_vertex>

--- a/js/plates-view/plate-mesh.ts
+++ b/js/plates-view/plate-mesh.ts
@@ -228,9 +228,7 @@ export default class PlateMesh {
     this.geometry.setIndex(new THREE.BufferAttribute(attributes.indices, 1));
     this.geometry.setAttribute("position", new THREE.BufferAttribute(attributes.positions, 3));
     this.geometry.setAttribute("normal", new THREE.BufferAttribute(attributes.normals, 3));
-    if (attributes.uvs) {
-      this.geometry.setAttribute("uv", new THREE.BufferAttribute(attributes.uvs, 2));
-    }
+    this.geometry.setAttribute("uv", new THREE.BufferAttribute(attributes.uvs, 2));
     this.geometry.setAttribute("color", new THREE.BufferAttribute(attributes.colors, 4));
     // Hide all fields by default. Alpha is a 4th channel in color attribute.
     for (let i = 3; i < attributes.colors.length; i += 4) {
@@ -306,7 +304,7 @@ export default class PlateMesh {
     let bump = field.elevation && Math.max(0.0025, Math.pow(field.elevation - 0.43, 3));
     if (field.normalizedAge < 1) {
       // Make oceanic ridges bumpy too.
-      bump += (1 - field.normalizedAge) * 0.1;
+      bump += (1 - field.normalizedAge) * 0.07;
     }
     vBumpScale[cc] = bump;
 


### PR DESCRIPTION
Demo links:
- default settings - 64 topo shades, flat shading, bump mapping ON: https://tectonic-explorer.concord.org/branch/177509275-elevation-3d/index.html?preset=subduction
- same, but with bump mapping OFF - cleaner / more cartoon-like style: https://tectonic-explorer.concord.org/branch/177509275-elevation-3d/index.html?preset=subduction&bumpMapping=false
- same, but also without flat shading: https://tectonic-explorer.concord.org/branch/177509275-elevation-3d/index.html?preset=subduction&bumpMapping=false&flatShading=false
- “realistic” settings - 256 topo shades, no flat shading, bump mapping ON: https://tectonic-explorer.concord.org/branch/177509275-elevation-3d/index.html?preset=subduction&topoColormapShades=256&flatShading=false

You can compare that with old way of rendering:
https://tectonic-explorer.concord.org/?preset=subduction

The most tricky part is updated shaders and colormap texture being read in the fragment shader. It fixes the initial blurriness of this rendering method. If I only used color attributes per vertex, GPU would linearly interpolate colors. Now the GPU interpolates elevation instead (what is what we actually want), then I'm reading this interpolated elevation in the fragment shader, and finally using it to get correct colormap color.

It works only for continuous colormaps like the topographic one. When rock type coloring is used, values cannot be interpolated (e.g. going from sediments to basalt would result in pixels colored in other rock types that are between these two colors in the color map). So, the color attribute is still used in some cases.

I've tried to add enough comments to make that more or less clear.