### PR TITLE
Add trench modeling

### DIFF
--- a/js/colormaps.ts
+++ b/js/colormaps.ts
@@ -31,7 +31,7 @@ function d3ScaleToArray(d3Scale: any, shadesCount: any) {
 }
 
 function d3Colormap(desc: any, shadesCount: number | null = null) {
-  const keys = Object.keys(desc).map(k => Number(k)).sort();
+  const keys = Object.keys(desc).map(k => Number(k)).sort((a, b) => a - b);
   if (!shadesCount) {
     shadesCount = keys.length;
   }
@@ -46,8 +46,8 @@ function d3Colormap(desc: any, shadesCount: number | null = null) {
 // https://gist.github.com/hugolpz/4351d8f1b3da93de2c61
 // https://en.wikipedia.org/wiki/Wikipedia:WikiProject_Maps/Conventions#Topographic_maps
 const topoColormap = d3Colormap({
-  [MIN_ELEVATION]: "#15364d",
-  [-0.05]: "#173e5c",
+  [MIN_ELEVATION]: "#0b161e",
+  [-0.4]: "#143248", // this defines trench color, as it has negative elevation (but still pretty close to 0)
   [BASE_OCEAN_ELEVATION]: "#3696d8",
   0.49: "#b5ebfe",
   0.50: "#A7DFD2",

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -45,7 +45,7 @@ export const CRUST_THICKNESS_TO_ELEVATION_RATIO = 0.5;
 export const MAX_REGULAR_SEDIMENT_THICKNESS = 0.1 * BASE_OCEANIC_CRUST_THICKNESS;
 // These constants decide how thick and how wide the accretionary wedge will be.
 export const MAX_WEDGE_SEDIMENT_THICKNESS = 6 * MAX_REGULAR_SEDIMENT_THICKNESS;
-export const WEDGE_ACCUMULATION_INTENSITY = 2;
+export const WEDGE_ACCUMULATION_INTENSITY = 1.2;
 
 // When the crust subducts, most of its rock layers are transferred to neighboring fields. 
 // When this value is low, it will be transferred slower than subduction and most of the rock will be lost.

--- a/js/plates-model/subduction.ts
+++ b/js/plates-model/subduction.ts
@@ -19,7 +19,6 @@ const MIN_PROGRESS_TO_DETACH = 0.3;
 const MIN_SPEED_TO_DETACH = 0.0005;
 const MIN_ANGLE_TO_DETACH = Math.PI * 0.55;
 
-// MIN_PROGRESS !== 0 ensures that subducting plate creates a visible trench.
 export const MIN_PROGRESS = 0;
 
 // Set of properties related to subduction. Used by Field instances.

--- a/js/plates-view/planet-view.ts
+++ b/js/plates-view/planet-view.ts
@@ -148,9 +148,9 @@ export default class PlanetView {
   }
 
   addStaticMantle() {
-    // Add "mantle". It won't be visible most of the time (only divergent boundaries).
+    // Add "mantle". It won't be visible most of the time.
     const material = new THREE.MeshPhongMaterial({ color: MANTLE_COLOR });
-    const geometry = new THREE.SphereGeometry(PLATE_RADIUS * 0.985, 64, 64);
+    const geometry = new THREE.SphereGeometry(PLATE_RADIUS * 0.9, 64, 64);
     const mesh = new THREE.Mesh(geometry, material);
     this.scene.add(mesh);
   }


### PR DESCRIPTION
I've ended up with relatively simple implementation.

`subduction.progress` is replaced with more general `bendingProgress` attribute, which is defined for each field. That way plate can bend even before subduction happens. It's done in `propagateBending` method. There are also some tweaks to wedge to cover unwanted break between the wedge and the top plate (it could create an impression that it's the deepest part of the ocean).