### PR TITLE
Update rendering of magma around divergent boundaries

### DIFF
--- a/js/colormaps.ts
+++ b/js/colormaps.ts
@@ -89,12 +89,12 @@ export function hueAndElevationToRgb(hue: number, elevation = 0) {
 }
 
 export const ROCKS_COL: Record<Rock, string> = {
-  [Rock.Granite]: "#4b1e01",
+  [Rock.Granite]: "#fc81c1",
   [Rock.Basalt]: "#06151b",
   [Rock.Gabbro]: "#5d5243",
   [Rock.Andesite]: "#893567",
   [Rock.Diorite]: "#5a2545",
-  [Rock.Rhyolite]: "#373633",
+  [Rock.Rhyolite]: "#fdbfdf",
   [Rock.OceanicSediment]: "#a87d05",
   [Rock.ContinentalSediment]: "#b26314",
 };

--- a/js/config.ts
+++ b/js/config.ts
@@ -102,7 +102,6 @@ const DEFAULT_CONFIG = {
   renderPlateLabels: true,
   crossSection3d: true,
   flatShading: false,
-  newRockColorOverlay: "gray",
   // Smaller number (16-64) will make topo scale less smooth and look closer to a real topographic map.
   // Large values (128-256) will smooth out the rendering.
   topoColormapShades: 256,

--- a/js/config.ts
+++ b/js/config.ts
@@ -102,6 +102,7 @@ const DEFAULT_CONFIG = {
   renderPlateLabels: true,
   crossSection3d: true,
   flatShading: false,
+  newRockColorOverlay: "gray",
   // Smaller number (16-64) will make topo scale less smooth and look closer to a real topographic map.
   // Large values (128-256) will smooth out the rendering.
   topoColormapShades: 256,

--- a/js/config.ts
+++ b/js/config.ts
@@ -77,7 +77,7 @@ const DEFAULT_CONFIG = {
   // Default range of elevation is [0, 1] (the deepest trench, the highest mountain). However subducting plates go
   // deeper and this variable sets the proportion between this depth and normal topography.
   subductionMinElevation: -3.3,
-  oceanicRidgeElevation: 0.47,
+  oceanicRidgeElevation: 0.1,
   oceanicRidgeWidth: 650, // km
   // Width of the area around continent which acts as it's bumper / buffer. When this area is about to subduct,
   // drag forces will be applied to stop relative motion of the plates and prevent subduction of the neighboring continent.

--- a/js/cross-section-colors.ts
+++ b/js/cross-section-colors.ts
@@ -1,7 +1,7 @@
 export const OCEANIC_CRUST_COL = "#27374f";
 export const CONTINENTAL_CRUST_COL = "#643d0c";
 export const LITHOSPHERE_COL = "#666";
-export const MANTLE_COL = "#033f19";
+export const MANTLE_COL = "#4b1e01";
 export const SKY_COL_1 = "#4375be";
 export const SKY_COL_2 = "#c0daeb";
 export const OCEAN_COL = "#1da2d8";

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -73,6 +73,10 @@ export const BASE_CONTINENTAL_CRUST_THICKNESS = elevationToCrustThickness(BASE_C
 // until it reaches this value. Then the oceanic crust will be formed instead.
 export const MIN_CONTINENTAL_CRUST_THICKNESS = BASE_OCEANIC_CRUST_THICKNESS * 1.1;
 
+export const LITHOSPHERE_THICKNESS = 0.7;
+
+export const NEW_OCEANIC_CRUST_THICKNESS_RATIO = 0.6;
+
 export const TRENCH_MAX_DEPTH = 0.085;
 export const TRENCH_SLOPE = 0.5;
 
@@ -135,7 +139,7 @@ export default class Field extends FieldBase {
     this.marked = marked;
   
     const baseCrustThickness = crustThickness !== undefined ? 
-      crustThickness : (type === "ocean" ? BASE_OCEANIC_CRUST_THICKNESS * this.normalizedAge : BASE_CONTINENTAL_CRUST_THICKNESS);
+      crustThickness : (type === "ocean" ? BASE_OCEANIC_CRUST_THICKNESS * (NEW_OCEANIC_CRUST_THICKNESS_RATIO + (1 - NEW_OCEANIC_CRUST_THICKNESS_RATIO) * this.normalizedAge) : BASE_CONTINENTAL_CRUST_THICKNESS);
     this.crust = new Crust(type, baseCrustThickness, this.normalizedAge === 1);
   }
 
@@ -290,10 +294,7 @@ export default class Field extends FieldBase {
   }
 
   get lithosphereThickness() {
-    if (this.isOcean) {
-      return 0.7 * this.normalizedAge;
-    }
-    return 0.7;
+    return LITHOSPHERE_THICKNESS;
   }
 
   setDefaultProps(type: FieldType) {
@@ -445,7 +446,7 @@ export default class Field extends FieldBase {
     
     if (this.type === "ocean" && this.normalizedAge < 1) {
       // Basalt and gabbro are added only at the beginning of oceanic crust lifecycle.
-      this.crust.addBasaltAndGabbro((BASE_OCEANIC_CRUST_THICKNESS - MAX_REGULAR_SEDIMENT_THICKNESS) * ageDiff / MAX_AGE);
+      this.crust.addBasaltAndGabbro((1 - NEW_OCEANIC_CRUST_THICKNESS_RATIO) * (BASE_OCEANIC_CRUST_THICKNESS - MAX_REGULAR_SEDIMENT_THICKNESS) * ageDiff / MAX_AGE);
     }
     if (this.volcanicAct?.active) {
       this.crust.addVolcanicRocks(this.volcanicAct.intensity * timestep * VOLCANIC_ACTIVITY_STRENGTH);

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -294,7 +294,7 @@ export default class Field extends FieldBase {
   }
 
   get lithosphereThickness() {
-    return LITHOSPHERE_THICKNESS;
+    return LITHOSPHERE_THICKNESS * Math.sqrt(this.normalizedAge);
   }
 
   setDefaultProps(type: FieldType) {

--- a/js/plates-model/model-output.ts
+++ b/js/plates-model/model-output.ts
@@ -57,14 +57,14 @@ type UpdateCategory = "fields" | "crossSection";
 
 // Sending data back to main thread is expensive. Don't send data too often and also try to distribute data
 // among different messages, not to create one which would be very big (that's why offset is used).
-const UPDATE_INTERVAL: Record<UpdateCategory, number> = {
+export const UPDATE_INTERVAL: Record<UpdateCategory, number> = {
   fields: 10,
-  crossSection: 10
+  crossSection: 5
 };
 
-const UPDATE_OFFSET: Record<UpdateCategory, number> = {
+export const UPDATE_OFFSET: Record<UpdateCategory, number> = {
   fields: 0,
-  crossSection: 5
+  crossSection: 3
 };
 
 function shouldUpdate(name: UpdateCategory, stepIdx: number) {

--- a/js/plates-view/cross-section-3d.ts
+++ b/js/plates-view/cross-section-3d.ts
@@ -229,7 +229,7 @@ export default class CrossSection3D {
     this.controls.rotateSpeed = 0.5;
     this.controls.zoomSpeed = 0.5;
     this.controls.minZoom = 0.8;
-    this.controls.maxZoom = 1.2;
+    this.controls.maxZoom = 4;
     this.controls.minPolarAngle = CAMERA_VERT_ANGLE;
     this.controls.maxPolarAngle = CAMERA_VERT_ANGLE;
 

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -8,6 +8,7 @@ import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, 
 import { IChunkArray, IEarthquake, IFieldData } from "../plates-model/get-cross-section";
 import { SEA_LEVEL } from "../plates-model/field";
 import { rockColor } from "../colormaps";
+import { UPDATE_INTERVAL } from "../plates-model/model-output";
 
 export interface ICrossSectionOptions {
   rockLayers: boolean;
@@ -69,7 +70,9 @@ function drawMagma(ctx: CanvasRenderingContext2D, top: THREE.Vector2) {
 // Very simple approach to "animation". Divergent boundary magma will be clipped. Animation progress is defined
 // by number of draw calls. It only a small visual hint and it doesn't have to correlated with the real model.
 let magmaAnimationFrame = 0;
-const animationStepsCount = 120;
+// The more often cross-section is updated, the more steps the full animation cycle has to have.
+const animationStepsCount = 600 / UPDATE_INTERVAL.crossSection;
+
 function drawDivergentBoundaryMagma(ctx: CanvasRenderingContext2D, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2) {
   const tmp1 =  p1.clone().lerp(p2, 0.3);
   const tmp2 = tmp1.clone();

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -65,27 +65,53 @@ function drawMagma(ctx: CanvasRenderingContext2D, top: THREE.Vector2) {
   ctx.drawImage(magmaImg, scaleX(top.x) - magmaImg.width / 2, scaleY(top.y));
 }
 
+
+// Very simple approach to "animation". Divergent boundary magma will be clipped. Animation progress is defined
+// by number of draw calls. It only a small visual hint and it doesn't have to correlated with the real model.
+let magmaAnimationFrame = 0;
+const animationStepsCount = 120;
 function drawDivergentBoundaryMagma(ctx: CanvasRenderingContext2D, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2) {
   const tmp1 =  p1.clone().lerp(p2, 0.3);
   const tmp2 = tmp1.clone();
   tmp2.y = p4.y + (p1.y - p4.y) * 0.7;
   const tmp3 = p2.clone().lerp(p3, 0.3);
+
+  const p1XScaled = scaleX(p1.x);
+  const p1YScaled = scaleY(p1.y);
+  const p3XScaled = scaleX(p3.x);
+  const p3YScaled = scaleY(p3.y);
   
-  const gradient = ctx.createLinearGradient(scaleX(p1.x), scaleY(p1.y), scaleX(p4.x), scaleY(p4.y));
+  const clipRectHeight = Math.abs(p3YScaled - p1YScaled);
+  const clipRectWidth = Math.abs(p3XScaled - p1XScaled);
+  let animationStep = magmaAnimationFrame % animationStepsCount;
+  if (animationStep > 0.5 * animationStepsCount) {
+    animationStep = animationStepsCount - animationStep;
+  }
+  const animationProgress = Math.pow(animationStep / (animationStepsCount * 0.5), 0.5);
+  
+  ctx.save();
+
+  ctx.beginPath();
+  ctx.rect(Math.min(p1XScaled, p3XScaled), p1YScaled + (1 - animationProgress) * clipRectHeight, clipRectWidth, animationProgress * clipRectHeight);
+  ctx.clip();
+
+  const gradient = ctx.createLinearGradient(0, p1YScaled, 0, p3YScaled);
   gradient.addColorStop(0, "#fc3c11");
   gradient.addColorStop(1, "#6b0009");
-
   ctx.fillStyle = gradient;
   ctx.beginPath();
-  ctx.moveTo(scaleX(p1.x), scaleY(p1.y));
+  ctx.moveTo(p1XScaled, p1YScaled);
   ctx.lineTo(scaleX(tmp1.x), scaleY(tmp1.y));
   ctx.lineTo(scaleX(tmp2.x), scaleY(tmp2.y));
   ctx.lineTo(scaleX(tmp3.x), scaleY(tmp3.y));
-  ctx.lineTo(scaleX(p3.x), scaleY(p3.y));
+  ctx.lineTo(p3XScaled, p3YScaled);
   ctx.lineTo(scaleX(p4.x), scaleY(p4.y));
   ctx.closePath();
   ctx.fill();
-  
+
+  ctx.restore();
+
+  magmaAnimationFrame += 1;
 }
 
 function drawMarker(ctx: CanvasRenderingContext2D, crustPos: THREE.Vector2) {
@@ -138,6 +164,11 @@ function renderCrust(ctx: CanvasRenderingContext2D, field: IFieldData, p1: THREE
     });
   } else {
     fillPath(ctx, field.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, p1, p2, p3, p4);
+  }
+  const normalizedAge = field?.normalizedAge || 1;
+  if (normalizedAge < 1) {
+    const color = config.newRockColorOverlay === "red" ? "255, 0, 0" : "255, 255, 255";
+    fillPath(ctx, `rgba(${color}, ${1 - Math.pow(normalizedAge, 0.2)})`, p1, p2, p3, p4);
   }
 }
 

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -65,6 +65,29 @@ function drawMagma(ctx: CanvasRenderingContext2D, top: THREE.Vector2) {
   ctx.drawImage(magmaImg, scaleX(top.x) - magmaImg.width / 2, scaleY(top.y));
 }
 
+function drawDivergentBoundaryMagma(ctx: CanvasRenderingContext2D, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2) {
+  const tmp1 =  p1.clone().lerp(p2, 0.3);
+  const tmp2 = tmp1.clone();
+  tmp2.y = p4.y + (p1.y - p4.y) * 0.7;
+  const tmp3 = p2.clone().lerp(p3, 0.3);
+  
+  const gradient = ctx.createLinearGradient(scaleX(p1.x), scaleY(p1.y), scaleX(p4.x), scaleY(p4.y));
+  gradient.addColorStop(0, "#fc3c11");
+  gradient.addColorStop(1, "#6b0009");
+
+  ctx.fillStyle = gradient;
+  ctx.beginPath();
+  ctx.moveTo(scaleX(p1.x), scaleY(p1.y));
+  ctx.lineTo(scaleX(tmp1.x), scaleY(tmp1.y));
+  ctx.lineTo(scaleX(tmp2.x), scaleY(tmp2.y));
+  ctx.lineTo(scaleX(tmp3.x), scaleY(tmp3.y));
+  ctx.lineTo(scaleX(p3.x), scaleY(p3.y));
+  ctx.lineTo(scaleX(p4.x), scaleY(p4.y));
+  ctx.closePath();
+  ctx.fill();
+  
+}
+
 function drawMarker(ctx: CanvasRenderingContext2D, crustPos: THREE.Vector2) {
   ctx.fillStyle = "#af3627";
   const markerWidth = 4;
@@ -158,6 +181,12 @@ function renderChunk(ctx: CanvasRenderingContext2D, chunkData: IChunkArray, opti
     }
     if (f1.risingMagma) {
       drawMagma(ctx, t1);
+    }
+    if (f1.divergentBoundaryMagma) {
+      drawDivergentBoundaryMagma(ctx, t1, tMid, cMid, c1);
+    }
+    if (f2.divergentBoundaryMagma) {
+      drawDivergentBoundaryMagma(ctx, t2, tMid, cMid, c2);
     }
   }
 }

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -167,8 +167,7 @@ function renderCrust(ctx: CanvasRenderingContext2D, field: IFieldData, p1: THREE
   }
   const normalizedAge = field?.normalizedAge || 1;
   if (normalizedAge < 1) {
-    const color = config.newRockColorOverlay === "red" ? "255, 0, 0" : "255, 255, 255";
-    fillPath(ctx, `rgba(${color}, ${1 - Math.pow(normalizedAge, 0.2)})`, p1, p2, p3, p4);
+    fillPath(ctx, `rgba(255, 255, 255, ${1 - Math.pow(normalizedAge, 0.2)})`, p1, p2, p3, p4);
   }
 }
 


### PR DESCRIPTION
Old cross-section:
<img width="887" alt="Screenshot 2021-05-20 at 15 40 10" src="https://user-images.githubusercontent.com/767857/118988672-b0057700-b981-11eb-98bf-bb9f7d88c78a.png">
⬇️ ⬇️ ⬇️
New cross-section:
<img width="920" alt="Screenshot 2021-05-20 at 15 39 20" src="https://user-images.githubusercontent.com/767857/118988680-b1cf3a80-b981-11eb-8bcc-eb67e96bbd67.png">

The magma animation is done in a very simple way, but it works. An obvious use case where animation would be twice as fast is if the user was looking at two divergent boundaries at the same time. But it almost never happens in practice, as the cross-section line is too short.

Also, there are some small tweaks of rock colors requested by Stephanie.
