### PR TITLE
Update rock layers rendering, mountain roots forming + small refactoring

### DIFF
--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -2,15 +2,17 @@ import { BASE_OCEANIC_CRUST_THICKNESS, FieldType } from "./field";
 
 // Do not use automatic enum values, as if we ever remove one rock type, other values shouldn't change.
 // It would break deserialization of the previously saved models.
+// Numeric values are important! They should define correct order of layers. For example, sediments are always
+// top-most layer, so they should have value 0. The deepest rock layers like gabbro should have the biggest value.
 export enum Rock {
-  OceanicSediment = 0,
-  ContinentalSediment = 1,
-  Granite = 2,
-  Basalt = 3,
-  Gabbro = 4,
-  Rhyolite = 5,
-  Andesite = 6,
-  Diorite = 7,
+  ContinentalSediment = 0,
+  OceanicSediment = 1,
+  Rhyolite = 3,
+  Andesite = 4,
+  Diorite = 5,
+  Granite = 6,
+  Basalt = 7,
+  Gabbro = 8,
 }
 
 // Labels used in UI.

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -203,11 +203,17 @@ export default class Crust {
   }
 
   addVolcanicRocks(totalAmount: number) {
+    const halfAmount = 0.5 * totalAmount;
     if (this.hasContinentalRocks) {
-      this.increaseLayerThickness(Rock.Rhyolite, totalAmount);
+      this.increaseLayerThickness(Rock.Rhyolite, halfAmount);
+      // Add mountain roots too. Granite is the lowest layer of continental crust.
+      this.increaseLayerThickness(Rock.Granite, halfAmount);
     } else if (this.hasOceanicRocks) {
-      this.increaseLayerThickness(Rock.Diorite, totalAmount * 0.7);
-      this.increaseLayerThickness(Rock.Andesite, totalAmount * 0.3);
+      this.increaseLayerThickness(Rock.Diorite, halfAmount * 0.7);
+      this.increaseLayerThickness(Rock.Andesite, halfAmount * 0.3);
+      // Add mountain roots too. Gabbro and Basalt are the lowest layers of oceanic crust.
+      this.increaseLayerThickness(Rock.Gabbro, halfAmount * 0.7);
+      this.increaseLayerThickness(Rock.Basalt, halfAmount * 0.3);
     }
   }
 

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -191,16 +191,12 @@ export default class Field extends FieldBase {
     return Field.deserialize(props, newPlate || this.plate);
   }
 
-  get type() {
-    return this.crust.isOceanicCrust() ? "ocean" :  "continent";
-  }
-
   get isOcean() {
-    return this.crust.isOceanicCrust();
+    return this.crust.canSubduct();
   }
 
   get isContinent() {
-    return !this.crust.isOceanicCrust();
+    return !this.crust.canSubduct();
   }
 
   get mass() {
@@ -218,11 +214,11 @@ export default class Field extends FieldBase {
   }
 
   get oceanicCrust() {
-    return this.isOcean;
+    return this.crust.hasOceanicRocks;
   }
 
   get continentalCrust() {
-    return this.isContinent;
+    return this.crust.hasContinentalRocks;
   }
 
   get risingMagma() {
@@ -265,7 +261,7 @@ export default class Field extends FieldBase {
   //  - [config.subductionMinElevation, 0] -> ocean trench and subduction range
   get elevation() {
     let modifier = 0;
-    if (this.isOcean) {
+    if (this.crust.hasOceanicRocks) {
       if (this.bendingProgress) {
         modifier += config.subductionMinElevation * this.bendingProgress;
       } 
@@ -459,7 +455,7 @@ export default class Field extends FieldBase {
     this.age += ageDiff;
 
     
-    if (this.type === "ocean" && this.normalizedAge < 1) {
+    if (this.crust.hasOceanicRocks && this.normalizedAge < 1) {
       // Basalt and gabbro are added only at the beginning of oceanic crust lifecycle.
       this.crust.addBasaltAndGabbro((1 - NEW_OCEANIC_CRUST_THICKNESS_RATIO) * (BASE_OCEANIC_CRUST_THICKNESS - MAX_REGULAR_SEDIMENT_THICKNESS) * ageDiff / MAX_AGE);
     }
@@ -480,9 +476,7 @@ export default class Field extends FieldBase {
       this.crust.spreadOceanicSediment(timestep, neighboringCrust);
     }
     this.crust.erode(timestep, neighboringCrust, this.maxSlopeFactor);
-    
-    this.crust.sortLayers();
-  }
+  }    
 
 
   propagateBending() {

--- a/js/plates-model/volcanic-activity.ts
+++ b/js/plates-model/volcanic-activity.ts
@@ -37,7 +37,7 @@ const ERUPTION_COOLDOWN = 5;
 
 const getFinalRockType = (crust: Crust, finalDistProportion: number) => {
   // based on: https://www.pivotaltracker.com/story/show/178271502
-  const isOceanicCrust = crust.wasInitiallyOceanicCrust();
+  const isOceanicCrust = crust.hasOceanicRocks;
   if (isOceanicCrust) {
     if (finalDistProportion < 0.75) {
       return Rock.Gabbro;

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -9,7 +9,7 @@ import { IChunkArray, IEarthquake, IFieldData, IMagmaBlobData, IRockLayerData } 
 import { SEA_LEVEL } from "../plates-model/field";
 import { rockColor, ROCKS_COL } from "../colormaps";
 import { UPDATE_INTERVAL } from "../plates-model/model-output";
-import { Rock } from "../plates-model/crust";
+import { Rock, RockOrderIndex } from "../plates-model/crust";
 
 export interface ICrossSectionOptions {
   rockLayers: boolean;
@@ -249,10 +249,6 @@ export function shouldMergeRockLayers(layers1: IRockLayerData[], layers2: IRockL
 }
 
 export function mergeRockLayers(layers1: IRockLayerData[], layers2: IRockLayerData[]) {
-  // Rock is enum that uses numeric values.
-  const ascFn = (a: IRockLayerData, b: IRockLayerData) => a.rock - b.rock;
-  layers1.sort(ascFn);
-  layers2.sort(ascFn);
   const result: IMergedRockLayerData[] = [];
   let i = 0; 
   let j = 0;
@@ -260,13 +256,13 @@ export function mergeRockLayers(layers1: IRockLayerData[], layers2: IRockLayerDa
     const a = layers1[i];
     const b = layers2[j];
 
-    if (a !== undefined && (b === undefined || a.rock < b.rock)) {
+    if (a !== undefined && (b === undefined || RockOrderIndex[a.rock] < RockOrderIndex[b.rock])) {
       result.push({ rock: a.rock, relativeThickness1: a.relativeThickness, relativeThickness2: 0 });
       i += 1;
-    } else if (b !== undefined && (a === undefined || b.rock < a.rock)) {
+    } else if (b !== undefined && (a === undefined || RockOrderIndex[b.rock] < RockOrderIndex[a.rock])) {
       result.push({ rock: b.rock, relativeThickness1: 0, relativeThickness2: b.relativeThickness });
       j += 1;
-    } else if (a.rock === b.rock) {
+    } else if (RockOrderIndex[a.rock] === RockOrderIndex[b.rock]) {
       result.push({ rock: a.rock, relativeThickness1: a.relativeThickness, relativeThickness2: b.relativeThickness });
       i += 1;
       j += 1;

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -5,13 +5,20 @@ import { depthToColor, drawEarthquakeShape } from "./earthquake-helpers";
 import { drawVolcanicEruptionShape } from "./volcanic-eruption-helpers";
 import { OCEANIC_CRUST_COL, CONTINENTAL_CRUST_COL, LITHOSPHERE_COL, MANTLE_COL, OCEAN_COL, SKY_COL_1, SKY_COL_2, MAGMA_LIGHT_RED, MAGMA_DARK_RED }
   from "../cross-section-colors";
-import { IChunkArray, IEarthquake, IFieldData, IMagmaBlobData } from "../plates-model/get-cross-section";
+import { IChunkArray, IEarthquake, IFieldData, IMagmaBlobData, IRockLayerData } from "../plates-model/get-cross-section";
 import { SEA_LEVEL } from "../plates-model/field";
 import { rockColor, ROCKS_COL } from "../colormaps";
 import { UPDATE_INTERVAL } from "../plates-model/model-output";
+import { Rock } from "../plates-model/crust";
 
 export interface ICrossSectionOptions {
   rockLayers: boolean;
+}
+
+interface IMergedRockLayerData {
+  rock: Rock;
+  relativeThickness1: number;
+  relativeThickness2: number;
 }
 
 const HEIGHT = 240; // px
@@ -213,24 +220,73 @@ function debugInfo(ctx: CanvasRenderingContext2D, p1: THREE.Vector2, p2: THREE.V
   });
 }
 
-function renderCrust(ctx: CanvasRenderingContext2D, field: IFieldData, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2, options: ICrossSectionOptions) {
-  if (options.rockLayers) {
-    let currentThickness = 0;
-    field.rockLayers.forEach(rl => {
-      const p1tmp = p1.clone().lerp(p4, currentThickness);
-      const p2tmp = p2.clone().lerp(p3, currentThickness);
-      const p3tmp = p2.clone().lerp(p3, currentThickness + rl.relativeThickness);
-      const p4tmp = p1.clone().lerp(p4, currentThickness + rl.relativeThickness);
-      fillPath(ctx, rockColor(rl.rock), p1tmp, p2tmp, p3tmp, p4tmp);
-      currentThickness += rl.relativeThickness;
-    });
-  } else {
-    fillPath(ctx, field.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, p1, p2, p3, p4);
-  }
+function renderSeparateRockLayers(ctx: CanvasRenderingContext2D, field: IFieldData, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2) {
+  let currentThickness = 0;
+  field.rockLayers.forEach(rl => {
+    const p1tmp = p1.clone().lerp(p4, currentThickness);
+    const p2tmp = p2.clone().lerp(p3, currentThickness);
+    const p3tmp = p2.clone().lerp(p3, currentThickness + rl.relativeThickness);
+    const p4tmp = p1.clone().lerp(p4, currentThickness + rl.relativeThickness);
+    fillPath(ctx, rockColor(rl.rock), p1tmp, p2tmp, p3tmp, p4tmp);
+    currentThickness += rl.relativeThickness;
+  });
+}
+
+function renderBasicCrust(ctx: CanvasRenderingContext2D, field: IFieldData, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2) {
+  fillPath(ctx, field.oceanicCrust ? OCEANIC_CRUST_COL : CONTINENTAL_CRUST_COL, p1, p2, p3, p4);
+}
+
+function renderFreshCrustOverlay(ctx: CanvasRenderingContext2D, field: IFieldData, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2) {
   const normalizedAge = field?.normalizedAge || 1;
   if (normalizedAge < 1) {
     fillPath(ctx, `rgba(255, 255, 255, ${1 - Math.pow(normalizedAge, 0.2)})`, p1, p2, p3, p4);
   }
+}
+
+export function shouldMergeRockLayers(layers1: IRockLayerData[], layers2: IRockLayerData[]) {
+  // Both layer arrays have the same bottom layer (e.g. granite or gabbro).
+  return layers1[layers1.length - 1].rock === layers2[layers2.length - 1].rock;
+}
+
+export function mergeRockLayers(layers1: IRockLayerData[], layers2: IRockLayerData[]) {
+  // Rock is enum that uses numeric values.
+  const ascFn = (a: IRockLayerData, b: IRockLayerData) => a.rock - b.rock;
+  layers1.sort(ascFn);
+  layers2.sort(ascFn);
+  const result: IMergedRockLayerData[] = [];
+  let i = 0; 
+  let j = 0;
+  while (i < layers1.length || j < layers2.length) {
+    const a = layers1[i];
+    const b = layers2[j];
+
+    if (a !== undefined && (b === undefined || a.rock < b.rock)) {
+      result.push({ rock: a.rock, relativeThickness1: a.relativeThickness, relativeThickness2: 0 });
+      i += 1;
+    } else if (b !== undefined && (a === undefined || b.rock < a.rock)) {
+      result.push({ rock: b.rock, relativeThickness1: 0, relativeThickness2: b.relativeThickness });
+      j += 1;
+    } else if (a.rock === b.rock) {
+      result.push({ rock: a.rock, relativeThickness1: a.relativeThickness, relativeThickness2: b.relativeThickness });
+      i += 1;
+      j += 1;
+    }
+  }
+  return result;
+}
+
+function renderMergedRockLayers(ctx: CanvasRenderingContext2D, mergedRockLayers: IMergedRockLayerData[], p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2) {
+  let currentThickness1 = 0;
+  let currentThickness2 = 0;
+  mergedRockLayers.forEach(rl => {
+    const p1tmp = p1.clone().lerp(p4, currentThickness1);
+    const p2tmp = p2.clone().lerp(p3, currentThickness2);
+    const p3tmp = p2.clone().lerp(p3, currentThickness2 + rl.relativeThickness2);
+    const p4tmp = p1.clone().lerp(p4, currentThickness1 + rl.relativeThickness1);
+    fillPath(ctx, rockColor(rl.rock), p1tmp, p2tmp, p3tmp, p4tmp);
+    currentThickness1 += rl.relativeThickness1;
+    currentThickness2 += rl.relativeThickness2;
+  });
 }
 
 function renderChunk(ctx: CanvasRenderingContext2D, chunkData: IChunkArray, options: ICrossSectionOptions) {
@@ -261,8 +317,22 @@ function renderChunk(ctx: CanvasRenderingContext2D, chunkData: IChunkArray, opti
       drawMarker(ctx, t1);
     }
     // Fill crust
-    renderCrust(ctx, f1, t1, tMid, cMid, c1, options);
-    renderCrust(ctx, f2, tMid, t2, c2, cMid, options);
+    if (!options.rockLayers) {
+      renderBasicCrust(ctx, f1, t1, tMid, cMid, c1);
+      renderBasicCrust(ctx, f2, tMid, t2, c2, cMid);
+    } else {
+      // Rock layers should be merged when we're rendering the same crust type - oceanic or continental.
+      // When crust types are different, just make a sharp boundary.
+      if (shouldMergeRockLayers(f1.rockLayers, f2.rockLayers)) {
+        renderMergedRockLayers(ctx, mergeRockLayers(f1.rockLayers, f2.rockLayers), t1, t2, c2, c1);
+      } else {
+        renderSeparateRockLayers(ctx, f1, t1, tMid, cMid, c1);
+        renderSeparateRockLayers(ctx, f2, tMid, t2, c2, cMid);
+      }
+    }
+    // New crust around divergent boundary is highlighted for a while.
+    renderFreshCrustOverlay(ctx, f1, t1, tMid, cMid, c1);
+    renderFreshCrustOverlay(ctx, f2, tMid, t2, c2, cMid);
     // Fill lithosphere
     fillPath(ctx, LITHOSPHERE_COL, c1, c2, l2, l1);
     // Fill mantle

--- a/test/plates-model/crust.test.ts
+++ b/test/plates-model/crust.test.ts
@@ -62,4 +62,69 @@ describe("Crust model", () => {
       { rock: Rock.Gabbro, thickness: 1.5 }
     ]);
   });
+
+  describe("addLayer", () => {
+    it("adds a new layer and keeps all the layers in correct order", () => {
+      const crust = new Crust();
+      crust.addLayer({ rock: Rock.Basalt, thickness: 0.1 } );
+      expect(crust.rockLayers).toEqual([
+        { rock: Rock.Basalt, thickness: 0.1 }
+      ]);
+      crust.addLayer({ rock: Rock.OceanicSediment, thickness: 0.1 });
+      expect(crust.rockLayers).toEqual([
+        { rock: Rock.OceanicSediment, thickness: 0.1 },
+        { rock: Rock.Basalt, thickness: 0.1 }
+      ]);
+      crust.addLayer({ rock: Rock.Gabbro, thickness: 0.1 });
+      expect(crust.rockLayers).toEqual([
+        { rock: Rock.OceanicSediment, thickness: 0.1 },
+        { rock: Rock.Basalt, thickness: 0.1 },
+        { rock: Rock.Gabbro, thickness: 0.1 }
+      ]);
+      crust.addLayer({ rock: Rock.Diorite, thickness: 0.1 });
+      expect(crust.rockLayers).toEqual([
+        { rock: Rock.OceanicSediment, thickness: 0.1 },
+        { rock: Rock.Diorite, thickness: 0.1 },
+        { rock: Rock.Basalt, thickness: 0.1 },
+        { rock: Rock.Gabbro, thickness: 0.1 }
+      ]);
+    });
+  });
+
+  describe("removeLayer", () => {
+    it("removes layer", () => {
+      const crust = new Crust();
+      crust.addLayer({ rock: Rock.Basalt, thickness: 0.1 });
+      crust.addLayer({ rock: Rock.Gabbro, thickness: 0.1 });
+      crust.addLayer({ rock: Rock.OceanicSediment, thickness: 0.1 });
+      crust.addLayer({ rock: Rock.Diorite, thickness: 0.1 });
+      expect(crust.rockLayers).toEqual([
+        { rock: Rock.OceanicSediment, thickness: 0.1 },
+        { rock: Rock.Diorite, thickness: 0.1 },
+        { rock: Rock.Basalt, thickness: 0.1 },
+        { rock: Rock.Gabbro, thickness: 0.1 }
+      ]);
+      
+      crust.removeLayer(Rock.Basalt);
+      expect(crust.rockLayers).toEqual([
+        { rock: Rock.OceanicSediment, thickness: 0.1 },
+        { rock: Rock.Diorite, thickness: 0.1 },
+        { rock: Rock.Gabbro, thickness: 0.1 }
+      ]);
+
+      crust.removeLayer(Rock.OceanicSediment);
+      expect(crust.rockLayers).toEqual([
+        { rock: Rock.Diorite, thickness: 0.1 },
+        { rock: Rock.Gabbro, thickness: 0.1 }
+      ]);
+
+      crust.removeLayer(Rock.Gabbro);
+      expect(crust.rockLayers).toEqual([
+        { rock: Rock.Diorite, thickness: 0.1 },
+      ]);
+
+      crust.removeLayer(Rock.Diorite);
+      expect(crust.rockLayers).toEqual([]);
+    });
+  });
 });

--- a/test/plates-view/render-cross-section.test.ts
+++ b/test/plates-view/render-cross-section.test.ts
@@ -1,0 +1,46 @@
+import { Rock } from "../../js/plates-model/crust";
+import { IRockLayerData } from "../../js/plates-model/get-cross-section";
+import { mergeRockLayers, shouldMergeRockLayers } from "../../js/plates-view/render-cross-section";
+
+describe("render cross-section helpers", () => {
+  describe("shouldMergeRockLayers", () => {
+    it("should return true if bottom layers match", () => {
+      const a: IRockLayerData[] = [{ rock: Rock.Rhyolite, relativeThickness: 0.5 }, { rock: Rock.Granite, relativeThickness: 0.5 }];
+      const b: IRockLayerData[] = [{ rock: Rock.Rhyolite, relativeThickness: 0.5 }, { rock: Rock.Granite, relativeThickness: 0.5 }];
+      const c: IRockLayerData[] = [{ rock: Rock.Rhyolite, relativeThickness: 0.5 }, { rock: Rock.Gabbro, relativeThickness: 0.5 }];
+      expect(shouldMergeRockLayers(a, b)).toEqual(true);
+      expect(shouldMergeRockLayers(a, c)).toEqual(false);
+    });
+  });
+
+  describe("mergeRockLayers", () => {
+    it("should merge two arrays of rock layers keeping the expected order", () => {
+      const a: IRockLayerData[] = [{ rock: Rock.OceanicSediment, relativeThickness: 0.5 }, { rock: Rock.Granite, relativeThickness: 0.5 }];
+      const b: IRockLayerData[] = [{ rock: Rock.Rhyolite, relativeThickness: 0.5 }, { rock: Rock.Granite, relativeThickness: 0.5 }];
+      expect(mergeRockLayers(a, b)).toEqual([
+        { rock: Rock.OceanicSediment, relativeThickness1: 0.5, relativeThickness2: 0 },
+        { rock: Rock.Rhyolite, relativeThickness1: 0, relativeThickness2: 0.5 },
+        { rock: Rock.Granite, relativeThickness1: 0.5, relativeThickness2: 0.5 }
+      ]);
+
+      const c: IRockLayerData[] = [
+        { rock: Rock.OceanicSediment, relativeThickness: 0.1 }, 
+        { rock: Rock.Andesite, relativeThickness: 0.2 },
+        { rock: Rock.Basalt, relativeThickness: 0.2 },
+        { rock: Rock.Gabbro, relativeThickness: 0.2 },
+      ];
+      const d: IRockLayerData[] = [
+        { rock: Rock.Diorite, relativeThickness: 0.2 },
+        { rock: Rock.Basalt, relativeThickness: 0.4 },
+        { rock: Rock.Gabbro, relativeThickness: 0.4 },
+      ];
+      expect(mergeRockLayers(c, d)).toEqual([
+        { rock: Rock.OceanicSediment, relativeThickness1: 0.1, relativeThickness2: 0 },
+        { rock: Rock.Andesite, relativeThickness1: 0.2, relativeThickness2: 0 },
+        { rock: Rock.Diorite, relativeThickness1: 0, relativeThickness2: 0.2 },
+        { rock: Rock.Basalt, relativeThickness1: 0.2, relativeThickness2: 0.4 },
+        { rock: Rock.Gabbro, relativeThickness1: 0.2, relativeThickness2: 0.4 },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This PR changes the way how rock layers are rendered. You can compare the screenshots below.

The main difference is that rock layers shouldn't have jagged edges anymore. CS rendering will interpolate between various layers. However, this requires all the rock layers to have a defined, specific order. So, sediments will always be the topmost layer, then rhyolite, etc, down to granite or gabbro. Only then I can connect rock layers between neighboring fields. Otherwise, if layers are totally mixed, we'd get crossing lines. But this constraint seems to be fine, there's no use case where layers should have a different order. 

Another changes in this PR:
- Mountain roots are formed in a different way to avoid the impression that volcanic rocks are "sinking" and getting lower than the initial crust elevation. Stephanie and Amy ware asking for that.
- Sediments are removed when volcanic rocks are added. This was requested by Chris.
- Small performance optimizations

<img width="889" alt="old 1" src="https://user-images.githubusercontent.com/767857/121911975-7893ab80-cd30-11eb-9e48-819a14fbcd01.png">
<img width="885" alt="new 1" src="https://user-images.githubusercontent.com/767857/121911995-7d585f80-cd30-11eb-8087-07d3257bfeea.png">
<img width="914" alt="old 2" src="https://user-images.githubusercontent.com/767857/121911983-7a5d6f00-cd30-11eb-8564-33b5e9e1b1d9.png">
<img width="930" alt="new 2" src="https://user-images.githubusercontent.com/767857/121912012-81847d00-cd30-11eb-88e2-cbea0349edaa.png">

