### PR TITLE
Refactor model methods related to plate merge and division, add automated tests of these functionalities

### DIFF
--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -76,6 +76,8 @@ export const ROCK_TRANSFER_INTENSITY = 25;
 export const MIN_EROSION_SLOPE = 20;
 export const EROSION_INTENSITY = 0.02;
 
+export const MAX_CRUST_THICKNESS_BASE = 2;
+
 export const IS_ROCK_TRANSFERABLE_DURING_OROGENY: Record<Rock, boolean> = {
   [Rock.ContinentalSediment]: true,
   [Rock.OceanicSediment]: true,
@@ -102,7 +104,7 @@ export default class Crust {
   // Rock layers, ordered from the top to the bottom (of the crust).
   rockLayers: IRockLayer[] = [];
   metamorphic = 0; // [0, 1] - 0 means that rocks are not metamorphic, 1 that they are fully metamorphic
-  maxCrustThickness = random() * 1 + 2;
+  maxCrustThickness = MAX_CRUST_THICKNESS_BASE + random();
 
   constructor(fieldType?: FieldType, thickness?: number, withSediments = true) {
     if (fieldType) {

--- a/js/plates-model/plate.ts
+++ b/js/plates-model/plate.ts
@@ -282,7 +282,7 @@ export default class Plate extends PlateBase<Field> {
 
   addAdjacentField(id: number) {
     if (!this.adjacentFields.has(id)) {
-      const newField = new Field({ id, plate: this });
+      const newField = new Field({ id, plate: this, adjacent: true });
       if (newField.isAdjacentField()) {
         this.adjacentFields.set(id, newField);
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint \"./js/**/*.{js,jsx,ts,tsx}\" \"./test/**/*.{js,jsx,ts,tsx}\" \"./cypress/**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint --fix \"./js/**/*.{js,jsx,ts,tsx}\" \"./test/**/*.{js,jsx,ts,tsx}\" \"./cypress/**/*.{js,jsx,ts,tsx}\"",
     "test": "jest",
-    "test:watch": "jest --watch --watchPathIgnorePatterns model-serialization.test.js",
+    "test:watch": "jest --watch --watchPathIgnorePatterns model-serialization.test.js plate-division-merge.test.ts",
     "start": "webpack serve",
     "build": "webpack",
     "build-production": "PRODUCTION=true webpack",

--- a/test/model-serialization.test.ts
+++ b/test/model-serialization.test.ts
@@ -2,8 +2,7 @@ import * as THREE from "three";
 import Model from "../js/plates-model/model";
 import config from "../js/config";
 import Plate from "../js/plates-model/plate";
-import Field from "../js/plates-model/field";
-import Subplate from "../js/plates-model/subplate";
+import { compareModels } from "./serialization-test-helpers";
 
 // Increase this paramter so it uses to real-world value (setup-tests.js sets a tiny value for performance reasons).
 config.voronoiSphereFieldsCount = 200000;
@@ -18,88 +17,6 @@ function initFunc(plates: Record<number, Plate>) {
   bluePlate.density = 1;
   purplePlate.density = 2;
   yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(1, 0, 0));
-}
-
-function compareModels(m1: Model, m2: Model) {
-  expect(m1.stepIdx).toEqual(m2.stepIdx);
-  expect(m1.time).toEqual(m2.time);
-  expect(m1.plates.length).toEqual(m2.plates.length);
-  m1.plates.forEach((p1: Plate, i: number) => {
-    const p2 = m2.plates[i];
-    comparePlates(p1, p2);
-  });
-}
-
-function comparePlates(p1: Plate, p2: Plate) {
-  expect(p1.id).toEqual(p2.id);
-  expect(p1.quaternion).toEqual(p2.quaternion);
-  expect(p1.angularVelocity).toEqual(p2.angularVelocity);
-  expect(p1.invMomentOfInertia).toEqual(p2.invMomentOfInertia);
-  expect(p1.density).toEqual(p2.density);
-  expect(p1.hue).toEqual(p2.hue);
-  expect(p1.size).toEqual(p2.size);
-  p1.fields.forEach((f1: Field) => {
-    const f2 = p2.fields.get(f1.id);
-    if (f2) {
-      compareFields(f1, f2);
-    } else {
-      expect("second field").toEqual("doesn't exist");
-    }
-  });
-  expect(p1.adjacentFields.size).toEqual(p2.adjacentFields.size);
-  p1.adjacentFields.forEach((f1: Field) => {
-    const f2 = p2.adjacentFields.get(f1.id);
-    if (f2) {
-      compareFields(f1, f2);  
-    } else {
-      expect("second field").toEqual("doesn't exist");
-    }
-  });
-  compareSubplates(p1.subplate, p2.subplate);
-}
-
-function compareSubplates(p1: Subplate, p2: Subplate) {
-  expect(p1.id).toEqual(p2.id);
-  expect(p1.quaternion).toEqual(p2.quaternion);
-  expect(p1.angularVelocity).toEqual(p2.angularVelocity);
-  expect(p1.size).toEqual(p2.size);
-  p1.fields.forEach((f1: Field) => {
-    const f2 = p2.fields.get(f1.id);
-    if (f2) {
-      compareFields(f1, f2);
-    } else {
-      expect("second field").toEqual("doesn't exist");
-    }
-  });
-}
-
-function compareFields(f1: Field, f2: Field) {
-  expect(f1.elevation).toEqual(f2.elevation);
-  expect(f1.crustThickness).toEqual(f2.crustThickness);
-  expect(f1.absolutePos).toEqual(f2.absolutePos);
-  expect(f1.force).toEqual(f2.force);
-  expect(f1.age).toEqual(f2.age);
-  expect(f1.mass).toEqual(f2.mass);
-  expect(f1.boundary).toEqual(f2.boundary);
-  expect(f1.noCollisionDist).toEqual(f2.noCollisionDist);
-  expect(f1.subduction?.progress).toEqual(f2.subduction?.progress);
-  expect(f1.draggingPlate?.id).toEqual(f2.draggingPlate?.id);
-  compareHelpers(f1.subduction, f2.subduction);
-  compareHelpers(f1.volcanicAct, f2.volcanicAct);
-  compareHelpers(f1.earthquake, f2.earthquake);
-  compareHelpers(f1.volcanicEruption, f2.volcanicEruption);
-  compareHelpers(f1.crust, f2.crust);
-}
-
-function compareHelpers(h1: any, h2: any) {
-  if (h1 === undefined && h2 === undefined) {
-    return;
-  }
-  Object.keys(h1).forEach(propName => {
-    if (propName !== "field") {
-      expect(propName + h1[propName]).toEqual(propName + h2[propName]);
-    }
-  });
 }
 
 let modelImgData: ImageData | null = null;

--- a/test/plate-division-merge.test.ts
+++ b/test/plate-division-merge.test.ts
@@ -44,7 +44,7 @@ test("plate division and merging consistency", () => {
   // Immediately merge two plates again.
   model1.mergePlates(model1.plates[0], model1.plates[1]);
 
-  // Plate division and merge invloves some random() calls. Save the current seedrandom state.
+  // Plate division and merge involves some random() calls. Save the current seedrandom state.
   const randState = seedrandom.getState();
   const testRandNumber = seedrandom.random();
 

--- a/test/plate-division-merge.test.ts
+++ b/test/plate-division-merge.test.ts
@@ -39,6 +39,8 @@ test("plate division and merging consistency", () => {
   const newPlateAdded = model1.dividePlate(model1.plates[0]);
   expect(newPlateAdded).toEqual(true);
   expect(model1.plates.length).toEqual(4);
+  // New plate should be inserted right after the first plate (one that was divided). It's a fourth plate, so
+  // its ID should equal to 3.
   expect(model1.plates[1].id).toEqual(3);
 
   // Immediately merge two plates again.

--- a/test/plate-division-merge.test.ts
+++ b/test/plate-division-merge.test.ts
@@ -1,0 +1,69 @@
+import * as THREE from "three";
+import Model from "../js/plates-model/model";
+import config from "../js/config";
+import Plate from "../js/plates-model/plate";
+import { compareModels } from "./serialization-test-helpers";
+import * as seedrandom from "../js/seedrandom";
+import dividePlate from "../js/plates-model/divide-plate";
+import Field from "../js/plates-model/field";
+
+// Increase this paramter so it uses to real-world value (setup-tests.js sets a tiny value for performance reasons).
+config.voronoiSphereFieldsCount = 200000;
+
+const TIMESTEP = 0.1;
+
+function initFunc(plates: Record<number, Plate>) {
+  const bluePlate = plates[210]; // 210 hue
+  const yellowPlate = plates[70]; // 70 hue
+  const purplePlate = plates[300]; // 300 hue
+  yellowPlate.density = 0;
+  bluePlate.density = 1;
+  purplePlate.density = 2;
+  yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(1, 0, 0));
+}
+
+let modelImgData: ImageData | null = null;
+
+beforeAll(done => {
+  (global as any).getModelImage("testModel.png", (imgData: ImageData) => {
+    modelImgData = imgData;
+    done();
+  });
+});
+
+// eslint-disable-next-line jest/expect-expect
+test("plate division and merging consistency", () => {
+  const model1 = new Model(modelImgData, initFunc);
+  
+  // Divide the first plate.
+  const newPlateAdded = model1.dividePlate(model1.plates[0]);
+  expect(newPlateAdded).toEqual(true);
+  expect(model1.plates.length).toEqual(4);
+  expect(model1.plates[1].id).toEqual(3);
+
+  // Immediately merge two plates again.
+  model1.mergePlates(model1.plates[0], model1.plates[1]);
+
+  // Plate division and merge invloves some random() calls. Save the current seedrandom state.
+  const randState = seedrandom.getState();
+  const testRandNumber = seedrandom.random();
+
+  // 50 steps so we get to some interesting state and make possible divergence / errors visible.
+  const steps = 50;
+  for (let i = 0; i < steps; i++) {
+    model1.step(TIMESTEP);
+  }
+
+  const model2 = new Model(modelImgData, initFunc);
+
+  // Restore seed random state saved above.
+  seedrandom.initializeFromState(randState);
+  // Check if it worked as expected.
+  expect(seedrandom.random()).toEqual(testRandNumber);
+
+  for (let i = 0; i < steps; i++) {
+    model2.step(TIMESTEP);
+  }
+
+  compareModels(model2, model1);
+});

--- a/test/serialization-test-helpers.ts
+++ b/test/serialization-test-helpers.ts
@@ -1,0 +1,89 @@
+import Model from "../js/plates-model/model";
+import Plate from "../js/plates-model/plate";
+import Field from "../js/plates-model/field";
+import Subplate from "../js/plates-model/subplate";
+
+export function compareModels(m1: Model, m2: Model) {
+  expect(m1.stepIdx).toEqual(m2.stepIdx);
+  expect(m1.time).toEqual(m2.time);
+  expect(m1.plates.length).toEqual(m2.plates.length);
+  m1.plates.forEach((p1: Plate, i: number) => {
+    const p2 = m2.plates[i];
+    comparePlates(p1, p2);
+  });
+}
+
+export function comparePlates(p1: Plate, p2: Plate) {
+  expect(p1.id).toEqual(p2.id);
+  expect(p1.quaternion).toEqual(p2.quaternion);
+  expect(p1.angularVelocity).toEqual(p2.angularVelocity);
+  expect(p1.invMomentOfInertia).toEqual(p2.invMomentOfInertia);
+  expect(p1.density).toEqual(p2.density);
+  expect(p1.hue).toEqual(p2.hue);
+  expect(p1.size).toEqual(p2.size);
+  p1.fields.forEach((f1: Field) => {
+    const f2 = p2.fields.get(f1.id);
+    if (f2) {
+      compareFields(f1, f2);
+    } else {
+      expect("second field").toEqual("doesn't exist");
+    }
+  });
+  expect(p1.adjacentFields.size).toEqual(p2.adjacentFields.size);
+  p1.adjacentFields.forEach((f1: Field) => {
+    const f2 = p2.adjacentFields.get(f1.id);
+    if (f2) {
+      compareFields(f1, f2);  
+    } else {
+      expect("second field").toEqual("doesn't exist");
+    }
+  });
+  compareSubplates(p1.subplate, p2.subplate);
+}
+
+export function compareSubplates(p1: Subplate, p2: Subplate) {
+  expect(p1.id).toEqual(p2.id);
+  expect(p1.quaternion).toEqual(p2.quaternion);
+  expect(p1.angularVelocity).toEqual(p2.angularVelocity);
+  expect(p1.size).toEqual(p2.size);
+  p1.fields.forEach((f1: Field) => {
+    const f2 = p2.fields.get(f1.id);
+    if (f2) {
+      compareFields(f1, f2);
+    } else {
+      expect("second field").toEqual("doesn't exist");
+    }
+  });
+}
+
+export function compareFields(f1: Field, f2: Field) {
+  expect(f1.elevation).toEqual(f2.elevation);
+  expect(f1.crustThickness).toEqual(f2.crustThickness);
+  expect(f1.absolutePos).toEqual(f2.absolutePos);
+  expect(f1.force).toEqual(f2.force);
+  expect(f1.age).toEqual(f2.age);
+  expect(f1.mass).toEqual(f2.mass);
+  expect(f1.boundary).toEqual(f2.boundary);
+  expect(f1.noCollisionDist).toEqual(f2.noCollisionDist);
+  expect(f1.subduction?.progress).toEqual(f2.subduction?.progress);
+  expect(f1.draggingPlate?.id).toEqual(f2.draggingPlate?.id);
+  compareHelpers(f1.subduction, f2.subduction);
+  compareHelpers(f1.volcanicAct, f2.volcanicAct);
+  compareHelpers(f1.earthquake, f2.earthquake);
+  compareHelpers(f1.volcanicEruption, f2.volcanicEruption);
+  compareHelpers(f1.crust, f2.crust);
+}
+
+export function compareHelpers(h1: any, h2: any) {
+  if (h1 === undefined && h2 === undefined) {
+    return;
+  }
+  if (h1 === undefined && h2 !== undefined || h1 !== undefined && h2 === undefined) {
+    expect(h1).toEqual(h2);
+  }
+  Object.keys(h1).forEach(propName => {
+    if (propName !== "field") {
+      expect(propName + h1[propName]).toEqual(propName + h2[propName]);
+    }
+  });
+}


### PR DESCRIPTION
It's a similar test to the one used by the serialization method.
The idea is to have two models, make a set of actions in one of them, make sure these actions bring it to the initial state, and finally run both models for some time and check if they stay identical.