### PR TITLE
Fix cross-section calculations

### DIFF
--- a/js/plates-model/get-cross-section.ts
+++ b/js/plates-model/get-cross-section.ts
@@ -31,6 +31,7 @@ export interface IMagmaBlobData {
 
 export interface IFieldData {
   id: number;
+  plateId: number | string;
   elevation: number;
   crustThickness: number;
   rockLayers: IRockLayerData[],
@@ -117,6 +118,7 @@ function getFieldRawData(field: Field, props?: IWorkerProps): IFieldData {
   const totalCrustThickness = field.crustThickness;
   const result: IFieldData = {
     id: field.id,
+    plateId: field.plate.id,
     elevation: field.elevation,
     crustThickness: totalCrustThickness,
     rockLayers: field.crust.rockLayers.map(rl => ({
@@ -267,7 +269,8 @@ function setupDivergentBoundaryField(divBoundaryPoint: IChunk, prevPoint: IChunk
       rockLayers: nextField?.rockLayers || prevField?.rockLayers || [],
       lithosphereThickness: (prevLithosphereThickness + nextLithosphereThickness) * 0.5,
       subduction: 0,
-      id: -1
+      id: -1,
+      plateId: -1,
     };
   } else {
     divBoundaryPoint.field = {
@@ -282,7 +285,8 @@ function setupDivergentBoundaryField(divBoundaryPoint: IChunk, prevPoint: IChunk
       lithosphereThickness: 0.2,
       subduction: 0,
       normalizedAge: 0.2,
-      id: -1
+      id: -1,
+      plateId: -1
     };
   }
 }
@@ -320,7 +324,7 @@ function getStepRotation(p1: THREE.Vector3, p2: THREE.Vector3, steps: number) {
 }
 
 function equalFields(f1: IFieldData | null, f2?: IFieldData | null) {
-  return f1?.id === f2?.id;
+  return f1?.id === f2?.id && f1?.plateId === f2?.plateId;
 }
 
 function calculatePointCenters(result: IChunkArray[]) {
@@ -349,9 +353,11 @@ export default function getCrossSection(plates: Plate[], point1: THREE.Vector3, 
   const stepRotation = getStepRotation(p1, p2, steps);
   const platesAndSubplates: (Plate | Subplate)[] = [];
   plates.forEach((plate: Plate) => {
-    platesAndSubplates.push(plate);
-    if (plate.subplate.size > 0) {
-      platesAndSubplates.push(plate.subplate);
+    if (plate.visible) {
+      platesAndSubplates.push(plate);
+      if (plate.subplate.size > 0) {
+        platesAndSubplates.push(plate.subplate);
+      }
     }
   });
   platesAndSubplates.forEach(plate => {

--- a/js/plates-model/get-cross-section.ts
+++ b/js/plates-model/get-cross-section.ts
@@ -330,6 +330,7 @@ function equalFields(f1: IFieldData | null, f2?: IFieldData | null) {
 function calculatePointCenters(result: IChunkArray[]) {
   result.forEach((chunkData: IChunkArray) => {
     chunkData.chunks.forEach((point: IChunk, idx: number) => {
+      // The first and the last point are treated in a special way. This ensures that given chunk maintains its length.
       if (idx === 0) {
         point.dist = point.distStart;
       } else if (idx === chunkData.chunks.length - 1) {
@@ -404,8 +405,11 @@ export default function getCrossSection(plates: Plate[], point1: THREE.Vector3, 
       result.push(currentData);
     }
   });
-  calculatePointCenters(result);
   fillGaps(result, arcLength);
+  // Note point centers should be calculated after gaps are filled. Some CS chunks can be merged during this process
+  // and the final value of `dist` depends on the point position in the array.
+  calculatePointCenters(result);
+
   if (config.smoothCrossSection) {
     // Smooth subduction areas.
     result.forEach((chunkData: IChunkArray) => {

--- a/js/plates-model/get-cross-section.ts
+++ b/js/plates-model/get-cross-section.ts
@@ -236,6 +236,7 @@ function fillGaps(result: IChunkArray[], length: number) {
     // Handle edge case when the cross-section line ends in a blank area.
     addDivergentBoundaryCenter(chunk1, null, length);
   }
+
 }
 
 function setupDivergentBoundaryField(divBoundaryPoint: IChunk, prevPoint: IChunk | null, nextPoint: IChunk | null) {
@@ -416,5 +417,6 @@ export default function getCrossSection(plates: Plate[], point1: THREE.Vector3, 
       smoothSubductionAreas(chunkData);
     });
   }
-  return result;
+  // Filter out empty chunks. A chunk can become empty while gaps are filled in `fillGaps` method.
+  return result.filter(chunkData => chunkData.chunks.length > 0);
 }

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -404,7 +404,7 @@ function renderChunk(ctx: CanvasRenderingContext2D, chunkData: IChunkArray, opti
     fillPath(ctx, MANTLE_COLOR, l1, l2, b2, b1);
     // Debug info, optional
     if (config.debugCrossSection) {
-      debugInfo(ctx, l1, b1, [i, f1.id, x1.toFixed(1) + " km"]);
+      debugInfo(ctx, l1, b1, [i, `${f1.id} (${f1.plateId})`, x1.toFixed(1) + " km"]);
     }
     if (f1.magma) {
       drawMagma(ctx, f1.magma, t1, c1);


### PR DESCRIPTION
This PR fixes (or at least greatly improves) issues described here:
https://www.pivotaltracker.com/story/show/178804156

Changes:
1. I've improved a bit `debugCrossSection` mode to show plate number for each rock column.
2. Some of the cases I've traced were related to the fact that `.dist` property of cross-section fields was not calculated correctly (after some plate chunks got merged together). It's probably confusing, but each field has three properties: distStart, dist, and distEnd. distStart and distEnd describe how wide is a given field in the cross-section view. `dist` is something that is finally used by the rendering code. Each field is reduced to a single point, as we don't want to render columns. Insteady, we find a center of each field and connect them. So, `dist` will usually equal the center between `distStart` and `distEnd`. But the first point of a given plate will use `distStart` and the last will use `distEnd` to ensure that plate has the correct width and there are no gaps between plates.
3. Other cases causing gaps between plates were related to the fact that rendering code was not handling correctly plate chunks that were made of a single point. I've added a code that splits single point chunks into two points and that's handled correctly.

I know that get-cross-section.ts file might really hard to understand and read. The naming of various properties isn't the best for sure, and I guess I should try to simplify some logic. It took me many hours with a notebook to trace the issues described above. But at the same time, I don't want to redo this whole logic, as generally, it works and I don't see an easy way to simplify it. Also, we have the last 2 days of development time. But a bigger refactoring of this file is definitely on my to-do list during the next dev cycle.

