### PR TITLE
Improve loading performance

### DIFF
--- a/cypress/integration/basic/simulation-rules/island-collision-2.js
+++ b/cypress/integration/basic/simulation-rules/island-collision-2.js
@@ -26,7 +26,7 @@ describe("Island Collision 2 model", () => {
     runModelFor(model, 100); // million years
 
     // Right plate - continental shelf with islands leftovers (oceanic volcanic rocks).
-    expect(getFieldElevation(model, 1, 998)).to.be.greaterThan(0.85);
+    expect(getFieldElevation(model, 1, 998)).to.be.greaterThan(0.80);
     const rockLayers = getFieldRockLayers(model, 1, 998);
     expect(rockLayers?.[0].rock).to.equal("Oceanic Sediment");
     expect(rockLayers?.[1].rock).to.equal("Andesite");

--- a/cypress/integration/basic/simulation-rules/subduction.js
+++ b/cypress/integration/basic/simulation-rules/subduction.js
@@ -25,11 +25,11 @@ describe("Subduction model", () => {
     // Right plate - continent.
     expect(getFieldElevation(model, 1, 821)).to.be.closeTo(0.54, delta);
 
-    runModelFor(model, 85); // million years
+    runModelFor(model, 100); // million years
 
     // Right plate - volcano.
-    expect(getFieldElevation(model, 1, 1069)).to.be.greaterThan(0.7);
-    const rockLayers = getFieldRockLayers(model, 1, 1069);
+    expect(getFieldElevation(model, 1, 1203)).to.be.greaterThan(0.7);
+    const rockLayers = getFieldRockLayers(model, 1, 1203);
     // Volcanic rock (Rhyolite) should be the top-most one.
     expect(rockLayers?.[0].rock).to.equal("Rhyolite");
   });

--- a/js/config.ts
+++ b/js/config.ts
@@ -133,10 +133,10 @@ const DEFAULT_CONFIG = {
     "wireframe",
     "save"
   ],
-  // Used by the grid model and defines quality of the collision detection. Shouldn't be changed in the real model.
-  // It's useful to decrease this value in tests that don't care about precision, as the model will initialized way
-  // faster.
-  voronoiSphereFieldsCount: 200000,
+  // Voronoi sphere is used by the grid model and defines quality of the collision detection. It shouldn't be changed 
+  // in the real model. It's useful to decrease this value in tests that don't care about precision, as the model will 
+  // initialized way faster. `undefined` value means that model will use a preferred value based on the grid size.
+  voronoiSphereFieldsCount: undefined,
   // Display key expanded by default
   key: true,
   // Show a time counter that displays model time in million years.

--- a/js/config.ts
+++ b/js/config.ts
@@ -135,7 +135,7 @@ const DEFAULT_CONFIG = {
   ],
   // Voronoi sphere is used by the grid model and defines quality of the collision detection. It shouldn't be changed 
   // in the real model. It's useful to decrease this value in tests that don't care about precision, as the model will 
-  // initialized way faster. `undefined` value means that model will use a preferred value based on the grid size.
+  // be initialized way faster. `undefined` value means that model will use a preferred value based on the grid size.
   voronoiSphereFieldsCount: undefined,
   // Display key expanded by default
   key: true,

--- a/js/plates-model/grid.ts
+++ b/js/plates-model/grid.ts
@@ -21,6 +21,8 @@ function dist(a: IKDTreeNode, b: IKDTreeNode) {
   return Math.sqrt(Math.pow(a.x - b.x, 2) + Math.pow(a.y - b.y, 2) + Math.pow(a.z - b.z, 2));
 }
 
+const VORONOI_SPHERE_FIELDS_PER_ONE_GRID_FIELD = 5;
+
 class Grid {
   fieldDiameter: number;
   fieldDiameterInKm: number;
@@ -35,7 +37,10 @@ class Grid {
     this.fieldDiameterInKm = this.fieldDiameter * c.earthRadius;
     // Note that kdTree will modify and reorder input array.
     this.kdTree = new kdTree<IKDTreeNode>(this.generateKDTreeNodes(), dist, ["x", "y", "z"]);
-    this.voronoiSphere = new VoronoiSphere(config.voronoiSphereFieldsCount, this.kdTree);
+    this.voronoiSphere = new VoronoiSphere(
+      config.voronoiSphereFieldsCount || this.size * VORONOI_SPHERE_FIELDS_PER_ONE_GRID_FIELD, 
+      this.kdTree
+    );
   }
 
   get size(): number {

--- a/js/plates-model/model-worker.ts
+++ b/js/plates-model/model-worker.ts
@@ -7,6 +7,7 @@ import Model, { ISerializedModel } from "./model";
 import config, { Colormap } from "../config";
 import Field from "./field";
 import { IVector3 } from "../types";
+import getGrid from "./grid";
 
 // We're in web worker environment. Also, assume that Model can be exported for global scope for easier debugging.
 declare const self: Worker & { m?: Model | null };
@@ -218,3 +219,7 @@ self.onmessage = function modelWorkerMsgHandler(event: { data: IncomingModelWork
 };
 
 workerFunction();
+
+// Preload Grid helper class. It takes a few seconds to create, so it's better to do it as soon as possible,
+// using the time that the main thread needs to load preset image.
+getGrid();

--- a/test/integration/model-serialization.test.ts
+++ b/test/integration/model-serialization.test.ts
@@ -4,7 +4,7 @@ import config from "../../js/config";
 import Plate from "../../js/plates-model/plate";
 import { compareModels } from "../serialization-test-helpers";
 
-// Increase this parameter so it uses to real-world value (setup-tests.js sets a tiny value for performance reasons).
+// Increase this parameter so it uses a real-world value (setup-tests.js sets a tiny value for performance reasons).
 config.voronoiSphereFieldsCount = 200000;
 
 const TIMESTEP = 0.2;

--- a/test/integration/model-serialization.test.ts
+++ b/test/integration/model-serialization.test.ts
@@ -4,8 +4,8 @@ import config from "../../js/config";
 import Plate from "../../js/plates-model/plate";
 import { compareModels } from "../serialization-test-helpers";
 
-// setup-tests.js sets a tiny value for performance reasons. Don't use this optimization here.
-config.voronoiSphereFieldsCount = undefined;
+// Increase this parameter so it uses to real-world value (setup-tests.js sets a tiny value for performance reasons).
+config.voronoiSphereFieldsCount = 200000;
 
 const TIMESTEP = 0.2;
 

--- a/test/integration/model-serialization.test.ts
+++ b/test/integration/model-serialization.test.ts
@@ -4,8 +4,8 @@ import config from "../../js/config";
 import Plate from "../../js/plates-model/plate";
 import { compareModels } from "../serialization-test-helpers";
 
-// Increase this paramter so it uses to real-world value (setup-tests.js sets a tiny value for performance reasons).
-config.voronoiSphereFieldsCount = 200000;
+// setup-tests.js sets a tiny value for performance reasons. Don't use this optimization here.
+config.voronoiSphereFieldsCount = undefined;
 
 const TIMESTEP = 0.2;
 

--- a/test/integration/plate-division-merge.test.ts
+++ b/test/integration/plate-division-merge.test.ts
@@ -5,8 +5,8 @@ import Plate from "../../js/plates-model/plate";
 import { compareModels } from "../serialization-test-helpers";
 import * as seedrandom from "../../js/seedrandom";
 
-// Increase this parameter so it uses to real-world value (setup-tests.js sets a tiny value for performance reasons).
-config.voronoiSphereFieldsCount = 200000;
+// setup-tests.js sets a tiny value for performance reasons. Don't use this optimization here.
+config.voronoiSphereFieldsCount = undefined;
 
 const TIMESTEP = 0.1;
 

--- a/test/integration/plate-division-merge.test.ts
+++ b/test/integration/plate-division-merge.test.ts
@@ -5,8 +5,8 @@ import Plate from "../../js/plates-model/plate";
 import { compareModels } from "../serialization-test-helpers";
 import * as seedrandom from "../../js/seedrandom";
 
-// setup-tests.js sets a tiny value for performance reasons. Don't use this optimization here.
-config.voronoiSphereFieldsCount = undefined;
+// Increase this parameter so it uses to real-world value (setup-tests.js sets a tiny value for performance reasons).
+config.voronoiSphereFieldsCount = 200000;
 
 const TIMESTEP = 0.1;
 


### PR DESCRIPTION
The most time-consuming thing is the creation of the `Grid` singleton instance that includes `VoronoiSphere` calculations. Voronoi Sphere is used to find a field that is closest to a specified position. It's useful for collision detection and a few other core parts of the model. This PR does two things:
 - Creates `Grid` instance in an optimal moment both in web worker and the main thread.
 - Sets an optimal Voronoi sphere field number based on the number of model fields. This number will be 5 times bigger than the number of model fields. The default grid has around 10000 fields, so the Voronoi sphere will have around 50k. The previous value was hardcoded to 200k which seemed to be too much. I've tested the model both with 200k and 50k fields and couldn't see a significant difference. 