### PR TITLE
Extend boundary utilities to support boundary assignment dialogs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,7 +65,7 @@ module.exports = {
     "quotes": ["error", "double", { allowTemplateLiterals: true, avoidEscape: true }],
     "lines-between-class-members": ["error", "always", { exceptAfterSingleLine: true }],
     "jsx-quotes": ["error", "prefer-double"],
-    "indent": ["error", 2],
+    "indent": ["error", 2, { ignoredNodes: ["ConditionalExpression"] }],
     "object-curly-spacing": ["error", "always"],
     "array-bracket-spacing": ["error", "never"],
     "radix": "error",

--- a/js/components/rock-images.tsx
+++ b/js/components/rock-images.tsx
@@ -46,7 +46,6 @@ interface IProps {
   src2x?: any;
   src3x?: any;
 }
-/* eslint-disable indent */
 export const RockImage = ({ src, src2x, src3x }: IProps) => {
   // https://stackoverflow.com/a/34739835
   const imageSrc = src3x && (window.devicePixelRatio > 2)
@@ -56,7 +55,6 @@ export const RockImage = ({ src, src2x, src3x }: IProps) => {
                       : src;
   return <div className={css.rockImage}><img src={imageSrc} /></div>;
 };
-/* eslint-enable indent */
 
 export const GabbroImage = () => {
   return <RockImage src={GabbroImageSrc} src2x={GabbroImageSrc2x} src3x={GabbroImageSrc3x} />;

--- a/js/plates-model/model-worker.ts
+++ b/js/plates-model/model-worker.ts
@@ -6,7 +6,7 @@ import markIslands from "./mark-islands";
 import Model, { ISerializedModel } from "./model";
 import config, { Colormap } from "../config";
 import Field, { ISerializedField } from "./field";
-import { BoundaryOrientation, IBoundaryInfo, IVector3 } from "../types";
+import { IVector3 } from "../types";
 import getGrid from "./grid";
 
 // We're in web worker environment. Also, assume that Model can be exported for global scope for easier debugging.
@@ -14,7 +14,7 @@ declare const self: Worker & { m?: Model | null };
 
 // Incoming messages:
 export type IncomingModelWorkerMsg = ILoadPresetMsg | ILoadModelMsg | IUnloadMsg | IPropsMsg | IStepForwardMsg | ISetHotSpotMsg | ISetDensitiesMsg |
-  IBoundaryInfoMsg | IFieldInfoMsg | IContinentDrawingMsg | IContinentErasingMsg | IMarkIslandsMsg | IRestoreSnapshotMsg | IRestoreInitialSnapshotMsg |
+  IFieldInfoMsg | IContinentDrawingMsg | IContinentErasingMsg | IMarkIslandsMsg | IRestoreSnapshotMsg | IRestoreInitialSnapshotMsg |
   ITakeLabeledSnapshotMsg | IRestoreLabeledSnapshotMsg | ISaveModelMsg | IMarkFieldMsg | IUnmarkAllFieldsMsg | ISetPlateProps;
 
 interface ILoadPresetMsg { type: "loadPreset"; imgData: ImageData; presetName: string; props: IWorkerProps; }
@@ -24,7 +24,6 @@ interface IPropsMsg { type: "props"; props: IWorkerProps; }
 interface IStepForwardMsg { type: "stepForward"; }
 interface ISetHotSpotMsg { type: "setHotSpot"; props: { position: IVector3; force: IVector3 }; }
 interface ISetDensitiesMsg { type: "setDensities"; densities: Record<string, number>; }
-interface IBoundaryInfoMsg { type: "boundaryInfo"; props: { position: IVector3, logOnly: boolean }; requestId: number }
 interface IFieldInfoMsg { type: "fieldInfo"; props: { position: IVector3, logOnly: boolean }; requestId: number }
 interface IContinentDrawingMsg { type: "continentDrawing"; props: { position: IVector3 }; }
 interface IContinentErasingMsg { type: "continentErasing"; props: { position: IVector3 }; }
@@ -39,15 +38,14 @@ interface IUnmarkAllFieldsMsg { type: "unmarkAllFields"; }
 interface ISetPlateProps { type: "setPlateProps"; props: { id: number, visible?: boolean } }
 
 // Messages sent by worker:
-export type ModelWorkerMsg = IOutputMsg | ISavedModelMsg | IBoundaryInfoResponseMsg | IFieldInfoResponseMsg;
+export type ModelWorkerMsg = IOutputMsg | ISavedModelMsg | IFieldInfoResponseMsg;
 
 interface ISavedModelMsg { type: "savedModel"; data: { savedModel: string; } }
 interface IOutputMsg { type: "output"; data: IModelOutput }
-interface IBoundaryInfoResponseMsg { type: "boundaryInfo"; requestId: number; response: IBoundaryInfo; }
 interface IFieldInfoResponseMsg { type: "fieldInfo"; requestId: number; response: ISerializedField; }
 
-export function isResponseMsg(msg: ModelWorkerMsg): msg is IBoundaryInfoResponseMsg | IFieldInfoResponseMsg {
-  return (msg.type === "boundaryInfo") || (msg.type === "fieldInfo");
+export function isResponseMsg(msg: ModelWorkerMsg): msg is IFieldInfoResponseMsg {
+  return msg.type === "fieldInfo";
 }
 
 // postMessage serialization is expensive. Pass only selected properties. Note that only these properties
@@ -126,7 +124,6 @@ function workerFunction() {
 }
 
 self.onmessage = function modelWorkerMsgHandler(event: { data: IncomingModelWorkerMsg }) {
-  const grid = getGrid();
   const data = event.data;
   if (data.type === "loadPreset") {
     // Export model to global m variable for convenience.
@@ -154,72 +151,6 @@ self.onmessage = function modelWorkerMsgHandler(event: { data: IncomingModelWork
     model?.setHotSpot(pos, force);
   } else if (data.type === "setDensities") {
     model?.setDensities(data.densities);
-  } else if (data.type === "boundaryInfo") {
-    // empty response => no boundary and no plates
-    let response: IBoundaryInfo = {};
-    const pos = (new THREE.Vector3()).copy(data.props.position as THREE.Vector3);
-    const field = model?.topFieldAt(pos, { visibleOnly: true });
-    if (field) {
-      // local/heuristic approach to determining plates and boundary type from adjacentFields
-      // boundary type determination to be replaced with global approach when available
-      const thisPlateId = `${field.plate.id}`;
-      let otherPlateId: string | undefined;
-      let orientation: BoundaryOrientation | undefined;
-      if (field.boundary && field.adjacentFields) {
-        const fieldPlatesMap: Record<string, { count: number; xSum: number; ySum: number, xMean: number, yMean: number }> = {};
-        field.adjacentFields.forEach(fieldId => {
-          const fieldPos = field.plate.absolutePosition(grid.fields[+fieldId].localPos);
-          const adjField = model?.topFieldAt(fieldPos);
-          const plate = adjField?.plate;
-          const plateId = `${plate?.id}`;
-          if (fieldPos && plate && (plateId != null)) {
-            if (!fieldPlatesMap[plateId]) {
-              fieldPlatesMap[plateId] = { count: 1, xSum: fieldPos.x, ySum: fieldPos.y, xMean: fieldPos.x, yMean: fieldPos.y };
-            } else {
-              ++fieldPlatesMap[plateId].count;
-              fieldPlatesMap[plateId].xSum += fieldPos.x;
-              fieldPlatesMap[plateId].ySum += fieldPos.y;
-            }
-          }
-        });
-        Object.keys(fieldPlatesMap).forEach(plateId => {
-          const fieldPlate = fieldPlatesMap[plateId];
-          if (fieldPlate?.count > 0) {
-            fieldPlate.xMean = fieldPlate.xSum / fieldPlate.count;
-            fieldPlate.yMean = fieldPlate.ySum / fieldPlate.count;
-            // in the rare case of more than two neighboring plates pick the one with more fields
-            if ((plateId !== thisPlateId) &&
-                (!otherPlateId || (fieldPlate?.count > fieldPlatesMap[otherPlateId].count))) {
-              otherPlateId = plateId;
-            }
-          }
-        });
-        // TODO: replace local/heuristic boundary type determination with global when available
-        const thisPlateInfo = fieldPlatesMap[thisPlateId];
-        const otherPlateInfo = otherPlateId && fieldPlatesMap[otherPlateId];
-        if (thisPlateInfo && otherPlateInfo) {
-          // compute boundary type from mean field positions
-          const xDiff = Math.abs(thisPlateInfo.xMean - otherPlateInfo.xMean);
-          const yDiff = Math.abs(thisPlateInfo.yMean - otherPlateInfo.yMean);
-          /* eslint-disable indent */
-          orientation = xDiff > yDiff
-                          ? "vertical"
-                          : (yDiff > xDiff
-                            ? thisPlateInfo.yMean > 0
-                              ? "horizontal-upper"
-                              : "horizontal-lower"
-                            : undefined);
-          /* eslint-enable indent */
-        }
-      }
-      response = { orientation, plates: [thisPlateId, otherPlateId ?? null] };
-    }
-    if (data.props.logOnly) {
-      // Useful for debugging and test.
-      console.log(response);
-    } else {
-      self.postMessage({ type: "boundaryInfo", requestId: data.requestId, response });
-    }
   } else if (data.type === "fieldInfo") {
     const pos = (new THREE.Vector3()).copy(data.props.position as THREE.Vector3);
     const field = model?.topFieldAt(pos, { visibleOnly: true });

--- a/js/stores/helpers/boundary-utils.ts
+++ b/js/stores/helpers/boundary-utils.ts
@@ -1,4 +1,6 @@
+import { toSpherical } from "../../geo-utils";
 import getGrid from "../../plates-model/grid";
+import { IBoundaryInfo } from "../../types";
 import FieldStore from "../field-store";
 import ModelStore from "../model-store";
 
@@ -76,6 +78,41 @@ export function unhighlightBoundary(field: FieldStore) {
         stack.push(n);
       }
     });
+  }
+}
+
+export function getBoundaryInfo(field: FieldStore, model: ModelStore): IBoundaryInfo | undefined {
+  const otherField = field.boundary ? findFieldFromNeighboringPlate(field, model) : undefined;
+  if (field && otherField) {
+    const plate = field.plate;
+    const otherPlate = otherField.plate;
+    const polarCapPlate = plate.isPolarCap
+                            ? plate
+                            : otherPlate.isPolarCap
+                                ? otherPlate
+                                : undefined;
+    const orientation = polarCapPlate?.center
+                          ? polarCapPlate.center.y > 0
+                              ? "northern-latitudinal"
+                              : "southern-latitudinal"
+                          : "longitudinal";
+    let plates: [number, number] = [plate.id, otherPlate.id];
+    if (polarCapPlate) {
+      // latitudinal boundary
+      const capPlateId = polarCapPlate.id;
+      const nonCapPlateId = plate === polarCapPlate ? otherPlate.id : plate.id;
+      plates = orientation === "northern-latitudinal"
+                ? [capPlateId, nonCapPlateId]
+                : [nonCapPlateId, capPlateId];
+    } else {
+      // longitudinal boundary
+      const platePos = toSpherical(plate.center);
+      const otherPlatePos = toSpherical(otherPlate.center);
+      plates = platePos.lon < otherPlatePos.lon
+                ? [otherPlate.id, plate.id]
+                : [plate.id, otherPlate.id];
+    }
+    return { orientation, plates };
   }
 }
 

--- a/js/stores/plate-store.ts
+++ b/js/stores/plate-store.ts
@@ -30,6 +30,10 @@ export default class PlateStore extends PlateBase<FieldStore> {
     this.id = id;
   }
 
+  get isPolarCap() {
+    return Math.abs(this.center.y) > 0.9;
+  }
+
   handleDataFromWorker(data: IPlateOutput) {
     // THREE.Quaternion is serialized to {_x: ..., _y: ..., _z: ..., _w: ...} format.
     const serializedQuaternion = data.quaternion as any;

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -18,7 +18,7 @@ import { ISerializedModel } from "../plates-model/model";
 import getGrid from "../plates-model/grid";
 import { rockProps } from "../plates-model/rock-properties";
 import FieldStore from "./field-store";
-import { findBoundaryFieldAround, highlightBoundarySegment, unhighlightBoundary } from "./helpers/highlight-boundary-segment";
+import { findBoundaryFieldAround, getBoundaryInfo, highlightBoundarySegment, unhighlightBoundary } from "./helpers/boundary-utils";
 
 export interface ISerializedState {
   version: 4;
@@ -405,10 +405,9 @@ export class SimulationStore {
   }
 
   @action.bound async setSelectedBoundary(position?: THREE.Vector3) {
-    const boundary = position ? await workerController.getBoundaryInfo(position) : null;
-    runInAction(() => {
-      this.selectedBoundary = boundary;
-    });
+    const targetField = position && this.model.topFieldAt(position) || null;
+    const boundary = targetField && getBoundaryInfo(targetField, this.model) || null;
+    this.selectedBoundary = boundary;
   }
 
   @action.bound setSelectedBoundaryType(type: BoundaryType) {

--- a/js/types.ts
+++ b/js/types.ts
@@ -17,11 +17,11 @@ export type RockKeyLabel = "Granite" | "Basalt" | "Gabbro" | "Rhyolite" | "Andes
 
 export type ICrossSectionWall = "front" | "back" | "top" | "left" | "right";
 
-// horizontal boundary => north/south forces; vertical boundary => east/west forces
-export type BoundaryOrientation = "horizontal-lower" | "horizontal-upper" | "vertical";
+// longitudinal boundary => east/west forces; latitudinal boundary => north/south forces
+export type BoundaryOrientation = "longitudinal" | "northern-latitudinal" | "southern-latitudinal";
 export type BoundaryType = "convergent" | "divergent";
 export interface IBoundaryInfo {
   orientation?: BoundaryOrientation;  // undefined => no boundary
   type?: BoundaryType;
-  plates?: [string, string | null];   // stringified plate ids
+  plates?: [number, number];
 }

--- a/js/worker-controller.ts
+++ b/js/worker-controller.ts
@@ -2,7 +2,6 @@ import { EventEmitter2 } from "eventemitter2";
 import { IncomingModelWorkerMsg, isResponseMsg, ModelWorkerMsg } from "./plates-model/model-worker";
 import * as THREE from "three";
 import { ISerializedField } from "./plates-model/field";
-import { IBoundaryInfo } from "./types";
 
 export type EventName = "output" | "savedModel";
 export type ResponseHandler = (response: any) => void;
@@ -63,14 +62,6 @@ class WorkerController {
   }
 
   // Helper functions that wrap postMessageToModel calls.
-  getBoundaryInfo(position: THREE.Vector3, logOnly = false): Promise<IBoundaryInfo> {
-    return new Promise<IBoundaryInfo>(resolve => {
-      const requestId = getRequestId();
-      this.responseHandlers[requestId] = resolve;
-      this.postMessageToModel({ type: "boundaryInfo", props: { position, logOnly }, requestId });
-    });
-  }
-
   getFieldInfo(position: THREE.Vector3, logOnly = false): Promise<ISerializedField> {
     return new Promise<ISerializedField>(resolve => {
       const requestId = getRequestId();


### PR DESCRIPTION
Extends the existing boundary utilities with some functions required by the dialog code:
- `highlight-boundary-segment.ts` renamed to `boundary-utils.ts`
- `getBoundaryInfo()` added to `boundary-utils.ts`
- `getBoundaryInfo()` removed from `model-worker.ts`
- `isPolarCap` added to `PlateStore`