### PR TITLE
Rock Sample tool bug fixes

### DIFF
--- a/js/components/cross-section-3d.tsx
+++ b/js/components/cross-section-3d.tsx
@@ -50,6 +50,7 @@ export default class CrossSection3D extends BaseComponent<IBaseProps, IState> {
   componentWillUnmount() {
     this.view.dispose();
     this.disposeObserver.forEach((dispose: any) => dispose());
+    this.interactions.disableEventHandlers();
   }
 
   render() {

--- a/js/components/planet-view.tsx
+++ b/js/components/planet-view.tsx
@@ -51,6 +51,7 @@ export default class PlanetView extends BaseComponent<IBaseProps, IState> {
     this.view3d.dispose();
     window.removeEventListener("resize", this.handleResize);
     this.disposeObserver.forEach((dispose: any) => dispose());
+    this.interactions.disableEventHandlers();
   }
 
   handleResize() {

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -418,6 +418,10 @@ export class SimulationStore {
 
   @action.bound setSelectedRock(rock: RockKeyLabel | null) {
     this.selectedRock = rock || null;
+    if (!this.key) {
+      // Open key automatically if it was closed by the user before.
+      this.key = true;
+    }
   }
 
   @action.bound setSelectedRockFlash(value: boolean) {


### PR DESCRIPTION
This PR fixes two bugs found during QA.

https://www.pivotaltracker.com/story/show/177652612/comments/227721882:
> If the key is manually closed and then the rock sample is then taken, should we expect the key to reopen? currently it doesn't and as per the description it seems like it should.

https://www.pivotaltracker.com/story/show/180051337/comments/227722170:
> With take sample enabled, if the cross section is closed and reopened, we lose the take sample setting and the rock sample marker is no longer displayed but even with this normal cursor we are able to take the rock samples and the key updated accordingly. This seems like a bug.
