### PR TITLE
Set hot spots / force vectors based on the boundary type

### DIFF
--- a/js/components/boundary-config-dialog.tsx
+++ b/js/components/boundary-config-dialog.tsx
@@ -109,8 +109,8 @@ interface IBoundaryOption {
 }
 const BoundaryOption = observer(({ boundary, type, getPlateHue, onAssign }: IBoundaryOption) => {
   const selectedClass = type === boundary.type ? css.selected : "";
-  const plate0Hue = getPlateHue(boundary.plates?.[0]) ?? plateHues[0];
-  const plate1Hue = getPlateHue(boundary.plates?.[1]) ?? plateHues[1];
+  const plate0Hue = getPlateHue(boundary.fields?.[0].plate.id) ?? plateHues[0];
+  const plate1Hue = getPlateHue(boundary.fields?.[1].plate.id) ?? plateHues[1];
   return (
     <div className={`${css.boundaryOption} ${selectedClass}`} onClick={() => onAssign(type)}>
       <DialogContentText>

--- a/js/geo-utils.ts
+++ b/js/geo-utils.ts
@@ -17,7 +17,8 @@ export function toSpherical(vec3: IVector3) {
   return { lat: Math.asin(Math.min(1, Math.max(-1, vec3.y))), lon: Math.atan2(vec3.z, vec3.x) };
 }
 
-// Converts [lat, lon] into a vector pointing north, assuming that the north direction is defined by [0, 1, 0] vector.
-export function trueNorthVector(lat: number, lon: number) {
+// Converts [lat, lon] into a vector pointing north (assuming that north-south axis is the Y axis).
+// Resulting vector is tangent to the planet (/ sphere) surface.
+export function getNorthVector(lat: number, lon: number) {
   return new THREE.Vector3(-Math.sin(lat) * Math.cos(lon), Math.cos(lat), -Math.sin(lat) * Math.sin(lon));
 }

--- a/js/geo-utils.ts
+++ b/js/geo-utils.ts
@@ -16,3 +16,8 @@ export function toSpherical(vec3: IVector3) {
   // Make sure vec3.y is between [-1, 1]. Sometimes it might not be due to numerical errors.
   return { lat: Math.asin(Math.min(1, Math.max(-1, vec3.y))), lon: Math.atan2(vec3.z, vec3.x) };
 }
+
+// Converts [lat, lon] into a vector pointing north, assuming that the north direction is defined by [0, 1, 0] vector.
+export function trueNorthVector(lat: number, lon: number) {
+  return new THREE.Vector3(-Math.sin(lat) * Math.cos(lon), Math.cos(lat), -Math.sin(lat) * Math.sin(lon));
+}

--- a/js/stores/helpers/boundary-utils.ts
+++ b/js/stores/helpers/boundary-utils.ts
@@ -1,6 +1,6 @@
-import { toSpherical } from "../../geo-utils";
+import { toCartesian, toSpherical, getNorthVector } from "../../geo-utils";
 import getGrid from "../../plates-model/grid";
-import { BoundaryType, IBoundaryInfo } from "../../types";
+import { IBoundaryInfo, IHotSpot } from "../../types";
 import FieldStore from "../field-store";
 import ModelStore from "../model-store";
 
@@ -108,6 +108,60 @@ export function getBoundaryInfo(field: FieldStore, otherField: FieldStore): IBou
               : [field, otherField];
   }
   return { orientation, fields };
+}
+
+export function convertBoundaryTypeToHotSpots(boundaryInfo: IBoundaryInfo): IHotSpot[] {
+  const [field0, field1] = boundaryInfo.fields || [];
+  const type = boundaryInfo.type;
+  switch (boundaryInfo.orientation) {
+  case "northern-latitudinal":
+    if (field0) {
+      const latLon = toSpherical(field0.absolutePos);
+      const lat = latLon.lat + 0.15;
+      const lon = latLon.lon;
+      const newPos = toCartesian([lat, lon]);
+      const rotationAxis = newPos.clone().normalize();
+      const trueNorth = getNorthVector(lat, lon);
+      const force = type === "convergent" ? trueNorth.applyAxisAngle(rotationAxis, Math.PI) : trueNorth;
+      return [{ position: newPos, force }];
+    }
+    break;
+  case "longitudinal":
+    if (field0 && field1) {
+      const latLon0 = toSpherical(field0.absolutePos);
+      const lat0 = latLon0.lat;
+      // TODO: it should be adjusted for extreme lat values in a better way
+      const kLonDiff = 0.2 + Math.pow(Math.abs(lat0), 2) * 0.2;
+      const lon0 = latLon0.lon - kLonDiff;
+      const latLon1 = toSpherical(field1.absolutePos);
+      const lat1 = latLon1.lat;
+      const lon1 = latLon1.lon + kLonDiff;
+      const latAvg = 0.5 * (lat0 + lat1);
+      const newPos0 = toCartesian([latAvg, lon0]);
+      const newPos1 = toCartesian([latAvg, lon1]);
+      const rotationAxis0 = newPos0.clone().normalize();
+      const rotationAxis1 = newPos1.clone().normalize();
+      const trueNorth0 = getNorthVector(latAvg, lon0);
+      const trueNorth1 = getNorthVector(latAvg, lon1);
+      const force0 = type === "convergent" ? trueNorth0.applyAxisAngle(rotationAxis0, 0.5 * Math.PI) : trueNorth0.applyAxisAngle(rotationAxis0, -0.5 * Math.PI);
+      const force1 = type === "convergent" ? trueNorth1.applyAxisAngle(rotationAxis1, -0.5 * Math.PI) : trueNorth1.applyAxisAngle(rotationAxis1, 0.5 * Math.PI);
+      return [{ position: newPos0, force: force0 }, { position: newPos1, force: force1 }];
+    }
+    break;
+  case "southern-latitudinal":
+    if (field1) {
+      const latLon = toSpherical(field1.absolutePos);
+      const lat = latLon.lat - 0.15;
+      const lon = latLon.lon;
+      const newPos = toCartesian([lat, lon]);
+      const rotationAxis = newPos.clone().normalize();
+      const trueNorth = getNorthVector(lat, lon);
+      const force = type === "convergent" ? trueNorth : trueNorth.applyAxisAngle(rotationAxis, Math.PI);
+      return [{ position: newPos, force }];
+    }
+    break;
+  }
+  return [];
 }
 
 export function findBoundaryFieldAround(field: FieldStore | null, model: ModelStore) {

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -13,14 +13,12 @@ import { IWorkerProps } from "../plates-model/model-worker";
 import { ICrossSectionOutput, IModelOutput } from "../plates-model/model-output";
 import { IGlobeInteractionName } from "../plates-interactions/globe-interactions-manager";
 import { ICrossSectionInteractionName } from "../plates-interactions/cross-section-interactions-manager";
-import { BoundaryType, IBoundaryInfo, IVec3Array, RockKeyLabel } from "../types";
+import { BoundaryType, IBoundaryInfo, IHotSpot, IVec3Array, RockKeyLabel } from "../types";
 import { ISerializedModel } from "../plates-model/model";
 import getGrid from "../plates-model/grid";
 import { rockProps } from "../plates-model/rock-properties";
 import FieldStore from "./field-store";
-import { findBoundaryFieldAround, getBoundaryInfo, highlightBoundarySegment, unhighlightBoundary } from "./helpers/boundary-utils";
-import { toCartesian, toSpherical, trueNorthVector } from "../geo-utils";
-import { Vector3 } from "three";
+import { convertBoundaryTypeToHotSpots, findBoundaryFieldAround, getBoundaryInfo, highlightBoundarySegment, unhighlightBoundary } from "./helpers/boundary-utils";
 
 export interface ISerializedState {
   version: 4;
@@ -198,7 +196,7 @@ export class SimulationStore {
     this.currentHotSpot = { position, force };
   }
 
-  @action.bound setHotSpot(data: { position: THREE.Vector3; force: THREE.Vector3 }) {
+  @action.bound setHotSpot(data: IHotSpot) {
     this.currentHotSpot = null;
     workerController.postMessageToModel({ type: "setHotSpot", props: data });
     // TODO: better synchronization approach
@@ -429,56 +427,7 @@ export class SimulationStore {
     if (this.selectedBoundary?.orientation) {
       // TODO: represent convergent/divergent in the model, e.g. isConvergent property
       this.selectedBoundary = { ...this.selectedBoundary, type };
-      const [field0, field1] = this.selectedBoundary.fields || [];
-      switch (this.selectedBoundary.orientation) {
-      case "northern-latitudinal":
-        if (field0) {
-          const latLon = toSpherical(field0.absolutePos);
-          const lat = latLon.lat + 0.15;
-          const lon = latLon.lon;
-          const newPos = toCartesian([lat, lon]);
-          const rotationAxis = newPos.clone().normalize();
-          const trueNorth = trueNorthVector(lat, lon);
-          const force = type === "convergent" ? trueNorth.applyAxisAngle(rotationAxis, Math.PI) : trueNorth;
-          this.setHotSpot({ position: newPos, force });
-        }
-        break;
-      case "longitudinal":
-        if (field0 && field1) {
-          const latLon0 = toSpherical(field0.absolutePos);
-          const lat0 = latLon0.lat;
-          // TODO: it should be adjusted for extreme lat values in a better way
-          const kLonDiff = 0.2 + Math.pow(Math.abs(lat0), 2) * 0.2;
-          const lon0 = latLon0.lon - kLonDiff;
-          const latLon1 = toSpherical(field1.absolutePos);
-          const lat1 = latLon1.lat;
-          const lon1 = latLon1.lon + kLonDiff;
-          const latAvg = 0.5 * (lat0 + lat1);
-          const newPos0 = toCartesian([latAvg, lon0]);
-          const newPos1 = toCartesian([latAvg, lon1]);
-          const rotationAxis0 = newPos0.clone().normalize();
-          const rotationAxis1 = newPos1.clone().normalize();
-          const trueNorth0 = trueNorthVector(latAvg, lon0);
-          const trueNorth1 = trueNorthVector(latAvg, lon1);
-          const force0 = type === "convergent" ? trueNorth0.applyAxisAngle(rotationAxis0, 0.5 * Math.PI) : trueNorth0.applyAxisAngle(rotationAxis0, -0.5 * Math.PI);
-          const force1 = type === "convergent" ? trueNorth1.applyAxisAngle(rotationAxis1, -0.5 * Math.PI) : trueNorth1.applyAxisAngle(rotationAxis1, 0.5 * Math.PI);
-          this.setHotSpot({ position: newPos0, force: force0 });
-          this.setHotSpot({ position: newPos1, force: force1 });
-        }
-        break;
-      case "southern-latitudinal":
-        if (field1) {
-          const latLon = toSpherical(field1.absolutePos);
-          const lat = latLon.lat - 0.15;
-          const lon = latLon.lon;
-          const newPos = toCartesian([lat, lon]);
-          const rotationAxis = newPos.clone().normalize();
-          const trueNorth = trueNorthVector(lat, lon);
-          const force = type === "convergent" ? trueNorth : trueNorth.applyAxisAngle(rotationAxis, Math.PI);
-          this.setHotSpot({ position: newPos, force });
-        }
-        break;
-      }
+      convertBoundaryTypeToHotSpots(this.selectedBoundary).forEach(hotSpot => this.setHotSpot(hotSpot));
     }
   }
 

--- a/js/types.ts
+++ b/js/types.ts
@@ -1,3 +1,5 @@
+import FieldStore from "./stores/field-store";
+
 export interface IVector3 {
   x: number;
   y: number;
@@ -23,5 +25,5 @@ export type BoundaryType = "convergent" | "divergent";
 export interface IBoundaryInfo {
   orientation?: BoundaryOrientation;  // undefined => no boundary
   type?: BoundaryType;
-  plates?: [number, number];
+  fields?: [FieldStore, FieldStore];
 }

--- a/js/types.ts
+++ b/js/types.ts
@@ -27,3 +27,8 @@ export interface IBoundaryInfo {
   type?: BoundaryType;
   fields?: [FieldStore, FieldStore];
 }
+
+export interface IHotSpot {
+ position: THREE.Vector3;
+ force: THREE.Vector3;
+}


### PR DESCRIPTION
This PR adds the math necessary to set force vectors using boundary type info. It might seem weird to keep fields in the `BoundaryInfo` instead of plates, but they provide more data than just the `plateId` (=> absolute position useful to calculate forces later). At the same time, they're defining `plateId` too.