### PR TITLE
Calculate boundary type

### DIFF
--- a/js/components/simulation.tsx
+++ b/js/components/simulation.tsx
@@ -70,9 +70,13 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
         </div>
         <ColorKey />
         { planetWizard && <PlanetWizard /> }
-        <BoundaryConfigDialog open={!!selectedBoundary?.orientation}
-          boundary={selectedBoundary || {}} getPlateHue={this.getPlateHue}
-          onAssign={this.handleAssign} onClose={this.handleClose} />
+        {
+          selectedBoundary &&
+          <BoundaryConfigDialog
+            open={!!selectedBoundary} boundary={selectedBoundary} getPlateHue={this.getPlateHue}
+            onAssign={this.handleAssign} onClose={this.handleClose}
+          />
+        }
       </div>
     );
   }

--- a/js/stores/helpers/boundary-utils.ts
+++ b/js/stores/helpers/boundary-utils.ts
@@ -105,7 +105,7 @@ export function getBoundaryInfo(field: FieldStore, otherField: FieldStore): IBou
     if (polarCapField.plate.hotSpot.force.length() > 0) {
       const { lat, lon } = toSpherical(polarCapField.plate.hotSpot.position);
       const northVec = getNorthVector(lat, lon);
-      const angleToNorth = polarCapField.plate.hotSpot.force.clone().angleTo(northVec);
+      const angleToNorth = polarCapField.plate.hotSpot.force.angleTo(northVec);
       // The angle is 0 when the force is facing north and Math.PI when it's facing south.
       const isForceFacingNorth = angleToNorth < Math.PI * 0.5;
       type = orientation === "northern-latitudinal"
@@ -126,7 +126,7 @@ export function getBoundaryInfo(field: FieldStore, otherField: FieldStore): IBou
       const { lat, lon } = toSpherical(westernField.plate.hotSpot.position);
       const rotationAxis = westernField.plate.hotSpot.position.clone().normalize();
       const westVec = getNorthVector(lat, lon).applyAxisAngle(rotationAxis, 0.5 * Math.PI);
-      const angleToWest = westernField.plate.hotSpot.force.clone().angleTo(westVec);
+      const angleToWest = westernField.plate.hotSpot.force.angleTo(westVec);
       // The angle is 0 when the force is facing west and Math.PI when it's facing east.
       const isForceFacingWest = angleToWest < Math.PI * 0.5;
       type = isForceFacingWest ? "divergent" : "convergent";

--- a/js/types.ts
+++ b/js/types.ts
@@ -23,9 +23,10 @@ export type ICrossSectionWall = "front" | "back" | "top" | "left" | "right";
 export type BoundaryOrientation = "longitudinal" | "northern-latitudinal" | "southern-latitudinal";
 export type BoundaryType = "convergent" | "divergent";
 export interface IBoundaryInfo {
-  orientation?: BoundaryOrientation;  // undefined => no boundary
-  type?: BoundaryType;
-  fields?: [FieldStore, FieldStore];
+  // Fields are ordered from north to south, or from west to east.
+  fields: [FieldStore, FieldStore];
+  orientation: BoundaryOrientation;
+  type: BoundaryType | undefined;
 }
 
 export interface IHotSpot {


### PR DESCRIPTION
[#179577787]

This PR adds calculations of the boundary type using existing hot spots and boundary orientation. I've used the dynamic approach, as it's reasonably easy with the orientation already calculated.

The nice side effect of that sometimes you can get information whether the given boundary is convergent or divergent even when you click on it for the very first time (if you set up neighbouring plates correctly).
