### PR TITLE
Fix longitudinal boundary assignment under rotation

### DIFF
--- a/js/stores/helpers/boundary-utils.ts
+++ b/js/stores/helpers/boundary-utils.ts
@@ -116,10 +116,11 @@ export function getBoundaryInfo(field: FieldStore, otherField: FieldStore, model
     // longitudinal boundary
     const { lat, lon } = toSpherical(field.absolutePos);
     const fieldRotationAxis = field.absolutePos.clone().normalize();
-    const westTestVec = getNorthVector(lat, lon).setLength(0.5).applyAxisAngle(fieldRotationAxis, 0.5 * Math.PI);
-    const eastTestVec = getNorthVector(lat, lon).setLength(0.5).applyAxisAngle(fieldRotationAxis, -0.5 * Math.PI);
-    const westTestField = model.topFieldAt(field.absolutePos.add(westTestVec));
-    const eastTestField = model.topFieldAt(field.absolutePos.add(eastTestVec));
+    const kTestVectorLen = 0.1; // the whole planet has radius 1.0, so 0.1 seems safe
+    const westTestVec = getNorthVector(lat, lon).setLength(kTestVectorLen).applyAxisAngle(fieldRotationAxis, 0.5 * Math.PI);
+    const eastTestVec = getNorthVector(lat, lon).setLength(kTestVectorLen).applyAxisAngle(fieldRotationAxis, -0.5 * Math.PI);
+    const westTestField = model.topFieldAt(field.absolutePos.clone().add(westTestVec));
+    const eastTestField = model.topFieldAt(field.absolutePos.clone().add(eastTestVec));
     fields = [field, otherField];
     const plateIds = [field.plate.id, otherField.plate.id];
     const westIndex = westTestField && plateIds.indexOf(westTestField?.plate.id);

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -416,7 +416,7 @@ export class SimulationStore {
     }
     const highlightedBoundaryField1 = this.highlightedBoundaries[0];
     const highlightedBoundaryField2 = this.highlightedBoundaries[1];
-    const boundary = getBoundaryInfo(highlightedBoundaryField1, highlightedBoundaryField2) || null;
+    const boundary = getBoundaryInfo(highlightedBoundaryField1, highlightedBoundaryField2, this.model) || null;
     this.selectedBoundary = boundary;
   }
 


### PR DESCRIPTION
This PR improves our heuristic for determine which plate is on which side of a longitudinal boundary segment. ~~It works _most_ of the time, but can still give incorrect results when the longitude values wrap between the boundary and the center of the plate. With our existing presets this code gives the correct results on all longitudinal boundaries except the 4/5 boundary in the uneven five-plate preset with the globe rotated. @pjanik may have a better idea for how to address this.~~

I figured out a better approach.