### PR TITLE
Offset initial dialog position; keep dialog in bounds when dragging

### DIFF
--- a/css-modules/boundary-config-dialog.less
+++ b/css-modules/boundary-config-dialog.less
@@ -3,7 +3,7 @@
   :global(.MuiDialogTitle-root) {
     font-size: 14px;
     font-weight: bold;
-    padding: 6px;
+    padding: 5px;
     text-align: center;
 
     // close-icon
@@ -26,8 +26,12 @@
 
   .dividerLine {
     width: 197px;
-    margin: 4px 1px 5px 12px;
+    margin: -4px 1px 0 9px;
     border: solid 1px #979797;
+  }
+
+  :global(.MuiDialogActions-root) {
+    padding: 5px;
   }
 
   .boundaryOption {

--- a/js/components/boundary-config-dialog.tsx
+++ b/js/components/boundary-config-dialog.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react";
 import * as React from "react";
 import Draggable from "react-draggable";
 import Dialog from "@mui/material/Dialog";
@@ -5,37 +6,40 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import Paper, { PaperProps } from "@mui/material/Paper";
-import { BoundaryOrientation, BoundaryType, IBoundaryInfo } from "../types";
+import { BoundaryOrientation, BoundaryType, IBoundaryInfo, IEventCoords } from "../types";
 import CloseIcon from "../../images/rock-key/svg/close-icon.svg";
 import BoundarySvg from "../../images/boundary.svg";
 import PlateArrow from "../../images/plate-arrow.svg";
 
 import css from "../../css-modules/boundary-config-dialog.less";
 
-function PaperComponent(props: PaperProps) {
-  return (
-    <Draggable
-      handle="#draggable-dialog-title"
-      cancel={'[class*="MuiDialogContent-root"]'}
-    >
-      <Paper {...props} />
-    </Draggable>
-  );
-}
-
 interface IProps {
-  open: boolean;
-  boundary: IBoundaryInfo;
+  boundary: IBoundaryInfo | null;
+  offset: IEventCoords;
   getPlateHue: (plateId?: number) => number | undefined;
   onAssign: (type: BoundaryType) => void;
   onClose: () => void;
 }
 // patterned after https://mui.com/components/dialogs/#draggable-dialog
-const BoundaryConfigDialog = ({ open, boundary, getPlateHue, onAssign, onClose }: IProps) => {
-  return (
+const BoundaryConfigDialog = ({ boundary, offset, getPlateHue, onAssign, onClose }: IProps) => {
+
+  function PaperComponent(props: PaperProps) {
+    return (
+      <Draggable
+        defaultPosition={offset}
+        bounds=".planet-wizard"
+        handle="#draggable-dialog-title"
+        cancel={'[class*="MuiDialogContent-root"]'}
+      >
+        <Paper {...props} />
+      </Draggable>
+    );
+  }
+
+  return (boundary &&
     <Dialog
       className={css.boundaryConfigDialog}
-      open={open}
+      open={!!boundary}
       onClose={onClose}
       PaperComponent={PaperComponent}
       aria-labelledby="draggable-dialog-title"
@@ -106,7 +110,9 @@ interface IBoundaryOption {
   getPlateHue: (plateId?: number) => number | undefined;
   onAssign: (type: BoundaryType) => void;
 }
-const BoundaryOption = ({ boundary, type, getPlateHue, onAssign }: IBoundaryOption) => {
+// observer so it updates when boundary type changes; if we pass a new boundary prop instead
+// the entire dialog rerenders and the dialog reverts to its default position.
+const BoundaryOption = observer(({ boundary, type, getPlateHue, onAssign }: IBoundaryOption) => {
   const selectedClass = type === boundary.type ? css.selected : "";
   const plate0Hue = getPlateHue(boundary.fields?.[0].plate.id) ?? plateHues[0];
   const plate1Hue = getPlateHue(boundary.fields?.[1].plate.id) ?? plateHues[1];
@@ -139,4 +145,4 @@ const BoundaryOption = ({ boundary, type, getPlateHue, onAssign }: IBoundaryOpti
       }
     </div>
   );
-};
+});

--- a/js/components/planet-view.tsx
+++ b/js/components/planet-view.tsx
@@ -5,12 +5,12 @@ import Caveat from "./caveat-notice";
 import InteractionSelector from "./interaction-selector";
 import SmallButton from "./small-button";
 import GlobeInteractionsManager from "../plates-interactions/globe-interactions-manager";
+import { IPlanetClickData } from "../plates-interactions/planet-click";
 import CanvasPlanetView from "../plates-view/planet-view";
 import TimeDisplay from "./time-display";
 import { CROSS_SECTION_TRANSITION_LENGTH } from "./cross-section";
 import { BaseComponent, IBaseProps } from "./base";
 import config from "../config";
-import * as THREE from "three";
 
 interface IState {}
 
@@ -79,33 +79,35 @@ export default class PlanetView extends BaseComponent<IBaseProps, IState> {
     this.interactions.on("forceDrawingEnd", (data: any) => {
       simulationStore?.setHotSpot(data);
     });
-    this.interactions.on("markField", (position: THREE.Vector3) => {
-      simulationStore?.markField(position);
+    this.interactions.on("markField", ({ globePosition }: IPlanetClickData) => {
+      simulationStore?.markField(globePosition);
     });
-    this.interactions.on("fieldInfo", (position: THREE.Vector3) => {
-      simulationStore?.getFieldInfo(position);
+    this.interactions.on("fieldInfo", ({ globePosition }: IPlanetClickData) => {
+      simulationStore?.getFieldInfo(globePosition);
     });
-    this.interactions.on("assignBoundary", () => {
-      simulationStore?.setSelectedBoundary();
+    this.interactions.on("assignBoundary", ({ globePosition, screenPosition }: IPlanetClickData) => {
+      // make sure the appropriate segment is highlighted
+      simulationStore?.highlightBoundarySegment(globePosition);
+      simulationStore?.setSelectedBoundary(screenPosition);
     });
-    this.interactions.on("takeRockSampleFromSurface", (position: THREE.Vector3) => {
-      simulationStore?.takeRockSampleFromSurface(position);
+    this.interactions.on("takeRockSampleFromSurface", ({ globePosition }: IPlanetClickData) => {
+      simulationStore?.takeRockSampleFromSurface(globePosition);
       simulationStore?.setSelectedRockFlash(true);
     });
-    this.interactions.on("continentDrawing", (position: THREE.Vector3) => {
-      simulationStore?.drawContinent(position);
+    this.interactions.on("continentDrawing", ({ globePosition }: IPlanetClickData) => {
+      simulationStore?.drawContinent(globePosition);
     });
     this.interactions.on("continentDrawingEnd", () => {
       simulationStore?.markIslands();
     });
-    this.interactions.on("continentErasing", (position: THREE.Vector3) => {
-      simulationStore?.eraseContinent(position);
+    this.interactions.on("continentErasing", ({ globePosition }: IPlanetClickData) => {
+      simulationStore?.eraseContinent(globePosition);
     });
     this.interactions.on("continentErasingEnd", () => {
       simulationStore?.markIslands();
     });
-    this.interactions.on("highlightBoundarySegment", (position: THREE.Vector3) => {
-      simulationStore?.highlightBoundarySegment(position);
+    this.interactions.on("highlightBoundarySegment", ({ globePosition }: IPlanetClickData) => {
+      simulationStore?.highlightBoundarySegment(globePosition);
     });
   }
 

--- a/js/components/planet-view.tsx
+++ b/js/components/planet-view.tsx
@@ -85,10 +85,10 @@ export default class PlanetView extends BaseComponent<IBaseProps, IState> {
     this.interactions.on("fieldInfo", ({ globePosition }: IPlanetClickData) => {
       simulationStore?.getFieldInfo(globePosition);
     });
-    this.interactions.on("assignBoundary", ({ globePosition, screenPosition }: IPlanetClickData) => {
+    this.interactions.on("assignBoundary", ({ globePosition, canvasPosition }: IPlanetClickData) => {
       // make sure the appropriate segment is highlighted
       simulationStore?.highlightBoundarySegment(globePosition);
-      simulationStore?.setSelectedBoundary(screenPosition);
+      simulationStore?.setSelectedBoundary(canvasPosition);
     });
     this.interactions.on("takeRockSampleFromSurface", ({ globePosition }: IPlanetClickData) => {
       simulationStore?.takeRockSampleFromSurface(globePosition);

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -48,14 +48,18 @@ export const STEPS_DATA: Record<string, IStepsData> = {
 const STEPS = config.preset || config.modelId
   ? config.planetWizardSteps.filter((stepName: string) => stepName !== "presets") : config.planetWizardSteps;
 
+interface IProps extends IBaseProps {
+  forwardedRef: React.ForwardedRef<HTMLDivElement | null>;
+}
+
 interface IState {
   step: number;
 }
 
 @inject("simulationStore")
 @observer
-export default class PlanetWizard extends BaseComponent<IBaseProps, IState> {
-  constructor(props: IBaseProps) {
+class PlanetWizard extends BaseComponent<IProps, IState> {
+  constructor(props: IProps) {
     super(props);
     this.state = {
       step: 0
@@ -232,7 +236,7 @@ export default class PlanetWizard extends BaseComponent<IBaseProps, IState> {
     const backDisabled = this.navigationDisabled || step === 0;
     const nextDisabled = this.navigationDisabled || this.nextButtonDisabled;
     return (
-      <div className="planet-wizard">
+      <div className="planet-wizard" ref={this.props.forwardedRef}>
         {
           stepName === "presets" &&
           <div className="planet-wizard-overlay step-plates" data-test="plate-num-options">
@@ -263,3 +267,10 @@ export default class PlanetWizard extends BaseComponent<IBaseProps, IState> {
     );
   }
 }
+
+// https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools
+function forwardRef(props: React.PropsWithChildren<IBaseProps>, ref: React.ForwardedRef<HTMLDivElement>) {
+  return <PlanetWizard forwardedRef={ref} {...props}/>;
+}
+forwardRef.displayName = PlanetWizard.name;
+export default React.forwardRef<HTMLDivElement>(forwardRef);

--- a/js/components/simulation.tsx
+++ b/js/components/simulation.tsx
@@ -41,6 +41,27 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
       </div>);
   }
 
+  getDialogOffset() {
+    const { selectedBoundary } = this.simulationStore;
+    const { screenPos } = selectedBoundary || {};
+    const topBarHeight = 20;
+    const dialogSize = { width: 250, height: 150 };
+    const dialogOffset = { x: 150, y: -100 };
+    if (screenPos) {
+      const planetWizardElt = document.querySelector(".planet-wizard");
+      const bounds = planetWizardElt?.getBoundingClientRect();
+      if (bounds) {
+        // adjust offset based on position of boundary click
+        dialogOffset.x += screenPos.x - bounds.width / 2;
+        dialogOffset.y += screenPos.y - bounds.height / 2;
+        // keep it in visible bounds
+        dialogOffset.x = Math.min(dialogOffset.x, (bounds.width - dialogSize.width) / 2);
+        dialogOffset.y = Math.max(dialogOffset.y, topBarHeight - (bounds.height - dialogSize.height) / 2);
+      }
+    }
+    return dialogOffset;
+  }
+
   getPlateHue = (plateId?: number) => {
     const plate = plateId != null ? this.simulationStore.model.getPlate(plateId) : undefined;
     return plate?.hue;
@@ -73,7 +94,7 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
         {
           selectedBoundary &&
           <BoundaryConfigDialog
-            open={!!selectedBoundary} boundary={selectedBoundary} getPlateHue={this.getPlateHue}
+            boundary={selectedBoundary} offset={this.getDialogOffset()} getPlateHue={this.getPlateHue}
             onAssign={this.handleAssign} onClose={this.handleClose}
           />
         }

--- a/js/components/simulation.tsx
+++ b/js/components/simulation.tsx
@@ -25,6 +25,8 @@ interface IState {}
 @inject("simulationStore")
 @observer
 export default class Simulation extends BaseComponent<IBaseProps, IState> {
+  private canvasRef = React.createRef<HTMLDivElement>();
+
   componentDidMount() {
     enableShutterbug(APP_CLASS_NAME);
   }
@@ -43,17 +45,16 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
 
   getDialogOffset() {
     const { selectedBoundary } = this.simulationStore;
-    const { screenPos } = selectedBoundary || {};
+    const { canvasClickPos } = selectedBoundary || {};
     const topBarHeight = 20;
     const dialogSize = { width: 250, height: 150 };
     const dialogOffset = { x: 150, y: -100 };
-    if (screenPos) {
-      const planetWizardElt = document.querySelector(".planet-wizard");
-      const bounds = planetWizardElt?.getBoundingClientRect();
+    if (canvasClickPos) {
+      const bounds = this.canvasRef.current?.getBoundingClientRect();
       if (bounds) {
         // adjust offset based on position of boundary click
-        dialogOffset.x += screenPos.x - bounds.width / 2;
-        dialogOffset.y += screenPos.y - bounds.height / 2;
+        dialogOffset.x += canvasClickPos.x - bounds.width / 2;
+        dialogOffset.y += canvasClickPos.y - bounds.height / 2;
         // keep it in visible bounds
         dialogOffset.x = Math.min(dialogOffset.x, (bounds.width - dialogSize.width) / 2);
         dialogOffset.y = Math.max(dialogOffset.y, topBarHeight - (bounds.height - dialogSize.height) / 2);
@@ -90,7 +91,7 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
           { !planetWizard && <BottomPanel /> }
         </div>
         <ColorKey />
-        { planetWizard && <PlanetWizard /> }
+        { planetWizard && <PlanetWizard ref={this.canvasRef}/> }
         {
           selectedBoundary &&
           <BoundaryConfigDialog

--- a/js/plates-interactions/base-interactions-manager.ts
+++ b/js/plates-interactions/base-interactions-manager.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import $ from "jquery";
 import { EventEmitter2 } from "eventemitter2";
-import { IInteractionHandler, mousePosNormalized } from "./helpers";
+import { IInteractionHandler, mousePos, mousePosNormalized } from "./helpers";
 
 const NAMESPACE = "interactions-manager";
 
@@ -74,23 +74,26 @@ export class BaseInteractionsManager {
     $elem.on(`pointerdown.${NAMESPACE}`, (event) => {
       this.view.controls.enableRotate = true;
       if (interaction.onPointerDown) {
-        const pos = mousePosNormalized(event, this.view.domElement);
-        this.raycaster.setFromCamera(pos, this.view.camera);
-        this.view.controls.enableRotate = !interaction.onPointerDown();
+        const screenPos = mousePos(event, this.view.domElement);
+        const globePos = mousePosNormalized(event, this.view.domElement);
+        this.raycaster.setFromCamera(globePos, this.view.camera);
+        this.view.controls.enableRotate = !interaction.onPointerDown(screenPos);
       }
     });
     $elem.on(`pointermove.${NAMESPACE}`, (event) => {
       if (interaction.onPointerMove) {
-        const pos = mousePosNormalized(event, this.view.domElement);
-        this.raycaster.setFromCamera(pos, this.view.camera);
-        interaction.onPointerMove();
+        const screenPos = mousePos(event, this.view.domElement);
+        const globePos = mousePosNormalized(event, this.view.domElement);
+        this.raycaster.setFromCamera(globePos, this.view.camera);
+        interaction.onPointerMove(screenPos);
       }
     });
     $elem.on(`pointerup.${NAMESPACE} pointercancel.${NAMESPACE}`, (event) => {
       if (interaction.onPointerUp) {
-        const pos = mousePosNormalized(event, this.view.domElement);
-        this.raycaster.setFromCamera(pos, this.view.camera);
-        interaction.onPointerUp();
+        const screenPos = mousePos(event, this.view.domElement);
+        const globePos = mousePosNormalized(event, this.view.domElement);
+        this.raycaster.setFromCamera(globePos, this.view.camera);
+        interaction.onPointerUp(screenPos);
       }
       this.view.controls.enableRotate = true;
     });

--- a/js/plates-interactions/base-interactions-manager.ts
+++ b/js/plates-interactions/base-interactions-manager.ts
@@ -74,26 +74,26 @@ export class BaseInteractionsManager {
     $elem.on(`pointerdown.${NAMESPACE}`, (event) => {
       this.view.controls.enableRotate = true;
       if (interaction.onPointerDown) {
-        const screenPos = mousePos(event, this.view.domElement);
+        const canvasPos = mousePos(event, this.view.domElement);
         const globePos = mousePosNormalized(event, this.view.domElement);
         this.raycaster.setFromCamera(globePos, this.view.camera);
-        this.view.controls.enableRotate = !interaction.onPointerDown(screenPos);
+        this.view.controls.enableRotate = !interaction.onPointerDown(canvasPos);
       }
     });
     $elem.on(`pointermove.${NAMESPACE}`, (event) => {
       if (interaction.onPointerMove) {
-        const screenPos = mousePos(event, this.view.domElement);
+        const canvasPos = mousePos(event, this.view.domElement);
         const globePos = mousePosNormalized(event, this.view.domElement);
         this.raycaster.setFromCamera(globePos, this.view.camera);
-        interaction.onPointerMove(screenPos);
+        interaction.onPointerMove(canvasPos);
       }
     });
     $elem.on(`pointerup.${NAMESPACE} pointercancel.${NAMESPACE}`, (event) => {
       if (interaction.onPointerUp) {
-        const screenPos = mousePos(event, this.view.domElement);
+        const canvasPos = mousePos(event, this.view.domElement);
         const globePos = mousePosNormalized(event, this.view.domElement);
         this.raycaster.setFromCamera(globePos, this.view.camera);
-        interaction.onPointerUp(screenPos);
+        interaction.onPointerUp(canvasPos);
       }
       this.view.controls.enableRotate = true;
     });

--- a/js/plates-interactions/helpers.ts
+++ b/js/plates-interactions/helpers.ts
@@ -1,14 +1,15 @@
 import $ from "jquery";
 import RockSampleCursorSrc from "../../images/rock-sample-cursor.png";
+import { IEventCoords } from "../types";
 
 export const TakeRockSampleCursor = `url("${RockSampleCursorSrc}") 16 42, crosshair`;
 
 export interface IInteractionHandler {
   setActive: () => void;
   setInactive: () => void;
-  onPointerDown?: () => boolean;
-  onPointerMove?: () => void;
-  onPointerUp?: () => void;
+  onPointerDown?: (pos: IEventCoords) => boolean;
+  onPointerMove?: (pos: IEventCoords) => void;
+  onPointerUp?: (pos: IEventCoords) => void;
   setScreenWidth?: (width: number) => void;
 }
 

--- a/js/plates-interactions/planet-click.ts
+++ b/js/plates-interactions/planet-click.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { IEventCoords } from "../types";
 
 interface IPlanetClickOptions {
   getIntersection: (mesh: THREE.Mesh) => THREE.Intersection;
@@ -10,11 +11,16 @@ interface IPlanetClickOptions {
   alwaysEmitMoveEvent?: boolean;
 }
 
+export interface IPlanetClickData {
+  screenPosition: IEventCoords;
+  globePosition: THREE.Vector3;
+}
+
 // Generic helper that detects click on the planet surface and emits an event with provided name.
 export default class PlanetClick {
   earthMesh: any;
   getIntersection: (mesh: THREE.Mesh) => THREE.Intersection;
-  emit: (event: string, data?: any) => void;
+  emit: (event: string, data?: IPlanetClickData) => void;
   startEventName?: string;
   moveEventName?: string;
   endEventName?: string;
@@ -45,7 +51,7 @@ export default class PlanetClick {
     document.body.style.cursor = "auto";
   }
 
-  onPointerDown() {
+  onPointerDown(screenPosition: IEventCoords) {
     if (!this.startEventName) {
       return false;
     }
@@ -53,12 +59,12 @@ export default class PlanetClick {
     if (!intersection) {
       return false;
     }
-    this.emit(this.startEventName, intersection.point);
+    this.emit(this.startEventName, { screenPosition, globePosition: intersection.point });
     this.pointerDown = true;
     return true;
   }
 
-  onPointerMove() {
+  onPointerMove(screenPosition: IEventCoords) {
     if ((!this.alwaysEmitMoveEvent && !this.pointerDown) || !this.moveEventName) {
       return;
     }
@@ -66,7 +72,7 @@ export default class PlanetClick {
     if (!intersection) {
       return;
     }
-    this.emit(this.moveEventName, intersection.point);
+    this.emit(this.moveEventName, { screenPosition, globePosition: intersection.point });
   }
 
   onPointerUp() {

--- a/js/plates-interactions/planet-click.ts
+++ b/js/plates-interactions/planet-click.ts
@@ -12,7 +12,7 @@ interface IPlanetClickOptions {
 }
 
 export interface IPlanetClickData {
-  screenPosition: IEventCoords;
+  canvasPosition: IEventCoords;
   globePosition: THREE.Vector3;
 }
 
@@ -51,7 +51,7 @@ export default class PlanetClick {
     document.body.style.cursor = "auto";
   }
 
-  onPointerDown(screenPosition: IEventCoords) {
+  onPointerDown(canvasPosition: IEventCoords) {
     if (!this.startEventName) {
       return false;
     }
@@ -59,12 +59,12 @@ export default class PlanetClick {
     if (!intersection) {
       return false;
     }
-    this.emit(this.startEventName, { screenPosition, globePosition: intersection.point });
+    this.emit(this.startEventName, { canvasPosition, globePosition: intersection.point });
     this.pointerDown = true;
     return true;
   }
 
-  onPointerMove(screenPosition: IEventCoords) {
+  onPointerMove(canvasPosition: IEventCoords) {
     if ((!this.alwaysEmitMoveEvent && !this.pointerDown) || !this.moveEventName) {
       return;
     }
@@ -72,7 +72,7 @@ export default class PlanetClick {
     if (!intersection) {
       return;
     }
-    this.emit(this.moveEventName, { screenPosition, globePosition: intersection.point });
+    this.emit(this.moveEventName, { canvasPosition, globePosition: intersection.point });
   }
 
   onPointerUp() {

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -13,7 +13,7 @@ import { IWorkerProps } from "../plates-model/model-worker";
 import { ICrossSectionOutput, IModelOutput } from "../plates-model/model-output";
 import { IGlobeInteractionName } from "../plates-interactions/globe-interactions-manager";
 import { ICrossSectionInteractionName } from "../plates-interactions/cross-section-interactions-manager";
-import { BoundaryType, IBoundaryInfo, IHotSpot, IVec3Array, RockKeyLabel } from "../types";
+import { BoundaryType, IBoundaryInfo, IEventCoords, IHotSpot, IVec3Array, RockKeyLabel } from "../types";
 import { ISerializedModel } from "../plates-model/model";
 import getGrid from "../plates-model/grid";
 import { rockProps } from "../plates-model/rock-properties";
@@ -409,7 +409,7 @@ export class SimulationStore {
     this.selectedBoundary = null;
   }
 
-  @action.bound setSelectedBoundary() {
+  @action.bound setSelectedBoundary(screenPosition: IEventCoords) {
     if (this.highlightedBoundaries.length !== 2) {
       this.selectedBoundary = null;
       return;
@@ -417,13 +417,13 @@ export class SimulationStore {
     const highlightedBoundaryField1 = this.highlightedBoundaries[0];
     const highlightedBoundaryField2 = this.highlightedBoundaries[1];
     const boundary = getBoundaryInfo(highlightedBoundaryField1, highlightedBoundaryField2, this.model) || null;
+    boundary && (boundary.screenPos = screenPosition);
     this.selectedBoundary = boundary;
   }
 
   @action.bound setSelectedBoundaryType(type: BoundaryType) {
     if (this.selectedBoundary?.orientation) {
-      // TODO: represent convergent/divergent in the model, e.g. isConvergent property
-      this.selectedBoundary = { ...this.selectedBoundary, type };
+      this.selectedBoundary.type = type;
       this.anyBoundaryDefinedByUser = true;
       convertBoundaryTypeToHotSpots(this.selectedBoundary).forEach(hotSpot => this.setHotSpot(hotSpot));
     }

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -409,7 +409,7 @@ export class SimulationStore {
     this.selectedBoundary = null;
   }
 
-  @action.bound setSelectedBoundary(screenPosition: IEventCoords) {
+  @action.bound setSelectedBoundary(canvasPosition: IEventCoords) {
     if (this.highlightedBoundaries.length !== 2) {
       this.selectedBoundary = null;
       return;
@@ -417,7 +417,7 @@ export class SimulationStore {
     const highlightedBoundaryField1 = this.highlightedBoundaries[0];
     const highlightedBoundaryField2 = this.highlightedBoundaries[1];
     const boundary = getBoundaryInfo(highlightedBoundaryField1, highlightedBoundaryField2, this.model) || null;
-    boundary && (boundary.screenPos = screenPosition);
+    boundary && (boundary.canvasClickPos = canvasPosition);
     this.selectedBoundary = boundary;
   }
 

--- a/js/types.ts
+++ b/js/types.ts
@@ -32,7 +32,7 @@ export interface IBoundaryInfo {
   fields: [FieldStore, FieldStore];
   orientation: BoundaryOrientation;
   type: BoundaryType | undefined;
-  screenPos?: IEventCoords; // position of boundary click
+  canvasClickPos?: IEventCoords; // position of boundary click in canvas
 }
 
 export interface IHotSpot {

--- a/js/types.ts
+++ b/js/types.ts
@@ -6,6 +6,11 @@ export interface IVector3 {
   z: number;
 }
 
+export interface IEventCoords {
+  x: number;
+  y: number;
+}
+
 export type IVec3Array = [number, number, number] | number[];
 
 export type IQuaternionArray = [number, number, number, number] | number[];
@@ -27,9 +32,10 @@ export interface IBoundaryInfo {
   fields: [FieldStore, FieldStore];
   orientation: BoundaryOrientation;
   type: BoundaryType | undefined;
+  screenPos?: IEventCoords; // position of boundary click
 }
 
 export interface IHotSpot {
- position: THREE.Vector3;
- force: THREE.Vector3;
+  position: THREE.Vector3;
+  force: THREE.Vector3;
 }


### PR DESCRIPTION
Positions the boundary assignment dialog above and to the right of the location of the click rather than in the center of the screen, so that it is less likely to cover up the boundary the user is interested in as well as the force arrows. Prevents the dialog from being dragged out of the visible area. Also tweaks the styling to match the spec better.

Demo: https://tectonic-explorer.concord.org/branch/boundary-dialog-position/index.html