### PR TITLE
Add rock patters to the globe view

### DIFF
--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -1,6 +1,6 @@
 // Slightly modified Phong shader taken from THREE.ShaderLib:
 // https://github.com/mrdoob/three.js/blob/0c51e577afd011aea8d635db2eeb9185b3999889/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
-// It supports alpha channel in color attribut (vec4 is used instead of vec3) + a few custom features like 
+// It supports alpha channel in color attribut (vec4 is used instead of vec3) + a few custom features like
 // hiding vertices, colormap texture, and so on. Custom code is always enclosed in // --- CUSTOM comment.
 
 // --- CUSTOM:
@@ -9,6 +9,9 @@ varying float vHidden;
 varying float vColormapValue;
 
 uniform sampler2D colormap;
+// Keep array length equal to number of rock patterns.
+uniform sampler2D patterns[7];
+uniform bool usePatterns;
 // ---
 #define PHONG
 uniform vec3 diffuse;
@@ -102,6 +105,22 @@ void main() {
     // Use specific color provided in color attribute. For example plate boundary color.
     // Note that rendering only for alpha > X (e.g. 0.75 or 0.5) makes this color line thinner.
     diffuseColor *= vec4(vColor.r, vColor.g, vColor.b, 1.0);
+  } else if (usePatterns == true) {
+    if (round(vColormapValue) == 0.0) {
+      diffuseColor *= texture2D(patterns[0], vec2(vUv.x * 100.0, vUv.y * 100.0));
+    } else if (round(vColormapValue) == 1.0) {
+      diffuseColor *= texture2D(patterns[1], vec2(vUv.x * 100.0, vUv.y * 100.0));
+    } else if (round(vColormapValue) == 2.0) {
+      diffuseColor *= texture2D(patterns[2], vec2(vUv.x * 100.0, vUv.y * 100.0));
+    } else if (round(vColormapValue) == 3.0) {
+      diffuseColor *= texture2D(patterns[3], vec2(vUv.x * 100.0, vUv.y * 100.0));
+    } else if (round(vColormapValue) == 4.0) {
+      diffuseColor *= texture2D(patterns[4], vec2(vUv.x * 100.0, vUv.y * 100.0));
+    } else if (round(vColormapValue) == 5.0) {
+      diffuseColor *= texture2D(patterns[5], vec2(vUv.x * 100.0, vUv.y * 100.0));
+    } else if (round(vColormapValue) == 6.0) {
+      diffuseColor *= texture2D(patterns[6], vec2(vUv.x * 100.0, vUv.y * 100.0));
+    }
   } else {
     // Use the default colormap if vColor is transparent.
     diffuseColor *= texture2D(colormap, vec2(0.5, vColormapValue));

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -7,6 +7,7 @@
 varying vec4 vColor;
 varying float vHidden;
 varying float vColormapValue;
+flat varying float vPatternIdx;
 
 uniform sampler2D colormap;
 // Keep array length equal to number of rock patterns.
@@ -106,19 +107,19 @@ void main() {
     // Note that rendering only for alpha > X (e.g. 0.75 or 0.5) makes this color line thinner.
     diffuseColor *= vec4(vColor.r, vColor.g, vColor.b, 1.0);
   } else if (usePatterns == true) {
-    if (round(vColormapValue) == 0.0) {
+    if (round(vPatternIdx) == 0.0) {
       diffuseColor *= texture2D(patterns[0], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vColormapValue) == 1.0) {
+    } else if (round(vPatternIdx) == 1.0) {
       diffuseColor *= texture2D(patterns[1], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vColormapValue) == 2.0) {
+    } else if (round(vPatternIdx) == 2.0) {
       diffuseColor *= texture2D(patterns[2], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vColormapValue) == 3.0) {
+    } else if (round(vPatternIdx) == 3.0) {
       diffuseColor *= texture2D(patterns[3], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vColormapValue) == 4.0) {
+    } else if (round(vPatternIdx) == 4.0) {
       diffuseColor *= texture2D(patterns[4], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vColormapValue) == 5.0) {
+    } else if (round(vPatternIdx) == 5.0) {
       diffuseColor *= texture2D(patterns[5], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vColormapValue) == 6.0) {
+    } else if (round(vPatternIdx) == 6.0) {
       diffuseColor *= texture2D(patterns[6], vec2(vUv.x * 100.0, vUv.y * 100.0));
     }
   } else {

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -7,11 +7,12 @@
 varying vec4 vColor;
 varying float vHidden;
 varying float vColormapValue;
-flat varying float vPatternIdx;
+flat in int vPatternIdx;
 
 uniform sampler2D colormap;
 // Keep array length equal to number of rock patterns.
-uniform sampler2D patterns[7];
+uniform sampler2D patterns[11];
+uniform float patternScale[11];
 uniform bool usePatterns;
 // ---
 #define PHONG
@@ -107,20 +108,32 @@ void main() {
     // Note that rendering only for alpha > X (e.g. 0.75 or 0.5) makes this color line thinner.
     diffuseColor *= vec4(vColor.r, vColor.g, vColor.b, 1.0);
   } else if (usePatterns == true) {
-    if (round(vPatternIdx) == 0.0) {
-      diffuseColor *= texture2D(patterns[0], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vPatternIdx) == 1.0) {
-      diffuseColor *= texture2D(patterns[1], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vPatternIdx) == 2.0) {
-      diffuseColor *= texture2D(patterns[2], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vPatternIdx) == 3.0) {
-      diffuseColor *= texture2D(patterns[3], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vPatternIdx) == 4.0) {
-      diffuseColor *= texture2D(patterns[4], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vPatternIdx) == 5.0) {
-      diffuseColor *= texture2D(patterns[5], vec2(vUv.x * 100.0, vUv.y * 100.0));
-    } else if (round(vPatternIdx) == 6.0) {
-      diffuseColor *= texture2D(patterns[6], vec2(vUv.x * 100.0, vUv.y * 100.0));
+    // This doesn't look convincing, but unfortunatelly that's the only way to do it in GLSL (=> version supported by
+    // WebGL to be more speciifc). It's impossible to simply say:
+    // `texture2D(patterns[vPatternIdx], vUv * patternScale[vPatternIdx]);`
+    // GLSL compiler returns an error saying that "array index for samplers must be constant integral expressions".
+    if (vPatternIdx == 0) {
+      diffuseColor *= texture2D(patterns[0], vUv * patternScale[0]);
+    } else if (vPatternIdx == 1) {
+      diffuseColor *= texture2D(patterns[1], vUv * patternScale[1]);
+    } else if (vPatternIdx == 2) {
+      diffuseColor *= texture2D(patterns[2], vUv * patternScale[2]);
+    } else if (vPatternIdx == 3) {
+      diffuseColor *= texture2D(patterns[3], vUv * patternScale[3]);
+    } else if (vPatternIdx == 4) {
+      diffuseColor *= texture2D(patterns[4], vUv * patternScale[4]);
+    } else if (vPatternIdx == 5) {
+      diffuseColor *= texture2D(patterns[5], vUv * patternScale[5]);
+    } else if (vPatternIdx == 6) {
+      diffuseColor *= texture2D(patterns[6], vUv * patternScale[6]);
+    } else if (vPatternIdx == 7) {
+      diffuseColor *= texture2D(patterns[7], vUv * patternScale[7]);
+    } else if (vPatternIdx == 8) {
+      diffuseColor *= texture2D(patterns[8], vUv * patternScale[8]);
+    } else if (vPatternIdx == 9) {
+      diffuseColor *= texture2D(patterns[9], vUv * patternScale[9]);
+    } else if (vPatternIdx == 10) {
+      diffuseColor *= texture2D(patterns[10], vUv * patternScale[10]);
     }
   } else {
     // Use the default colormap if vColor is transparent.

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -108,7 +108,7 @@ void main() {
     // Note that rendering only for alpha > X (e.g. 0.75 or 0.5) makes this color line thinner.
     diffuseColor *= vec4(vColor.r, vColor.g, vColor.b, 1.0);
   } else if (usePatterns == true) {
-    // This doesn't look convincing, but unfortunatelly that's the only way to do it in GLSL (=> version supported by
+    // This doesn't look convincing, but unfortunately that's the only way to do it in GLSL (=> version supported by
     // WebGL to be more speciifc). It's impossible to simply say:
     // `texture2D(patterns[vPatternIdx], vUv * patternScale[vPatternIdx]);`
     // GLSL compiler returns an error saying that "array index for samplers must be constant integral expressions".

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -112,28 +112,18 @@ void main() {
     // WebGL to be more specific). It's impossible to simply say:
     // `texture2D(patterns[vPatternIdx], vUv * patternScale[vPatternIdx]);`
     // GLSL compiler returns an error saying that "array index for samplers must be constant integral expressions".
-    if (vPatternIdx == 0) {
-      diffuseColor *= texture2D(patterns[0], vUv * patternScale[0]);
-    } else if (vPatternIdx == 1) {
-      diffuseColor *= texture2D(patterns[1], vUv * patternScale[1]);
-    } else if (vPatternIdx == 2) {
-      diffuseColor *= texture2D(patterns[2], vUv * patternScale[2]);
-    } else if (vPatternIdx == 3) {
-      diffuseColor *= texture2D(patterns[3], vUv * patternScale[3]);
-    } else if (vPatternIdx == 4) {
-      diffuseColor *= texture2D(patterns[4], vUv * patternScale[4]);
-    } else if (vPatternIdx == 5) {
-      diffuseColor *= texture2D(patterns[5], vUv * patternScale[5]);
-    } else if (vPatternIdx == 6) {
-      diffuseColor *= texture2D(patterns[6], vUv * patternScale[6]);
-    } else if (vPatternIdx == 7) {
-      diffuseColor *= texture2D(patterns[7], vUv * patternScale[7]);
-    } else if (vPatternIdx == 8) {
-      diffuseColor *= texture2D(patterns[8], vUv * patternScale[8]);
-    } else if (vPatternIdx == 9) {
-      diffuseColor *= texture2D(patterns[9], vUv * patternScale[9]);
-    } else if (vPatternIdx == 10) {
-      diffuseColor *= texture2D(patterns[10], vUv * patternScale[10]);
+    switch (vPatternIdx) {
+      case 0: diffuseColor *= texture2D(patterns[0], vUv * patternScale[0]); break;
+      case 1: diffuseColor *= texture2D(patterns[1], vUv * patternScale[1]); break;
+      case 2: diffuseColor *= texture2D(patterns[2], vUv * patternScale[2]); break;
+      case 3: diffuseColor *= texture2D(patterns[3], vUv * patternScale[3]); break;
+      case 4: diffuseColor *= texture2D(patterns[4], vUv * patternScale[4]); break;
+      case 5: diffuseColor *= texture2D(patterns[5], vUv * patternScale[5]); break;
+      case 6: diffuseColor *= texture2D(patterns[6], vUv * patternScale[6]); break;
+      case 7: diffuseColor *= texture2D(patterns[7], vUv * patternScale[7]); break;
+      case 8: diffuseColor *= texture2D(patterns[8], vUv * patternScale[8]); break;
+      case 9: diffuseColor *= texture2D(patterns[9], vUv * patternScale[9]); break;
+      case 10: diffuseColor *= texture2D(patterns[10], vUv * patternScale[10]); break;
     }
   } else {
     // Use the default colormap if vColor is transparent.

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -109,7 +109,7 @@ void main() {
     diffuseColor *= vec4(vColor.r, vColor.g, vColor.b, 1.0);
   } else if (usePatterns == true) {
     // This doesn't look convincing, but unfortunately that's the only way to do it in GLSL (=> version supported by
-    // WebGL to be more speciifc). It's impossible to simply say:
+    // WebGL to be more specific). It's impossible to simply say:
     // `texture2D(patterns[vPatternIdx], vUv * patternScale[vPatternIdx]);`
     // GLSL compiler returns an error saying that "array index for samplers must be constant integral expressions".
     if (vPatternIdx == 0) {

--- a/js/plates-view/plate-mesh-fragment.glsl
+++ b/js/plates-view/plate-mesh-fragment.glsl
@@ -1,6 +1,6 @@
 // Slightly modified Phong shader taken from THREE.ShaderLib:
 // https://github.com/mrdoob/three.js/blob/0c51e577afd011aea8d635db2eeb9185b3999889/src/renderers/shaders/ShaderLib/meshphong_frag.glsl.js
-// It supports alpha channel in color attribut (vec4 is used instead of vec3) + a few custom features like
+// It supports alpha channel in color attribute (vec4 is used instead of vec3) + a few custom features like
 // hiding vertices, colormap texture, and so on. Custom code is always enclosed in // --- CUSTOM comment.
 
 // --- CUSTOM:

--- a/js/plates-view/plate-mesh-vertex.glsl
+++ b/js/plates-view/plate-mesh-vertex.glsl
@@ -1,6 +1,6 @@
 // Slightly modified Phong shader taken from THREE.ShaderLib.
 // https://github.com/mrdoob/three.js/blob/0c51e577afd011aea8d635db2eeb9185b3999889/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
-// It supports alpha channel in color attribut (vec4 is used instead of vec3) + a few custom features like 
+// It supports alpha channel in color attribut (vec4 is used instead of vec3) + a few custom features like
 // hiding vertices, colormap texture, and so on. Custom code is always enclosed in // --- CUSTOM comment.
 
 // --- CUSTOM:
@@ -9,11 +9,13 @@ attribute vec4 color;
 attribute float hidden;
 attribute float vertexBumpScale;
 attribute float colormapValue;
+attribute float patternIdx;
 
 varying vec4 vColor;
 varying float vHidden;
 varying float vBumpScale;
 varying float vColormapValue;
+flat varying float vPatternIdx;
 // ---
 
 #define PHONG
@@ -40,6 +42,7 @@ void main() {
   vBumpScale = vertexBumpScale;
   vHidden = hidden;
   vColormapValue = colormapValue;
+  vPatternIdx = patternIdx;
   // ---
 
 	#include <uv_vertex>

--- a/js/plates-view/plate-mesh-vertex.glsl
+++ b/js/plates-view/plate-mesh-vertex.glsl
@@ -9,13 +9,13 @@ attribute vec4 color;
 attribute float hidden;
 attribute float vertexBumpScale;
 attribute float colormapValue;
-attribute float patternIdx;
+in int patternIdx;
 
 varying vec4 vColor;
 varying float vHidden;
 varying float vBumpScale;
 varying float vColormapValue;
-flat varying float vPatternIdx;
+flat out int vPatternIdx;
 // ---
 
 #define PHONG

--- a/js/plates-view/plate-mesh-vertex.glsl
+++ b/js/plates-view/plate-mesh-vertex.glsl
@@ -1,6 +1,6 @@
 // Slightly modified Phong shader taken from THREE.ShaderLib.
 // https://github.com/mrdoob/three.js/blob/0c51e577afd011aea8d635db2eeb9185b3999889/src/renderers/shaders/ShaderLib/meshphong_vert.glsl.js
-// It supports alpha channel in color attribut (vec4 is used instead of vec3) + a few custom features like
+// It supports alpha channel in color attribute (vec4 is used instead of vec3) + a few custom features like
 // hiding vertices, colormap texture, and so on. Custom code is always enclosed in // --- CUSTOM comment.
 
 // --- CUSTOM:

--- a/js/plates-view/plate-mesh.ts
+++ b/js/plates-view/plate-mesh.ts
@@ -45,10 +45,8 @@ const SHARED_BUMP_MAP = new THREE.TextureLoader().load("data/mountains.jpg");
 // 1. Two arrays that define patterns and scale need a new length. For example:
 //    uniform sampler2D patterns[11]; -> uniform sampler2D patterns[12];
 //    uniform float patternScale[11]; -> uniform float patternScale[12];
-// 2. A new `else if` clause that resolves pattern sampler and scale value needs to be added:
-//    else if (vPatternIdx == 11) {
-//      diffuseColor *= texture2D(patterns[11], vUv * patternScale[11]);
-//    }
+// 2. Extend switch statement that resolves the pattern sampler and scale value:
+//    case 11: diffuseColor *= texture2D(patterns[11], vUv * patternScale[11]); break;
 //    Note that it's the only way to do it in GLSL. It's impossible to simply say:
 //    texture2D(patterns[vPatternIdx], vUv * patternScale[vPatternIdx]);
 //    GLSL returns an error saying that "array index for samplers must be constant integral expressions".

--- a/js/plates-view/plate-mesh.ts
+++ b/js/plates-view/plate-mesh.ts
@@ -41,8 +41,8 @@ const VOLCANIC_ERUPTIONS_LAYER_DIFF = 2 * LAYER_DIFF;
 const SHARED_BUMP_MAP = new THREE.TextureLoader().load("data/mountains.jpg");
 
 const SURFACE_ROCK_PATTERN_IDX: Partial<Record<Rock, number>> = {
-  [Rock.Basalt]: 0,
-  [Rock.OceanicSediment]: 1,
+  [Rock.OceanicSediment]: 0,
+  [Rock.Basalt]: 1,
   [Rock.Andesite]: 2,
   [Rock.Limestone]: 3,
   [Rock.Shale]: 4,
@@ -51,8 +51,8 @@ const SURFACE_ROCK_PATTERN_IDX: Partial<Record<Rock, number>> = {
 };
 
 const SURFACE_ROCK_PATTERN_MAP_ARRAY = [
-  new THREE.TextureLoader().load(getRockPatternImgSrc(Rock.Basalt)),
   new THREE.TextureLoader().load(getRockPatternImgSrc(Rock.OceanicSediment)),
+  new THREE.TextureLoader().load(getRockPatternImgSrc(Rock.Basalt)),
   new THREE.TextureLoader().load(getRockPatternImgSrc(Rock.Andesite)),
   new THREE.TextureLoader().load(getRockPatternImgSrc(Rock.Limestone)),
   new THREE.TextureLoader().load(getRockPatternImgSrc(Rock.Shale)),
@@ -283,11 +283,13 @@ export default class PlateMesh {
     this.geometry.setAttribute("elevation", new THREE.BufferAttribute(new Float32Array(verticesCount), 1));
     this.geometry.setAttribute("hidden", new THREE.BufferAttribute(new Float32Array(verticesCount), 1));
     this.geometry.setAttribute("colormapValue", new THREE.BufferAttribute(new Float32Array(verticesCount), 1));
+    this.geometry.setAttribute("patternIdx", new THREE.BufferAttribute(new Int8Array(verticesCount), 1));
     (this.geometry.attributes.color as THREE.BufferAttribute).setUsage(THREE.DynamicDrawUsage);
     (this.geometry.attributes.vertexBumpScale as THREE.BufferAttribute).setUsage(THREE.DynamicDrawUsage);
     (this.geometry.attributes.elevation as THREE.BufferAttribute).setUsage(THREE.DynamicDrawUsage);
     (this.geometry.attributes.hidden as THREE.BufferAttribute).setUsage(THREE.DynamicDrawUsage);
     (this.geometry.attributes.colormapValue as THREE.BufferAttribute).setUsage(THREE.DynamicDrawUsage);
+    (this.geometry.attributes.patternIdx as THREE.BufferAttribute).setUsage(THREE.DynamicDrawUsage);
     // Hide all fields by default. Later updates will set correct value for visible fields.
     for (let i = 0; i < verticesCount; i += 1) {
       this.geometry.attributes.hidden.setX(i, 1);
@@ -408,7 +410,7 @@ export default class PlateMesh {
       this.geoAttributes.colormapValue.setX(id, field.normalizedAge);
     } else if (colormap === "rock") {
       // colormapValue will be used to pick the texture in plate-mesh-fragment.glsl.
-      this.geoAttributes.colormapValue.setX(id, SURFACE_ROCK_PATTERN_IDX[field.rockType] || 0);
+      this.geoAttributes.patternIdx.setX(id, SURFACE_ROCK_PATTERN_IDX[field.rockType] || 0);
     }
 
     // Elevation will modify mesh geometry.
@@ -445,6 +447,7 @@ export default class PlateMesh {
     // added and connected to hidden fields. This color will be visible at the very edge of plate.
     // Reset colormap value attribute after colormap is updated for each fields.
     this.geoAttributes.colormapValue.setX(fieldId, this.defaultColormapValue);
+    this.geoAttributes.patternIdx.setX(fieldId, 0);
     this.geoAttributes.vertexBumpScale.setX(fieldId, 0);
 
     this.geoAttributes.color.setXYZW(
@@ -516,6 +519,7 @@ export default class PlateMesh {
     this.geoAttributes.hidden.needsUpdate = true;
     this.geoAttributes.color.needsUpdate = true;
     this.geoAttributes.colormapValue.needsUpdate = true;
+    this.geoAttributes.patternIdx.needsUpdate = true;
     this.geoAttributes.vertexBumpScale.needsUpdate = true;
     // Flat shading doesn't require normals. And it uses faster way to calculate final elevation.
     if (config.flatShading) {


### PR DESCRIPTION
Copying my message from Slack as it might be useful if I ever want to revisit this feature:

> At this point, I’m pretty sure that it’s almost impossible to implement it 100% correctly because of some specifics how GPU work. I’ll try to explain that as simple as possible (might not be necessary for most of the people here, but maybe useful even for me if I ever go back to this issue and forget what was the problem ;)). You can imagine that each vertex in our 3D mesh is a model field. 3 vertices create a triangle, and all triangles together create a 3D globe we can see. We can specify which pattern texture should be used for each vertex of this triangle, but we’re not able to specify which texture should be used for all the pixels between these vertices (=> triangle “body”). GPU does it automatically - it takes each of the triangle vertices and interpolates linearly all the pattern values to have some values for all the pixels that lie inside the triangle. And this approach works well when the neighbouring vertices have similar pattern values like one vertex uses pattern = 3 and another pattern = 4. All the values between 3 and 4 can be rounded to either 3 and 4, so all the pixels between two mesh vertex would have a correct pattern. But if you imagine that neighboring vertices use pattern 3 and 10, the automatic interpolation will result in patterns 3,4,5,6…,9,10. So, we’ll have a full rainbow of patterns between two model fields. You can see that in the attached screenshot if you take a look at volcanoes on the continent - they’re surrounded by narrow stripes of patterns that should not be there. If we could order all the patterns in a way that two patterns are next to each other each time they might be next to each other in the model, we could workaround that. But I’ve tried and it’s impossible - Rhyolite is often surrounded by Sandstone, Shale, or Limestone, and so on. There are too many combinations.

> Everything would work great if we could tell GPU to use nearest neighbor interpolation instead of the linear one, but that’s just impossible. I’ve checked OpenGL specs, docs, looked for similar issues. The only thing I could do was to use no interpolation at all. But then GPU takes value for the whole triangle from one of the three vertices. That’s why the current visualization that looks a bit squarish and sometimes it might not match the underlying model perfectly. This is visible especially with the rock picker - it doesn’t work precisely and sometimes you might be clicking one color and see a different one in the rock key. We’d have this problem even in the perfect scenario, but probably much less visible. On a positive note, it still looks better than the old visualization. :wink:

> I think the only way to improve all that would be to completely change our 3D mesh and represent each model field with a full triangle. But that’s an enormous amount of work that and creates many other issues too.

Re code itself - I hope the comments explain why the GLSL lines look that weird.