### PR TITLE
Remove rock colors, update key to handle colormap == rock

### DIFF
--- a/js/colors/rock-colors.ts
+++ b/js/colors/rock-colors.ts
@@ -9,78 +9,52 @@ import sandstonePatternImgSrc from "../../images/rock-patterns/sandstone-cs.png"
 import rhyolitePatternImgSrc from "../../images/rock-patterns/rhyolite-cs.png";
 import andesitePatternImgSrc from "../../images/rock-patterns/andesite-cs.png";
 import dioritePatternImgSrc from "../../images/rock-patterns/diorite-cs.png";
-import { cssColorToRGBAFloat, RGBAFloat } from "./utils";
 
 interface IRockPattern {
   imgElement: HTMLImageElement;
   patternImgSrc: string;
-  mainColor: string;
-  mainColorRGBAFloat: RGBAFloat;
 }
 
-// Use any RGBAFloat color to satisfy IRockPattern interface requirements.
-// The real value is assigned in preprocessRockPatterns function.
-const placeholderColor = { r: 0, g: 0, b: 0, a: 0 };
 const ROCK_PATTERN: Record<Rock, IRockPattern> = {
   [Rock.Granite]: {
     imgElement: new Image(),
-    patternImgSrc: granitePatternImgSrc,
-    mainColor: "#ebc0d9",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: granitePatternImgSrc
   },
   [Rock.Gabbro]: {
     imgElement: new Image(),
-    patternImgSrc: gabbroPatternImgSrc,
-    mainColor: "#000000",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: gabbroPatternImgSrc
   },
   [Rock.Basalt]: {
     imgElement: new Image(),
-    patternImgSrc: basaltPatternImgSrc,
-    mainColor: "#3b3b3f",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: basaltPatternImgSrc
   },
   [Rock.Andesite]: {
     imgElement: new Image(),
-    patternImgSrc: andesitePatternImgSrc,
-    mainColor: "#dbaaf2",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: andesitePatternImgSrc
   },
   [Rock.Diorite]: {
     imgElement: new Image(),
-    patternImgSrc: dioritePatternImgSrc,
-    mainColor: "#b280e7",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: dioritePatternImgSrc
   },
   [Rock.Rhyolite]: {
     imgElement: new Image(),
-    patternImgSrc: rhyolitePatternImgSrc,
-    mainColor: "#ffd2ec",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: rhyolitePatternImgSrc
   },
   [Rock.Sandstone]: {
     imgElement: new Image(),
-    patternImgSrc: sandstonePatternImgSrc,
-    mainColor: "#fbe770",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: sandstonePatternImgSrc
   },
   [Rock.Limestone]: {
     imgElement: new Image(),
-    patternImgSrc: limestonePatternImgSrc,
-    mainColor: "#d1eaff",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: limestonePatternImgSrc
   },
   [Rock.Shale]: {
     imgElement: new Image(),
-    patternImgSrc: shalePatternImgSrc,
-    mainColor: "#e5ad8d",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: shalePatternImgSrc
   },
   [Rock.OceanicSediment]: {
     imgElement: new Image(),
-    patternImgSrc: oceanicSedimentPatternImgSrc,
-    mainColor: "#b98843",
-    mainColorRGBAFloat: placeholderColor
+    patternImgSrc: oceanicSedimentPatternImgSrc
   },
 };
 
@@ -88,16 +62,10 @@ const preprocessRockPatterns = () => {
   Object.values(ROCK_PATTERN).forEach(pattern => {
     // Preload image.
     pattern.imgElement.src = pattern.patternImgSrc;
-    // Convert hex color to RGBAFloat.
-    pattern.mainColorRGBAFloat = cssColorToRGBAFloat(pattern.mainColor);
   });
 };
 
 preprocessRockPatterns();
-
-export const getRockColor = (rock: Rock): string => ROCK_PATTERN[rock].mainColor;
-
-export const getRockColorRGBAFloat = (rock: Rock): RGBAFloat => ROCK_PATTERN[rock].mainColorRGBAFloat;
 
 export const getRockPatternImgSrc = (rock: Rock): string => ROCK_PATTERN[rock].patternImgSrc;
 
@@ -107,8 +75,9 @@ export const getRockCanvasPattern = (ctx: CanvasRenderingContext2D, rock: Rock) 
   if (pattern.patternImgSrc !== "" && pattern.imgElement.complete) {
     canvasPattern = ctx.createPattern(pattern.imgElement, "repeat");
   }
-  // Return main color while image is still loading or pattern image is not defined.
-  return canvasPattern !== null ? canvasPattern : pattern.mainColor;
+  // #ccc might be visible for a short moment while the pattern is still loading. However, given the pattern
+  // image size, this is not likely to happen.
+  return canvasPattern || "#ccc";
 };
 
 export const IGNEOUS_PURPLE = "#BA00BA";

--- a/js/components/color-key.tsx
+++ b/js/components/color-key.tsx
@@ -5,10 +5,8 @@ import { EARTHQUAKE_COLORS } from "../plates-view/earthquake-helpers";
 import FontIcon from "react-toolbox/lib/font_icon";
 import { Button } from "react-toolbox/lib/button";
 import { BaseComponent, IBaseProps } from "./base";
-import { Rock, rockProps, ROCK_PROPERTIES } from "../plates-model/rock-properties";
 import PlateStore from "../stores/plate-store";
-import config, { Colormap } from "../config";
-import { getRockColor, getRockPatternImgSrc } from "../colors/rock-colors";
+import { Colormap } from "../config";
 import { RGBAFloatToCssColor } from "../colors/utils";
 import { RockKey } from "./rock-key";
 
@@ -40,11 +38,10 @@ function renderPlateScale(canvas: any, hue: any) {
   }
 }
 
-const KEY_TITLE: Record<Colormap, string> = {
+const KEY_TITLE: Partial<Record<Colormap, string>> = {
   topo: "Elevation",
   plate: "Plate Density",
-  age: "Crust Age",
-  rock: "Rock Type"
+  age: "Crust Age"
 };
 
 interface IState {}
@@ -97,21 +94,9 @@ export default class ColorKey extends BaseComponent<IBaseProps, IState> {
     );
   }
 
-  renderRockTypes(withPatterns: boolean) {
-    return (
-      (Object.keys(ROCK_PROPERTIES) as unknown[] as Rock[]).map((rock: Rock) => (
-        <tr key={rock}>
-          <td colSpan={2}>&nbsp;</td>
-          <td>{ rect(getRockColor(rock), withPatterns && config.crossSectionPatterns ? getRockPatternImgSrc(rock) : undefined) }</td>
-          <td className={css.crossSectionColor}>{ rockProps(rock).label }</td>
-        </tr>
-      ))
-    );
-  }
-
   renderKeyContent() {
     const { colormap, model, earthquakes, volcanicEruptions, crossSectionVisible, interaction } = this.simulationStore;
-    const rockKeyVisible = crossSectionVisible || interaction === "takeRockSample";
+    const rockKeyVisible = colormap === "rock" || crossSectionVisible || interaction === "takeRockSample";
     // hide the old key when showing the new rock key (temporary until tabbed UI is implemented)
     const colorKeyStyle = rockKeyVisible ? { display: "none" } : undefined;
     this.plateCanvas = {};
@@ -123,43 +108,39 @@ export default class ColorKey extends BaseComponent<IBaseProps, IState> {
             <tr>
               <th colSpan={4}>{ KEY_TITLE[colormap] }</th>
             </tr>
-            {
-              colormap === "rock" ?
-                this.renderRockTypes(false) :
-                <tr>
-                  <td colSpan={2}>&nbsp;</td>
-                  <td>
-                    <div className={css.canvases + " " + css[colormap]}>
-                      {
-                        colormap === "topo" &&
-                        <canvas ref={(c) => {
-                          this.topoCanvas = c;
-                        }} />
-                      }
-                      {
-                        (colormap === "plate" || colormap === "age") && model.plates.map((plate: any) => <canvas key={plate.id} ref={(c) => {
-                          this.plateCanvas[plate.id] = c;
-                        }} />)
-                      }
-                    </div>
-                  </td>
-                  <td>
-                    <div className={css.labels}>
-                      { (colormap === "topo" || colormap === "plate") &&
-                        <div>
-                          <p style={{ marginTop: 0 }}>8000m</p>
-                          <p style={{ marginTop: 20 }}>0m</p>
-                          <p style={{ marginTop: 20 }}>-8000m</p>
-                        </div> }
-                      { colormap === "age" &&
-                        <div>
-                          <p style={{ marginTop: 0 }}>New Crust</p>
-                          <p style={{ marginTop: 52 }}>Old Crust</p>
-                        </div> }
-                    </div>
-                  </td>
-                </tr>
-            }
+            <tr>
+              <td colSpan={2}>&nbsp;</td>
+              <td>
+                <div className={css.canvases + " " + css[colormap]}>
+                  {
+                    colormap === "topo" &&
+                    <canvas ref={(c) => {
+                      this.topoCanvas = c;
+                    }} />
+                  }
+                  {
+                    (colormap === "plate" || colormap === "age") && model.plates.map((plate: any) => <canvas key={plate.id} ref={(c) => {
+                      this.plateCanvas[plate.id] = c;
+                    }} />)
+                  }
+                </div>
+              </td>
+              <td>
+                <div className={css.labels}>
+                  { (colormap === "topo" || colormap === "plate") &&
+                    <div>
+                      <p style={{ marginTop: 0 }}>8000m</p>
+                      <p style={{ marginTop: 20 }}>0m</p>
+                      <p style={{ marginTop: 20 }}>-8000m</p>
+                    </div> }
+                  { colormap === "age" &&
+                    <div>
+                      <p style={{ marginTop: 0 }}>New Crust</p>
+                      <p style={{ marginTop: 52 }}>Old Crust</p>
+                    </div> }
+                </div>
+              </td>
+            </tr>
           </tbody>
           { volcanicEruptions &&
             <tbody className={css.volcanoKeyContainer} style={colorKeyStyle} data-test="color-key-volcanic-eruptions">

--- a/js/config.ts
+++ b/js/config.ts
@@ -108,7 +108,6 @@ const DEFAULT_CONFIG = {
   renderEulerPoles: false,
   renderLatLongLines: false,
   renderPlateLabels: true,
-  crossSectionPatterns: true,
   flatShading: false,
   // Smaller number (16-64) will make topo scale less smooth and look closer to a real topographic map.
   // Large values (128-256) will smooth out the rendering.

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -7,7 +7,7 @@ import {
   OCEANIC_CRUST_COLOR, CONTINENTAL_CRUST_COLOR, LITHOSPHERE_COLOR, MANTLE_COLOR, OCEAN_COLOR, SKY_COLOR_1, SKY_COLOR_2,
   MAGMA_LIGHT_RED, MAGMA_DARK_RED, METAMORPHIC_1, METAMORPHIC_2, METAMORPHIC_3, MAGMA_INTERMEDIATE, MAGMA_BLOB_BORDER
 } from "../colors/cross-section-colors";
-import { getRockCanvasPattern, getRockColor } from "../colors/rock-colors";
+import { getRockCanvasPattern } from "../colors/rock-colors";
 import { IEarthquake, ICrossSectionFieldData, IMagmaBlobData, IRockLayerData } from "../plates-model/get-cross-section";
 import { SEA_LEVEL } from "../plates-model/crust";
 import { UPDATE_INTERVAL } from "../plates-model/model-output";
@@ -326,7 +326,7 @@ class CrossSectionRenderer {
       const p2tmp = p2.clone().lerp(p3, currentThickness);
       const p3tmp = p2.clone().lerp(p3, currentThickness + rl.relativeThickness);
       const p4tmp = p1.clone().lerp(p4, currentThickness + rl.relativeThickness);
-      if (this.fillPath(config.crossSectionPatterns ? getRockCanvasPattern(ctx, rl.rock) : getRockColor(rl.rock), p1tmp, p2tmp, p3tmp, p4tmp)) {
+      if (this.fillPath(getRockCanvasPattern(ctx, rl.rock), p1tmp, p2tmp, p3tmp, p4tmp)) {
         this.intersection = rockProps(rl.rock).label;
       }
       currentThickness += rl.relativeThickness;
@@ -341,7 +341,7 @@ class CrossSectionRenderer {
       const p2tmp = p2.clone().lerp(p3, currentThickness2);
       const p3tmp = p2.clone().lerp(p3, currentThickness2 + rl.relativeThickness2);
       const p4tmp = p1.clone().lerp(p4, currentThickness1 + rl.relativeThickness1);
-      if (this.fillPath(config.crossSectionPatterns ? getRockCanvasPattern(this.ctx, rl.rock) : getRockColor(rl.rock), p1tmp, p2tmp, p3tmp, p4tmp)) {
+      if (this.fillPath(getRockCanvasPattern(this.ctx, rl.rock), p1tmp, p2tmp, p3tmp, p4tmp)) {
         this.intersection = rockProps(rl.rock).label;
       }
       currentThickness1 += rl.relativeThickness1;
@@ -458,7 +458,7 @@ class CrossSectionRenderer {
       let color: string | CanvasPattern = magmaColor(verticalProgress);
       // && blob.finalRockType is redundant, but otherwise TS complains about this value being potentially undefined
       if (transformedIntoRock && blob.finalRockType) {
-        color = config.crossSectionPatterns ? getRockCanvasPattern(this.ctx, blob.finalRockType) : getRockColor(blob.finalRockType);
+        color = getRockCanvasPattern(this.ctx, blob.finalRockType);
       }
 
       if (this.fillPath2([p1, p2, p3, p4, p5, p6], color, rockLayers ? MAGMA_BLOB_BORDER : "", MAGMA_BLOB_BORDER_WIDTH)) {


### PR DESCRIPTION
[#179943345]

Now, when we render rock patterns in the 3d view, I think it doesn't make sense to keep the hex color of the rocks. It's additional maintenance and they're already out of sync with the patterns. 

Also, I've updated the key to show rock key when colormap == rock.