### PR TITLE
Fix a bug that was sometimes leaving the boundary highlighted forever

### DIFF
--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -407,6 +407,7 @@ export class SimulationStore {
 
   @action.bound clearSelectedBoundary() {
     this.selectedBoundary = null;
+    this.unhighlightBoundarySegment();
   }
 
   @action.bound setSelectedBoundary(canvasPosition: IEventCoords) {
@@ -452,18 +453,23 @@ export class SimulationStore {
   }
 
   @action.bound highlightBoundarySegment(position: THREE.Vector3) {
+    this.unhighlightBoundarySegment();
+
+    const targetField = this.model.topFieldAt(position);
+    const boundaryField = findBoundaryFieldAround(targetField, this.model);
+    if (boundaryField) {
+      this.highlightedBoundaries = highlightBoundarySegment(boundaryField, this.model);
+      this.highlightedBoundaries.forEach(f => f.plate.rerender());
+    }
+  }
+
+  @action.bound unhighlightBoundarySegment() {
     if (this.highlightedBoundaries.length > 0) {
       this.highlightedBoundaries.forEach(f => {
         unhighlightBoundary(f);
         f.plate.rerender();
       });
       this.highlightedBoundaries = [];
-    }
-    const targetField = this.model.topFieldAt(position);
-    const boundaryField = findBoundaryFieldAround(targetField, this.model);
-    if (boundaryField) {
-      this.highlightedBoundaries = highlightBoundarySegment(boundaryField, this.model);
-      this.highlightedBoundaries.forEach(f => f.plate.rerender());
     }
   }
 


### PR DESCRIPTION
[#179577787]

This was happening when the user wasn't closing the boundary type dialog, but moving his mouse straight to "Next" button.