### PR TITLE
Fix bugs related to interactions and cursors

### DIFF
--- a/js/plates-interactions/base-interactions-manager.ts
+++ b/js/plates-interactions/base-interactions-manager.ts
@@ -3,7 +3,7 @@ import $ from "jquery";
 import { EventEmitter2 } from "eventemitter2";
 import { IInteractionHandler, mousePos, mousePosNormalized } from "./helpers";
 
-const NAMESPACE = "interactions-manager";
+let _instanceId = 0;
 
 export interface IView {
   domElement: HTMLElement;
@@ -14,6 +14,7 @@ export interface IView {
 }
 
 export class BaseInteractionsManager {
+  namespace: string;
   activeInteraction: IInteractionHandler | null;
   emitter: EventEmitter2;
   interactions: Record<string, IInteractionHandler> = {};
@@ -21,6 +22,8 @@ export class BaseInteractionsManager {
   view: IView;
 
   constructor(view: IView) {
+    this.namespace = `interactions-manager-${_instanceId++}`;
+
     this.view = view;
 
     this.emitter = new EventEmitter2();
@@ -75,7 +78,7 @@ export class BaseInteractionsManager {
       return;
     }
     let wasCameraUnlocked = false;
-    $elem.on(`pointerdown.${NAMESPACE}`, (event) => {
+    $elem.on(`pointerdown.${this.namespace}`, (event) => {
       if ((event.target as any) !== this.view.domElement) {
         return;
       }
@@ -90,7 +93,7 @@ export class BaseInteractionsManager {
         }
       }
     });
-    $elem.on(`pointermove.${NAMESPACE}`, (event) => {
+    $elem.on(`pointermove.${this.namespace}`, (event) => {
       if ((event.target as any) !== this.view.domElement) {
         return;
       }
@@ -101,7 +104,7 @@ export class BaseInteractionsManager {
         interaction.onPointerMove(canvasPos);
       }
     });
-    $elem.on(`pointerup.${NAMESPACE} pointercancel.${NAMESPACE}`, (event) => {
+    $elem.on(`pointerup.${this.namespace} pointercancel.${this.namespace}`, (event) => {
       if (wasCameraUnlocked) {
         this.view.controls.enableRotate = true;
       }
@@ -118,6 +121,6 @@ export class BaseInteractionsManager {
   }
 
   disableEventHandlers() {
-    $(document).off(`.${NAMESPACE}`);
+    $(document).off(`.${this.namespace}`);
   }
 }

--- a/js/plates-interactions/base-interactions-manager.ts
+++ b/js/plates-interactions/base-interactions-manager.ts
@@ -48,7 +48,6 @@ export class BaseInteractionsManager {
       this.activeInteraction = this.interactions[name];
       this.enableEventHandlers();
       if (this.activeInteraction.cursor) {
-        console.log("set cursor", this.activeInteraction.cursor);
         this.view.domElement.style.cursor = this.activeInteraction.cursor;
       }
     }

--- a/js/plates-interactions/base-interactions-manager.ts
+++ b/js/plates-interactions/base-interactions-manager.ts
@@ -37,14 +37,20 @@ export class BaseInteractionsManager {
 
   setInteraction(name: string) {
     if (this.activeInteraction) {
-      this.activeInteraction.setInactive();
+      if (this.activeInteraction.cursor) {
+        this.view.domElement.style.cursor = "auto";
+        console.log("set cursor auto");
+      }
       this.activeInteraction = null;
       this.disableEventHandlers();
     }
     if (name && this.interactions[name]) {
       this.activeInteraction = this.interactions[name];
-      this.activeInteraction.setActive();
       this.enableEventHandlers();
+      if (this.activeInteraction.cursor) {
+        console.log("set cursor", this.activeInteraction.cursor);
+        this.view.domElement.style.cursor = this.activeInteraction.cursor;
+      }
     }
   }
 

--- a/js/plates-interactions/cross-section-click.ts
+++ b/js/plates-interactions/cross-section-click.ts
@@ -4,7 +4,7 @@ import { ICrossSectionWall } from "../types";
 export interface ICrossSectionClickOptions {
   getIntersection: (mesh: THREE.Mesh) => (THREE.Intersection | undefined);
   wallMesh: Record<ICrossSectionWall, THREE.Mesh>;
-  cursor?: string;
+  cursor: string;
   onPointerDown: (event: { wall: ICrossSectionWall, intersection: THREE.Vector2 }) => void;
 }
 
@@ -15,6 +15,10 @@ export default class CrossSectionClick {
 
   constructor(options: ICrossSectionClickOptions) {
     this.options = options;
+  }
+
+  get cursor() {
+    return this.options.cursor;
   }
 
   getRelativeIntersection(wallType: ICrossSectionWall, absoluteIntersection: THREE.Intersection) {
@@ -33,20 +37,6 @@ export default class CrossSectionClick {
       return new THREE.Vector2(-point.z, -point.y + height * 0.5);
     case "back":
       return new THREE.Vector2(-point.x + width * 0.5, -point.y + height * 0.5);
-    }
-  }
-
-  // "active" state is when user points at target object but still hasn't pressed the mouse button.
-  // This kind of state should provide some hint that interaction is possible.
-  setActive() {
-    if (this.options.cursor) {
-      document.body.style.cursor = this.options.cursor;
-    }
-  }
-
-  setInactive() {
-    if (this.options.cursor) {
-      document.body.style.cursor = "auto";
     }
   }
 

--- a/js/plates-interactions/cross-section-drawing.ts
+++ b/js/plates-interactions/cross-section-drawing.ts
@@ -34,6 +34,10 @@ export default class CrossSectionDrawing {
     return Math.min(config.maxCrossSectionLength, (this.screenWidth - CROSS_SECTION_PADDING) / config.crossSectionPxPerKm);
   }
 
+  get cursor() {
+    return "crosshair";
+  }
+
   checkMaxLength(data: any) {
     const { point1, point2 } = data;
     const length = point1.angleTo(point2) * c.earthRadius;
@@ -44,16 +48,6 @@ export default class CrossSectionDrawing {
       allowedRotation.slerp(rotation, this.maxLineWidth / length);
       data.point2 = point1.clone().applyQuaternion(allowedRotation);
     }
-  }
-
-  // "active" state is when user points at target object but still hasn't pressed the mouse button.
-  // This kind of state should provide some hint that interaction is possible.
-  setActive() {
-    document.body.style.cursor = "crosshair";
-  }
-
-  setInactive() {
-    document.body.style.cursor = "auto";
   }
 
   onPointerDown() {

--- a/js/plates-interactions/force-drawing.ts
+++ b/js/plates-interactions/force-drawing.ts
@@ -34,14 +34,8 @@ export default class ForceDrawing {
     this.data = null;
   }
 
-  // "active" state is when user points at target object but still hasn't pressed the mouse button.
-  // This kind of state should provide some hint that interaction is possible.
-  setActive() {
-    document.body.style.cursor = "crosshair";
-  }
-
-  setInactive() {
-    document.body.style.cursor = "auto";
+  get cursor() {
+    return "crosshair";
   }
 
   onPointerDown() {

--- a/js/plates-interactions/helpers.ts
+++ b/js/plates-interactions/helpers.ts
@@ -5,8 +5,7 @@ import { IEventCoords } from "../types";
 export const TakeRockSampleCursor = `url("${RockSampleCursorSrc}") 16 42, crosshair`;
 
 export interface IInteractionHandler {
-  setActive: () => void;
-  setInactive: () => void;
+  cursor: string;
   onPointerDown?: (pos: IEventCoords) => boolean;
   onPointerMove?: (pos: IEventCoords) => void;
   onPointerUp?: (pos: IEventCoords) => void;

--- a/js/plates-interactions/planet-click.ts
+++ b/js/plates-interactions/planet-click.ts
@@ -41,16 +41,6 @@ export default class PlanetClick {
     this.earthMesh = new THREE.Mesh(new THREE.SphereGeometry(1.0, 64, 64));
   }
 
-  // "active" state is when user points at target object but still hasn't pressed the mouse button.
-  // This kind of state should provide some hint that interaction is possible.
-  setActive() {
-    document.body.style.cursor = this.cursor;
-  }
-
-  setInactive() {
-    document.body.style.cursor = "auto";
-  }
-
   onPointerDown(canvasPosition: IEventCoords) {
     if (!this.startEventName) {
       return false;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180230314

There are two instances of interaction managers - one for the planet view and one for the cross-section. Recently, I've moved event handlers from canvases to document. This was breaking interactions in some edge cases, depending on the timing of MobX observers. For example, the cross-section manager could remove all the event handlers from document **after** the planet view manager just added its own handlers.

Also, I've fixed cursors handling. Using document was causing similar issues, so I've limited custom cursor to canvas that is unique per manager.