### PR TITLE
Add earthquakes/volcanic eruption switches to bottom bar

### DIFF
--- a/css-modules/slider-switch.less
+++ b/css-modules/slider-switch.less
@@ -1,0 +1,70 @@
+@import "../css/variables.less";
+
+.sliderSwitch {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    .thumbHighlight {
+      background: #ffffff80;
+    }
+  }
+  &:active {
+    .thumbHighlight {
+      background: #ffffff;
+    }
+  }
+
+  .track {
+    width: 27px;
+    height: 10px;
+    margin-left: 20px;
+    border-radius: 11px;
+    background: #797979;
+
+    &:global(.on) {
+      background: #32a447;
+    }
+  }
+
+  .thumbHighlight {
+    position: absolute;
+    left: 10px;
+    transition: left .25s;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: #ffffff00;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .thumb {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.35);
+      background: #797979;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      .thumbInterior {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: white;
+        &:global(.on) {
+          background: #98d1a3;
+        }
+      }
+    }
+  }
+
+  label {
+    margin-left: 15px;
+    font-weight: bold;
+    cursor: pointer;
+  }
+}

--- a/css/bottom-panel.less
+++ b/css/bottom-panel.less
@@ -1,3 +1,5 @@
+@import "./variables.less";
+
 .bottom-panel {
   width: 100%;
   height: 65px;
@@ -92,6 +94,27 @@
     display: flex;
     justify-content: space-evenly;
     align-items: unsafe flex-end;
+
+    .event-buttons {
+      width: 146px;
+      display: flex;
+      justify-content: space-evenly;
+      flex-direction: column;
+      border: none;
+      height: @control-panel-content-height;
+      border-radius: @component-border-radius @component-border-radius 0 0;
+      cursor: pointer;
+      background-color: rgb(var(--theme-primary-color));
+      color: rgb(var(--theme-secondary-color));
+      transition: background-color .25s;
+      font-family: @default-font-family;
+      font-size: @smaller-font-size;
+      font-weight: @default-font-weight;
+
+      &:hover {
+        background-color: rgb(var(--theme-hover-background-color));
+      }
+    }
   }
 
   .right-widgets {

--- a/js/components/bottom-panel.tsx
+++ b/js/components/bottom-panel.tsx
@@ -9,6 +9,7 @@ import { Button } from "react-toolbox/lib/button";
 import { IconHighlightButton } from "./icon-highlight-button";
 import { MapTypeButton } from "./map-type-button";
 import SidebarMenu from "./sidebar-menu";
+import { SliderSwitch } from "./slider-switch";
 import config, { Colormap } from "../config";
 import DrawCrossSectionIconSVG from "../../images/draw-cross-section-icon.svg";
 import TakeSampleIconControlSVG from "../../images/take-sample-icon-control.svg";
@@ -92,6 +93,16 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
     setOption("playing", !this.options.playing);
   }
 
+  setShowEarthquakes = (on: boolean) => {
+    const { setOption } = this.simulationStore;
+    setOption("earthquakes", on);
+  }
+
+  setShowVolcanicEruptions = (on: boolean) => {
+    const { setOption } = this.simulationStore;
+    setOption("volcanicEruptions", on);
+  }
+
   toggleSidebar = () => {
     const { sidebarActive } = this.state;
     this.setState({ sidebarActive: !sidebarActive });
@@ -110,6 +121,9 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
     const sidebarAction = sidebarActive ? "close" : "menu";
     const isDrawingCrossSection = interaction === "crossSection";
     const isTakingRockSample = interaction === "takeRockSample";
+    const showEarthquakesToggle = config.sidebar.includes("earthquakes");
+    const showVolcanicEruptionsToggle = config.sidebar.includes("volcanicEruptions");
+    const showEventsGroup = showEarthquakesToggle || showVolcanicEruptionsToggle;
 
     const setColorMap = (colorMap: Colormap) => {
       this.simulationStore.setOption("colormap", colorMap);
@@ -149,6 +163,17 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
                 label={<>Take<br/>Sample</>} Icon={TakeSampleIconControlSVG}
                 onClick={() => this.toggleInteraction("takeRockSample")} />
             </ControlGroup>
+            { showEventsGroup &&
+              <ControlGroup>
+                <div className="event-buttons">
+                  { showVolcanicEruptionsToggle &&
+                    <SliderSwitch label="Volcanoes"
+                      isOn={this.simulationStore.volcanicEruptions} onSet={this.setShowVolcanicEruptions}/> }
+                  { showEarthquakesToggle &&
+                    <SliderSwitch label="Earthquakes"
+                      isOn={this.simulationStore.earthquakes} onSet={this.setShowEarthquakes}/> }
+                </div>
+              </ControlGroup> }
           </div>
           <div className="right-widgets">
             {

--- a/js/components/sidebar-menu.tsx
+++ b/js/components/sidebar-menu.tsx
@@ -32,17 +32,14 @@ interface IState {}
 @inject("simulationStore")
 @observer
 export default class SidebarMenu extends BaseComponent<IProps, IState> {
-  changeColormap: (value: any) => void;
   changeInteraction: (value: any) => void;
   changeTimestep: (value: any) => void;
   toggleBoundaries: () => void;
-  toggleEarthquakes: () => void;
   toggleEulerPoles: () => void;
   toggleForces: () => void;
   toggleLatLongLines: () => void;
   togglePlateLabels: () => void;
   toggleVelocities: () => void;
-  toggleVolcanicEruptions: () => void;
   toggleWireframe: () => void;
   toggleMetamorphism: () => void;
   storedPlayState: boolean;
@@ -51,8 +48,6 @@ export default class SidebarMenu extends BaseComponent<IProps, IState> {
     super(props);
     this.saveModel = this.saveModel.bind(this);
     this.hideSaveDialog = this.hideSaveDialog.bind(this);
-    this.toggleEarthquakes = this.toggleOption.bind(this, "earthquakes");
-    this.toggleVolcanicEruptions = this.toggleOption.bind(this, "volcanicEruptions");
     this.toggleMetamorphism = this.toggleOption.bind(this, "metamorphism");
     this.toggleWireframe = this.toggleOption.bind(this, "wireframe");
     this.toggleVelocities = this.toggleOption.bind(this, "renderVelocities");
@@ -61,7 +56,6 @@ export default class SidebarMenu extends BaseComponent<IProps, IState> {
     this.toggleEulerPoles = this.toggleOption.bind(this, "renderEulerPoles");
     this.toggleLatLongLines = this.toggleOption.bind(this, "renderLatLongLines");
     this.togglePlateLabels = this.toggleOption.bind(this, "renderPlateLabels");
-    this.changeColormap = this.handleChange.bind(this, "colormap");
     this.changeInteraction = this.handleChange.bind(this, "interaction");
     this.changeTimestep = this.handleChange.bind(this, "timestep");
     this.storedPlayState = true;
@@ -159,12 +153,6 @@ export default class SidebarMenu extends BaseComponent<IProps, IState> {
           }
           { enabledWidgets.interactions &&
             <ListItem ripple={false} itemContent={<Dropdown className="wide-dropdown" label="Interaction" source={INTERACTION_OPTIONS} value={options.interaction} onChange={this.changeInteraction} />} /> }
-          { /* { enabledWidgets.colormap &&
-            <ListItem ripple={false} itemContent={<Dropdown label="Color Scheme" source={COLORMAP_OPTIONS} value={options.colormap} onChange={this.changeColormap} />} /> } */ }
-          { enabledWidgets.earthquakes &&
-            <ListCheckbox caption="Earthquakes" legend="Show earthquakes" data-test="toggle-earthquakes" checked={options.earthquakes} onChange={this.toggleEarthquakes} className={css.listItem} /> }
-          { enabledWidgets.volcanicEruptions &&
-            <ListCheckbox caption="Volcanic Eruptions" legend="Show volcanic eruptions" data-test="toggle-volcanicEruptions" checked={options.volcanicEruptions} onChange={this.toggleVolcanicEruptions} className={css.listItem} /> }
           { enabledWidgets.metamorphism &&
             <ListCheckbox caption="Metamorphism" legend="Show metamorphism" data-test="toggle-metamorphism" checked={options.metamorphism} onChange={this.toggleMetamorphism} className={css.listItem} /> }
           { enabledWidgets.latLongLines &&

--- a/js/components/slider-switch.tsx
+++ b/js/components/slider-switch.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState } from "react";
+import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
+
+import css from "../../css-modules/slider-switch.less";
+
+interface IProps {
+  label: string;
+  isOn: boolean;
+  onSet: (on: boolean) => void;
+}
+export const SliderSwitch: React.FC<IProps> = ({ label, isOn, onSet }) => {
+  const kThumbOffPos = 0;
+  const kThumbOnPos = 20;
+  const [isDragging, setIsDragging] = useState(false);
+  const totalDrag = useRef(0);
+  const endDragTime = useRef(0);
+  // position of the thumb; used with Draggable in controlled mode
+  const [position, setPosition] = useState(isOn ? kThumbOnPos : kThumbOffPos);
+  // restrict dragging to the range of movement of the thumb
+  const dragBounds = { left: 0, top: 0, right: kThumbOnPos, bottom: 0 };
+
+  const handleStart = (e: DraggableEvent, data: DraggableData) => {
+    setIsDragging(true);
+    totalDrag.current = 0;
+  };
+  const handleDrag = (e: DraggableEvent, data: DraggableData) => {
+    setPosition(data.x);
+    totalDrag.current += Math.abs(data.deltaX);
+  };
+  const handleStop = (e: DraggableEvent, data: DraggableData) => {
+    setIsDragging(false);
+    // must drag a few pixels to be considered a real drag
+    if (totalDrag.current >= 3) {
+      endDragTime.current = performance.now();
+    }
+    const isOnNow = data.x > (kThumbOffPos + kThumbOnPos) / 2;
+    (isOn !== isOnNow) && onSet(isOnNow);
+  };
+
+  const handleClick = () => {
+    // skip clicks immediately following drags; unfortunately, preventDefault() doesn't
+    if (performance.now() - endDragTime.current > 100) {
+      onSet(!isOn);
+    }
+  };
+  useEffect(() => {
+    // synchronize position at end of drag
+    if (!isDragging) {
+      const expectedPos = isOn ? kThumbOnPos : kThumbOffPos;
+      (position !== expectedPos) && setPosition(expectedPos);
+    }
+  }, [isDragging, isOn, position]);
+
+  const onClass = isOn ? "on" : "";
+  return (
+    <div className={css.sliderSwitch} onClick={handleClick}>
+      <div className={`${css.track} ${onClass}`} />
+      <Draggable axis="x" position={{ x: position, y: 0 }} bounds={dragBounds}
+        onStart={handleStart} onDrag={handleDrag} onStop={handleStop}>
+        <div className={`${css.thumbHighlight} ${onClass}`}>
+          <div className={`${css.thumb} ${onClass}`}>
+            <div className={`${css.thumbInterior} ${onClass}`}/>
+          </div>
+        </div>
+      </Draggable>
+      <label>{ label }</label>
+    </div>
+  );
+};

--- a/test/components/sidebar-menu.test.tsx
+++ b/test/components/sidebar-menu.test.tsx
@@ -21,8 +21,6 @@ describe("SidebarMenu component", () => {
     const allOptions = [
       ["interactions", "Interaction"],
       ["timestep", "Model Speed"],
-      ["earthquakes", "Earthquakes"],
-      ["volcanicEruptions", "Volcanic Eruptions"],
       ["latLongLines", "Latitude and Longitude Lines"],
       ["plateLabels", "Plate Labels"],
       ["velocityArrows", "Velocity Arrows"],
@@ -72,7 +70,6 @@ describe("SidebarMenu component", () => {
     //   ['renderPlateLabels', 'togglePlateLabels']
     // ]
     const checkboxOptions = [
-      "earthquakes",
       "wireframe",
       "renderVelocities",
       "renderForces",


### PR DESCRIPTION
PT: [[#180019424]](https://www.pivotaltracker.com/story/show/180019424)

Demo: https://tectonic-explorer.concord.org/branch/volcanoes-earthquakes/index.html?preset=benchmark

Presence/absence of switches is controlled by authoring (same as before)
Clicking on any part of switch changes the polarity of the switch
Thumb can also be dragged from one end to the other