### PR TITLE
Support geode url param; update authoring

### DIFF
--- a/css-modules/map-type-button.less
+++ b/css-modules/map-type-button.less
@@ -76,6 +76,7 @@
         background: white;
         border: none;
         border-radius: 5px;
+        cursor: pointer;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/js/color-maps.ts
+++ b/js/color-maps.ts
@@ -1,0 +1,32 @@
+import config, { Colormap } from "./config";
+import PlanetCrustAgePNG from "../images/planet-crust-age/planet-crust-age@3x.png";
+import PlanetPlateColorPNG from "../images/planet-plate-color/planet-plate-color@3x.png";
+import PlanetRockTypesPNG from "../images/planet-rock-types/planet-rock-types@3x.png";
+import PlanetTopographicPNG from "../images/planet-topographic/planet-topographic@3x.png";
+
+const COLORMAP_OPTIONS: { label: string, value: Colormap, image: any }[] = [
+  { value: "topo", label: "Topographic", image: PlanetTopographicPNG },
+  { value: "plate", label: "Plate Color", image: PlanetPlateColorPNG },
+  { value: "age", label: "Crust Age", image: PlanetCrustAgePNG },
+  { value: "rock", label: "Rock Type", image: PlanetRockTypesPNG }
+];
+
+export function getColorMapImage(colorMap: Colormap) {
+  return COLORMAP_OPTIONS.find(item => item.value === colorMap)?.image;
+}
+
+export function getColorMapLabel(colorMap: Colormap) {
+  return COLORMAP_OPTIONS.find(item => item.value === colorMap)?.label;
+}
+
+export function getAvailableColorMaps(_config: Record<string, any>) {
+  const disableRockMap = _config.geode || (_config.rockLayers === false);
+  const baseOptions: Colormap[] = _config.colormapOptions || ["topo", "plate", "age", "rock"];
+  const options = baseOptions.filter(map => !((map === "rock") && disableRockMap));
+  // must have at least one option available
+  (options.length === 0) && options.push("topo");
+  // filter the color map array based on the available options
+  return COLORMAP_OPTIONS.filter(option => options.includes(option.value));
+}
+
+export const availableColorMaps = getAvailableColorMaps(config);

--- a/js/components/authoring.tsx
+++ b/js/components/authoring.tsx
@@ -31,7 +31,9 @@ const MAIN_OPTIONS: Option[] = [
 const VIEW_OPTIONS: Option[] = [
   ["colormap", "default map type"],
   ["colormapOptions", "available map types"],
+  "showEarthquakesSwitch",
   "earthquakes",
+  "showVolcanoesSwitch",
   "volcanicEruptions",
   "metamorphism",
   "renderVelocities",

--- a/js/components/bottom-panel.tsx
+++ b/js/components/bottom-panel.tsx
@@ -114,6 +114,7 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
   }
 
   render() {
+    const { showDrawCrossSectionButton, showTakeSampleButton, showEarthquakesSwitch, showVolcanoesSwitch } = config;
     const { sidebarActive } = this.state;
     const { interaction, colormap } = this.simulationStore;
     const { reload, restoreSnapshot, restoreInitialSnapshot, stepForward } = this.simulationStore;
@@ -121,9 +122,7 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
     const sidebarAction = sidebarActive ? "close" : "menu";
     const isDrawingCrossSection = interaction === "crossSection";
     const isTakingRockSample = interaction === "takeRockSample";
-    const showEarthquakesToggle = config.showEarthquakesSwitch;
-    const showVolcanicEruptionsToggle = config.showVolcanoesSwitch;
-    const showEventsGroup = showEarthquakesToggle || showVolcanicEruptionsToggle;
+    const showEventsGroup = showEarthquakesSwitch || showVolcanoesSwitch;
 
     const setColorMap = (colorMap: Colormap) => {
       this.simulationStore.setOption("colormap", colorMap);
@@ -146,11 +145,12 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
               <ControlGroup>
                 <MapTypeButton colorMap={colormap} onSetColorMap={setColorMap} />
               </ControlGroup> }
-            <ControlGroup>
-              <IconHighlightButton active={isDrawingCrossSection} disabled={false} data-test="draw-cross-section"
-                style={{ width: 92 }} label={<>Draw<br/>Cross-section</>} Icon={DrawCrossSectionIconSVG}
-                onClick={() => this.toggleInteraction("crossSection")} />
-            </ControlGroup>
+            { showDrawCrossSectionButton &&
+              <ControlGroup>
+                <IconHighlightButton active={isDrawingCrossSection} disabled={false} data-test="draw-cross-section"
+                  style={{ width: 92 }} label={<>Draw<br/>Cross-section</>} Icon={DrawCrossSectionIconSVG}
+                  onClick={() => this.toggleInteraction("crossSection")} />
+              </ControlGroup> }
             <ControlGroup>
               <div className="buttons">
                 <RestartButton disabled={!options.snapshotAvailable} onClick={restoreInitialSnapshot} data-test="restart-button" />
@@ -159,7 +159,7 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
                 <StepForwardButton disabled={options.playing} onClick={stepForward} data-test="step-forward-button" />
               </div>
             </ControlGroup>
-            { !config.geode &&
+            { !config.geode && showTakeSampleButton &&
               <ControlGroup>
                 <IconHighlightButton active={isTakingRockSample} disabled={false} style={{ width: 64 }} data-test="take-sample"
                   label={<>Take<br/>Sample</>} Icon={TakeSampleIconControlSVG}
@@ -168,10 +168,10 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
             { showEventsGroup &&
               <ControlGroup>
                 <div className="event-buttons">
-                  { showVolcanicEruptionsToggle &&
+                  { showVolcanoesSwitch &&
                     <SliderSwitch label="Volcanoes"
                       isOn={this.simulationStore.volcanicEruptions} onSet={this.setShowVolcanicEruptions}/> }
-                  { showEarthquakesToggle &&
+                  { showEarthquakesSwitch &&
                     <SliderSwitch label="Earthquakes"
                       isOn={this.simulationStore.earthquakes} onSet={this.setShowEarthquakes}/> }
                 </div>

--- a/js/components/bottom-panel.tsx
+++ b/js/components/bottom-panel.tsx
@@ -121,8 +121,8 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
     const sidebarAction = sidebarActive ? "close" : "menu";
     const isDrawingCrossSection = interaction === "crossSection";
     const isTakingRockSample = interaction === "takeRockSample";
-    const showEarthquakesToggle = config.sidebar.includes("earthquakes");
-    const showVolcanicEruptionsToggle = config.sidebar.includes("volcanicEruptions");
+    const showEarthquakesToggle = config.showEarthquakesSwitch;
+    const showVolcanicEruptionsToggle = config.showVolcanoesSwitch;
     const showEventsGroup = showEarthquakesToggle || showVolcanicEruptionsToggle;
 
     const setColorMap = (colorMap: Colormap) => {

--- a/js/components/bottom-panel.tsx
+++ b/js/components/bottom-panel.tsx
@@ -142,9 +142,10 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
                 <span className="label">Reload</span>
               </Button>
             }
-            <ControlGroup>
-              <MapTypeButton colorMap={colormap} onSetColorMap={setColorMap} />
-            </ControlGroup>
+            { config.colormapOptions?.length > 1 &&
+              <ControlGroup>
+                <MapTypeButton colorMap={colormap} onSetColorMap={setColorMap} />
+              </ControlGroup> }
             <ControlGroup>
               <IconHighlightButton active={isDrawingCrossSection} disabled={false} data-test="draw-cross-section"
                 style={{ width: 92 }} label={<>Draw<br/>Cross-section</>} Icon={DrawCrossSectionIconSVG}
@@ -158,11 +159,12 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
                 <StepForwardButton disabled={options.playing} onClick={stepForward} data-test="step-forward-button" />
               </div>
             </ControlGroup>
-            <ControlGroup>
-              <IconHighlightButton active={isTakingRockSample} disabled={false} style={{ width: 64 }} data-test="take-sample"
-                label={<>Take<br/>Sample</>} Icon={TakeSampleIconControlSVG}
-                onClick={() => this.toggleInteraction("takeRockSample")} />
-            </ControlGroup>
+            { !config.geode &&
+              <ControlGroup>
+                <IconHighlightButton active={isTakingRockSample} disabled={false} style={{ width: 64 }} data-test="take-sample"
+                  label={<>Take<br/>Sample</>} Icon={TakeSampleIconControlSVG}
+                  onClick={() => this.toggleInteraction("takeRockSample")} />
+              </ControlGroup> }
             { showEventsGroup &&
               <ControlGroup>
                 <div className="event-buttons">

--- a/js/components/map-type-button.tsx
+++ b/js/components/map-type-button.tsx
@@ -1,42 +1,21 @@
 import { observer } from "mobx-react";
 import React from "react";
-import config, { Colormap } from "../config";
-import { SimulationStore } from "../stores/simulation-store";
-import PlanetCrustAgePNG from "../../images/planet-crust-age/planet-crust-age@3x.png";
-import PlanetPlateColorPNG from "../../images/planet-plate-color/planet-plate-color@3x.png";
-import PlanetRockTypesPNG from "../../images/planet-rock-types/planet-rock-types@3x.png";
-import PlanetTopographicPNG from "../../images/planet-topographic/planet-topographic@3x.png";
+import { availableColorMaps, getColorMapImage, getColorMapLabel } from "../color-maps";
+import { Colormap } from "../config";
 import ScrollIcon from "../../images/scroll-icon.svg";
 
 import css from "../../css-modules/map-type-button.less";
 
-export const COLORMAP_OPTIONS: { label: string, value: Colormap, image: any }[] = [
-  { value: "topo", label: "Topographic", image: PlanetTopographicPNG },
-  { value: "plate", label: "Plate Color", image: PlanetPlateColorPNG },
-  { value: "age", label: "Crust Age", image: PlanetCrustAgePNG },
-];
-if (config.rockLayers) {
-  COLORMAP_OPTIONS.push({ value: "rock", label: "Rock Type", image: PlanetRockTypesPNG });
-}
-
 function getNextColorMap(colorMap: Colormap) {
-  const index = COLORMAP_OPTIONS.findIndex(item => item.value === colorMap);
-  const newIndex = (index + 1) % COLORMAP_OPTIONS.length;
-  return COLORMAP_OPTIONS[newIndex].value;
+  const index = availableColorMaps.findIndex(item => item.value === colorMap);
+  const newIndex = (index + 1) % availableColorMaps.length;
+  return availableColorMaps[newIndex].value;
 }
 
 function getPrevColorMap(colorMap: Colormap) {
-  const index = COLORMAP_OPTIONS.findIndex(item => item.value === colorMap);
-  const newIndex = (index + COLORMAP_OPTIONS.length - 1) % COLORMAP_OPTIONS.length;
-  return COLORMAP_OPTIONS[newIndex].value;
-}
-
-function getColorMapImage(colorMap: Colormap) {
-  return COLORMAP_OPTIONS.find(item => item.value === colorMap)?.image;
-}
-
-function getColorMapLabel(colorMap: Colormap) {
-  return COLORMAP_OPTIONS.find(item => item.value === colorMap)?.label;
+  const index = availableColorMaps.findIndex(item => item.value === colorMap);
+  const newIndex = (index + availableColorMaps.length - 1) % availableColorMaps.length;
+  return availableColorMaps[newIndex].value;
 }
 
 interface IProps {

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -4,6 +4,7 @@ import { Button } from "react-toolbox/lib/button";
 import FontIcon from "react-toolbox/lib/font_icon";
 import config from "../config";
 import presets from "../presets";
+import { IGlobeInteractionName } from "../plates-interactions/globe-interactions-manager";
 import { SimulationStore } from "../stores/simulation-store";
 import ccLogo from "../../images/cc-logo.png";
 import ccLogoSmall from "../../images/cc-logo-small.png";
@@ -21,24 +22,26 @@ const AVAILABLE_PRESETS = [
 ];
 
 interface IStepsData {
-  info: string; // label of bottom bar button
+  info: (geode: boolean) => string; // label of bottom bar button
   navigationDisabled?: boolean; // whether next/back navigation should be disabled globally
   nextDisabled?: (simulationStore: SimulationStore) => boolean; // whether next navigation should be disabled conditionally
 }
 export const STEPS_DATA: Record<string, IStepsData> = {
   presets: {
-    info: "Select layout of the planet",
+    info: () => "Select layout of the planet",
     navigationDisabled: true
   },
   continents: {
-    info: "Draw continents"
+    info: () => "Draw continents"
   },
   forces: {
-    info: "Assign boundary types",
-    nextDisabled: simulationStore => !simulationStore.anyBoundaryDefinedByUser
+    info: (geode: boolean) => geode
+            ? "Assign forces to plates"
+            : "Assign boundary types",
+    nextDisabled: simulationStore => !simulationStore.anyHotSpotDefinedByUser
   },
   densities: {
-    info: "Order plates"
+    info: () => "Order plates"
   }
 };
 
@@ -176,8 +179,9 @@ class PlanetWizard extends BaseComponent<IProps, IState> {
   setForcesStep() {
     const { setOption } = this.simulationStore;
     this.simulationStore.setAnyBoundaryDefinedByUser(false);
-    setOption("interaction", "assignBoundary");
-    setOption("selectableInteractions", config.cameraLockedInPlanetWizard ? [] : ["assignBoundary", "none"]);
+    const forcesInteraction: IGlobeInteractionName = config.geode ? "force" : "assignBoundary";
+    setOption("interaction", forcesInteraction);
+    setOption("selectableInteractions", config.cameraLockedInPlanetWizard ? [] : [forcesInteraction, "none"]);
     setOption("colormap", "topo");
     if (config.cameraLockedInPlanetWizard) {
       this.simulationStore.resetPlanetCamera();
@@ -272,7 +276,7 @@ class PlanetWizard extends BaseComponent<IProps, IState> {
             STEPS.map((stName: string, idx: number) =>
               <span className="step" key={idx} data-test={"step" + idx}>
                 { this.renderStep(idx) }
-                { this.renderInfo(idx, STEPS_DATA[stName].info) }
+                { this.renderInfo(idx, STEPS_DATA[stName].info(config.geode)) }
                 <div className="divider" />
               </span>)
           }

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -178,7 +178,7 @@ class PlanetWizard extends BaseComponent<IProps, IState> {
 
   setForcesStep() {
     const { setOption } = this.simulationStore;
-    this.simulationStore.setAnyBoundaryDefinedByUser(false);
+    this.simulationStore.setAnyHotSpotDefinedByUser(false);
     const forcesInteraction: IGlobeInteractionName = config.geode ? "force" : "assignBoundary";
     setOption("interaction", forcesInteraction);
     setOption("selectableInteractions", config.cameraLockedInPlanetWizard ? [] : [forcesInteraction, "none"]);

--- a/js/config.ts
+++ b/js/config.ts
@@ -22,6 +22,8 @@ const DEFAULT_CONFIG = {
   modelId: "",
   // If true, the model will start automatically.
   playing: true,
+  // If true, show the earthquakes switch in the bottom bar
+  showEarthquakesSwitch: true,
   // If true, the model will show randomly generated earthquakes.
   earthquakes: false,
   // Lifespan of an earthquake in model time.
@@ -30,6 +32,8 @@ const DEFAULT_CONFIG = {
   earthquakeInSubductionZoneProbability: 300,
   // Constant that decides how likely is for an earthquake to show up in the divergent boundary zone.
   earthquakeInDivergentZoneProbability: 540,
+  // If true, show the volcanoes switch in the bottom bar
+  showVolcanoesSwitch: true,
   // If true, the model will show randomly generated volcanic eruptions.
   volcanicEruptions: false,
   // Lifespan of a volcanic eruption in model time.
@@ -126,8 +130,6 @@ const DEFAULT_CONFIG = {
     "interactions",
     "timestep",
     "colormap",
-    "earthquakes",
-    "volcanicEruptions",
     "metamorphism",
     "latLongLines",
     "plateLabels",

--- a/js/config.ts
+++ b/js/config.ts
@@ -22,6 +22,10 @@ const DEFAULT_CONFIG = {
   modelId: "",
   // If true, the model will start automatically.
   playing: true,
+  // If true, show the Draw Cross-section button in the bottom bar
+  showDrawCrossSectionButton: true,
+  // If true, show the Take Sample button in the bottom bar
+  showTakeSampleButton: true,
   // If true, show the earthquakes switch in the bottom bar
   showEarthquakesSwitch: true,
   // If true, the model will show randomly generated earthquakes.
@@ -124,7 +128,7 @@ const DEFAULT_CONFIG = {
   // Large values (128-256) will smooth out the rendering.
   topoColormapShades: 256,
   // Shows extended version of the cross-section with separate rock layers.
-  rockLayers: true,
+  // rockLayers: true,  // replaced by `geode` property
   bumpMapping: true,
   sidebar: [
     "interactions",

--- a/js/config.ts
+++ b/js/config.ts
@@ -3,6 +3,9 @@ import { getURLParam } from "./utils";
 export type Colormap = "topo" | "plate" | "age" | "rock";
 
 const DEFAULT_CONFIG = {
+  // default to TecRocks, showing all UI features
+  // if geode is specified, restrict UI to geode features
+  geode: false,
   // Authoring mode that lets user pick a planet layout and put continents on them.
   // Usually it is overwritten using URL param: planetWizard=true.
   planetWizard: false,
@@ -94,6 +97,8 @@ const DEFAULT_CONFIG = {
   minSizeRatioForDivision: 0.6,
   // Rendering:
   colormap: "topo", // 'topo', 'age', 'plate', or 'rock'
+  // color map options available for user selection
+  colormapOptions: ["topo", "plate", "age", "rock"],
   // Defines interaction that can be selected using top bar.
   selectableInteractions: ["force", "none"],
   // Enables metamorphic overlay in the cross-section (added in subduction and orogeny zones).
@@ -180,4 +185,10 @@ Object.keys(DEFAULT_CONFIG).forEach((key) => {
 });
 
 const finalConfig: Record<string, any> = { ...DEFAULT_CONFIG, ...urlConfig };
+// `geode` param overrides some other params
+if (finalConfig.geode) {
+  // can't draw force arrows if you can't rotate the globe
+  finalConfig.cameraLockedInPlanetWizard = false;
+  finalConfig.rockLayers = false;
+}
 export default finalConfig;

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -75,7 +75,7 @@ export class SimulationStore {
   @observable currentHotSpot: { position: THREE.Vector3; force: THREE.Vector3; } | null = null;
   @observable screenWidth = Infinity;
   @observable selectedBoundary: IBoundaryInfo | null = null;
-  @observable anyBoundaryDefinedByUser = false;
+  @observable anyHotSpotDefinedByUser = false;
   @observable selectedRock: RockKeyLabel | null = null;
   @observable selectedRockFlash = false;
   // Why boundary is in fact a FieldStore? One field is enough to define a single boundary segment. No need to store more data.
@@ -203,6 +203,7 @@ export class SimulationStore {
   @action.bound setCurrentHotSpot(position: THREE.Vector3, force: THREE.Vector3) {
     // Make sure to create a new `currentHotSpot` object, so View3d can detect that this property has been changed.
     this.currentHotSpot = { position, force };
+    this.anyHotSpotDefinedByUser = true;
   }
 
   @action.bound setHotSpot(data: IHotSpot) {

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -68,7 +68,7 @@ export class SimulationStore {
   @observable planetCameraAnimating = false;
   @observable crossSectionCameraAngle = DEFAULT_CROSS_SECTION_CAMERA_ANGLE;
   @observable crossSectionCameraAnimating = false;
-  @observable rockLayers = config.rockLayers;
+  @observable rockLayers = !config.geode;
   @observable lastStoredModel: string | null = null;
   @observable savingModel = false;
   @observable debugMarker = new THREE.Vector3();

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -449,8 +449,8 @@ export class SimulationStore {
     this.screenWidth = val;
   }
 
-  @action.bound setAnyBoundaryDefinedByUser(val: boolean) {
-    this.anyBoundaryDefinedByUser = val;
+  @action.bound setAnyHotSpotDefinedByUser(val: boolean) {
+    this.anyHotSpotDefinedByUser = val;
   }
 
   @action.bound clearSelectedBoundary() {
@@ -473,7 +473,7 @@ export class SimulationStore {
   @action.bound setSelectedBoundaryType(type: BoundaryType) {
     if (this.selectedBoundary?.orientation) {
       this.selectedBoundary.type = type;
-      this.setAnyBoundaryDefinedByUser(true);
+      this.setAnyHotSpotDefinedByUser(true);
       convertBoundaryTypeToHotSpots(this.selectedBoundary).forEach(hotSpot => this.setHotSpot(hotSpot));
     }
   }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,68 @@
+import { getURLParam } from "../js/utils";
+
+describe("getURLParam", () => {
+
+  // mocking code cribbed from CLUE
+  const originalLocation = window.location;
+
+  const mockWindowLocation = (newLocation: Location | URL) => {
+    delete (window as any).location;
+    window.location = newLocation as Location;
+  };
+
+  const setLocation = (url: string) => {
+    mockWindowLocation(new URL(url));
+  };
+
+  const testQueryParam = (params: string, name: string) => {
+    setLocation(`https://concord.org${params ? `?${params}` : ""}`);
+    return getURLParam(name);
+  };
+
+  afterEach(() => {
+    mockWindowLocation(originalLocation);
+  });
+
+  it("should return null for nonexistent parameters", () => {
+    expect(testQueryParam("", "foo")).toBeNull();
+    expect(testQueryParam("bar=roo", "foo")).toBeNull();
+  });
+
+  it("should return true for parameters without values", () => {
+    expect(testQueryParam("foo&bar", "foo")).toBe(true);
+    expect(testQueryParam("foo&bar", "bar")).toBe(true);
+    expect(testQueryParam("foo=&bar=", "foo")).toBe(true);
+    expect(testQueryParam("foo=&bar=", "bar")).toBe(true);
+  });
+
+  it("should return the value for parameters with values", () => {
+    expect(testQueryParam("foo=bar", "foo")).toBe("bar");
+    expect(testQueryParam("foo=bar&baz=roo", "foo")).toBe("bar");
+    expect(testQueryParam("foo=bar&baz=roo", "baz")).toBe("roo");
+  });
+
+  it("should process names with square brackets", () => {
+    // the purpose of the square-bracket name processing code is not entirely clear
+    expect(testQueryParam("foo[]=bar", "foo[]")).toBe("bar");
+  });
+
+  it("should return stringified array results", () => {
+    expect(testQueryParam("foo=[bar,baz,roo]", "foo")).toBe("[bar,baz,roo]");
+  });
+
+  it("should decode encoded characters in returned values", () => {
+    expect(testQueryParam("foo=bar%20baz", "foo")).toBe("bar baz");
+  });
+
+  it("should replace '+' with ' ' in returned values", () => {
+    expect(testQueryParam("foo=bar+baz", "foo")).toBe("bar baz");
+  });
+
+  it("should ignore hash parameters", () => {
+    expect(testQueryParam("foo=bar#baz=roo", "foo")).toBe("bar");
+    expect(testQueryParam("foo=bar#baz=roo", "baz")).toBeNull();
+    expect(testQueryParam("#foo=bar&baz=roo", "foo")).toBeNull();
+    // code as written ignores the first hash param but accepts subsequent ones
+    // expect(testQueryParam("#foo=bar&baz=roo", "baz")).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR attempts to wrap up a number of outstanding PT stories:

[[#180169391]](https://www.pivotaltracker.com/story/show/180169391) TecRocks model bottom bar UI
[[#180168841]](https://www.pivotaltracker.com/story/show/180168841) GEODE Bottom Bar UI
[[#180256803]](https://www.pivotaltracker.com/story/show/180256803) Authoring control of available map types

Demo (TecRocks): https://tectonic-explorer.concord.org/branch/geode-param/index.html?preset=benchmark
Demo (Geode): https://tectonic-explorer.concord.org/branch/geode-param/index.html?geode&preset=benchmark
Demo (Authoring): https://tectonic-explorer.concord.org/branch/geode-param/index.html?authoring

Notable features:
- new `geode` url parameter controls whether the TecRocks or Geode UI is presented
- `geode` planet wizard uses prior force-drawing UI instead of TecRocks boundary-assignment UI
- new `colormapOptions` parameter controls the map types available for user selection
- `geode` and `colormapOptions` parameters are authorable
- `geode` parameter overrides other parameters
  - `cameraLockedInPlanetWizard` => false in `geode` since planet rotation is required in force-drawing UI
  - `rockLayers` => false in `geode`
- Map types control in bottom bar is now shown if only one map type option is available
- Take [Rock] Sample control in bottom bar is not shown in `geode`
- Presentation of `Earthquakes` and `Volcanoes` switches is authorable
- TecRocks-only authoring options are hidden when `geode` parameter is specified
- interdependent authoring options are updated dynamically
  - available planet wizard options update based on `geode` parameter
  - default map type limited to one of currently available map types
  - "rock" map type not available in `geode`

Separately, when I started working on url parameters I was curious about how the parser handled parameters without values and a few other special cases, so I took a little time to write a unit test for the parameter parser that puts it through its paces.