### PR TITLE
Eliminate metamorphism option from authoring and sidebar in geode

### DIFF
--- a/js/components/authoring.tsx
+++ b/js/components/authoring.tsx
@@ -1,3 +1,4 @@
+import clone from "lodash/clone";
 import React, { PureComponent } from "react";
 import Checkbox from "react-toolbox/lib/checkbox";
 import { Button } from "react-toolbox/lib/button";
@@ -22,7 +23,6 @@ type ValueLabel = { value: string; label: string };
 
 // Options can be defined as string or [name, label] array.
 const MAIN_OPTIONS: Option[] = [
-  ["rockLayers", "show rock layers"],
   ["playing", "auto-start simulation"],
   ["timeCounter", "show time counter"],
   ["selectableInteractions", "main view interaction buttons"]
@@ -48,7 +48,7 @@ const VIEW_OPTIONS: Option[] = [
 ];
 
 // Options that need not be authored or specified in the url for geode
-const TECROCKS_ONLY_OPTIONS = ["cameraLockedInPlanetWizard", "showTakeSampleButton"];
+const TECROCKS_ONLY_OPTIONS = ["cameraLockedInPlanetWizard", "metamorphism", "showTakeSampleButton"];
 
 // Options that are defined manually or just shouldn't be displayed in "Advanced options" section.
 const SKIPPED_OPTIONS: Option[] = ["authoring", "geode", "planetWizard", "planetWizardSteps",
@@ -267,6 +267,8 @@ export default class Authoring extends PureComponent<IProps, IState> {
     const setValues = (values: any) => {
       this.setState({ [name]: values });
     };
+    const filteredOptions = clone(options);
+    TECROCKS_ONLY_OPTIONS.forEach(key => (filteredOptions[key] != null) && delete filteredOptions[key]);
     return (
       <div key={`autocompl-${name}`}>
         <div className={css.autocompleteLabel}>{ label }</div>
@@ -275,7 +277,7 @@ export default class Authoring extends PureComponent<IProps, IState> {
           direction="down"
           onChange={setValues}
           label={"Choose options"}
-          source={options}
+          source={filteredOptions}
           value={this.state[name]}
         />
       </div>

--- a/js/components/sidebar-menu.tsx
+++ b/js/components/sidebar-menu.tsx
@@ -153,7 +153,7 @@ export default class SidebarMenu extends BaseComponent<IProps, IState> {
           }
           { enabledWidgets.interactions &&
             <ListItem ripple={false} itemContent={<Dropdown className="wide-dropdown" label="Interaction" source={INTERACTION_OPTIONS} value={options.interaction} onChange={this.changeInteraction} />} /> }
-          { enabledWidgets.metamorphism &&
+          { !config.geode && enabledWidgets.metamorphism &&
             <ListCheckbox caption="Metamorphism" legend="Show metamorphism" data-test="toggle-metamorphism" checked={options.metamorphism} onChange={this.toggleMetamorphism} className={css.listItem} /> }
           { enabledWidgets.latLongLines &&
             <ListCheckbox caption="Latitude and Longitude Lines" legend="Geographic coordinate system" data-test="toggle-renderLatLongLines" checked={options.renderLatLongLines} onChange={this.toggleLatLongLines} className={css.listItem} /> }


### PR DESCRIPTION
From a comment in [this PT story](https://www.pivotaltracker.com/story/show/180168841):

>I also noticed that the "Metamorphism" check box was available in the menu in the link provided below. That should not be in the GEODE version. Can you remove it?

Testable at https://tectonic-explorer.concord.org/branch/no-geode-metaphorphism/index.html?geode&preset=benchmark.