### PR TITLE
Fix fullscreen icon button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
         "canvas": "^2.8.0",
         "copy-webpack-plugin": "^9.1.0",
-        "css-loader": "^6.5.1",
+        "css-loader": "^5.2.7",
         "cypress": "^9.0.0",
         "cypress-image-snapshot": "^4.0.1",
         "enzyme": "^3.11.0",
@@ -6661,29 +6661,31 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.5.1.tgz",
-      "integrity": "sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
+      "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
       "dev": true,
       "dependencies": {
         "icss-utils": "^5.1.0",
+        "loader-utils": "^2.0.0",
         "postcss": "^8.2.15",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^3.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 10.13.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.0.0"
+        "webpack": "^4.27.0 || ^5.0.0"
       }
     },
     "node_modules/css-loader/node_modules/lru-cache": {
@@ -24221,18 +24223,20 @@
       }
     },
     "css-loader": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.5.1.tgz",
-      "integrity": "sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
+      "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
       "dev": true,
       "requires": {
         "icss-utils": "^5.1.0",
+        "loader-utils": "^2.0.0",
         "postcss": "^8.2.15",
         "postcss-modules-extract-imports": "^3.0.0",
         "postcss-modules-local-by-default": "^4.0.0",
         "postcss-modules-scope": "^3.0.0",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^3.0.0",
         "semver": "^7.3.5"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
     "canvas": "^2.8.0",
     "copy-webpack-plugin": "^9.1.0",
-    "css-loader": "^6.5.1",
+    "css-loader": "^5.2.7",
     "cypress": "^9.0.0",
     "cypress-image-snapshot": "^4.0.1",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
For as-yet-unknown reasons, the update to `css-loader` v6 broke the rendering of the fullscreen icon button. In lieu of investigating we simply revert to `css-loader` v5 for now.

Demo: https://tectonic-explorer.concord.org/branch/css-loader-5/index.html?preset=benchmark