### PR TITLE
Authoring: fix handling of autocomple options, fix sidebar options in Geode mode

### DIFF
--- a/js/config.ts
+++ b/js/config.ts
@@ -135,7 +135,6 @@ const DEFAULT_CONFIG = {
   sidebar: [
     "interactions",
     "timestep",
-    "colormap",
     "metamorphism",
     "latLongLines",
     "plateLabels",


### PR DESCRIPTION
There were two issues related to autocomplete:
- "metamorphic" value was not handled correctly for "sidebar" array and Geode/TecRock mode, so it was possible to remove it from the TecRock version
- array values were compared unsorted that could lead to unnecessary URL arguments

First, I've tried to handle it in a more generic way (by filtering autocomplete options dynamically rather than storying them in state and modifying explicitly) and then refactor other pieces that use a similar approach. But I ran into issues and just gave up to save time. Especially that other pieces are more complicated than sidebar. After working on this, I have an impression that it might become pretty confusing if we add more Geode options (I had hard times finding out what's going on, even though the issue wasn't very complex). If I have more time or when I add one more Geode option, I'd try to think if there's some generic way to handle all that.

[#180267346]