### PR TITLE
Rock key: update styles to make enough space for scrollbar

### DIFF
--- a/css-modules/side-container.less
+++ b/css-modules/side-container.less
@@ -84,8 +84,11 @@
       border-left: 4px solid red;
       margin-top: 2px;
       box-shadow: @outlineWithoutBottom;
-      padding: @tabPanelTopPadding 10px @tabPanelBottomPadding 10px;
+      // 15px padding is bigger than in the UI specs, but it's necessary for scrollbar to fit the padding area.
+      // It might not be visible on MacOS, but some other systems always show scrollbar when mouse is connected.
+      padding: @tabPanelTopPadding 15px @tabPanelBottomPadding 15px;
       overflow-y: scroll;
+      overflow-x: hidden;
     }
 
     .mapTypeBorder {

--- a/css/variables.less
+++ b/css/variables.less
@@ -8,4 +8,4 @@
 @component-border-radius: 9px;
 @control-panel-height: 65px;
 @control-panel-content-height: 74px; // it's higher than @control-panel-height because of "bubbles"
-@tabs-panel-width: 326px;
+@tabs-panel-width: 336px;


### PR DESCRIPTION
A small fix to address layout issues when scrollbars are visible:
https://www.pivotaltracker.com/story/show/179940030/comments/228127468
(probably on windows + mouse)

[#179940030]