### PR TITLE
Add LARA / AP logging

### DIFF
--- a/js/components/advanced-options.tsx
+++ b/js/components/advanced-options.tsx
@@ -7,6 +7,7 @@ import Slider from "react-toolbox/lib/slider";
 import Dropdown from "react-toolbox/lib/dropdown";
 import config from "../config";
 import { BaseComponent, IBaseProps } from "./base";
+import { log } from "../log";
 
 import css from "../../css-modules/advanced-options.less";
 
@@ -77,11 +78,19 @@ export class AdvancedOptions extends BaseComponent<IProps, IState> {
     } else {
       setOption(name, value);
     }
+
+    if (name === "interaction") {
+      log({ action: "InteractionUpdated", data: { value } });
+    } else if (name === "timestep") {
+      log({ action: "SimulationSpeedUpdated", data: { value } });
+    }
   }
 
   toggleOption(name: any) {
     const { setOption } = this.simulationStore;
-    setOption(name, !this.options[name]);
+    const newValue = !this.options[name];
+    setOption(name, newValue);
+    log({ action: "AdvancedOptionToggled", data: { label: name, value: newValue } });
   }
 
   togglePlateVisibility(plateId: number, checked: boolean) {
@@ -129,6 +138,7 @@ export class AdvancedOptions extends BaseComponent<IProps, IState> {
     this.simulationStore.saveModel();
     this.storedPlayState = this.options.playing;
     this.handleChange("playing", false);
+    log({ action: "ModelShared" });
   }
 
   render() {

--- a/js/components/bottom-panel.tsx
+++ b/js/components/bottom-panel.tsx
@@ -15,6 +15,7 @@ import { IGlobeInteractionName } from "../plates-interactions/globe-interactions
 import { BaseComponent, IBaseProps } from "./base";
 
 import "../../css/bottom-panel.less";
+import { log } from "../log";
 
 function toggleFullscreen() {
   if (screenfull.isEnabled) {
@@ -71,25 +72,38 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
   }
 
   fullscreenChange = () => {
-    this.setState({ fullscreen: screenfull.isEnabled && screenfull.isFullscreen });
+    const fullscreen = screenfull.isEnabled && screenfull.isFullscreen;
+    this.setState({ fullscreen });
+    log({ action: fullscreen ? "FullScreenEnabled" : "FullScreenDisabled" });
   };
 
   togglePlayPause = () => {
     const { setOption } = this.simulationStore;
-    setOption("playing", !this.options.playing);
+    const newState = !this.options.playing;
+    setOption("playing", newState);
+    log({ action: newState ? "SimulationStarted" : "SimulationStopped" });
   };
 
   setShowEarthquakes = (on: boolean) => {
     this.simulationStore.setEarthquakesVisible(on);
+    log({ action: on ? "EarthquakesVisible" : "EarthquakesHidden" });
   };
 
   setShowVolcanicEruptions = (on: boolean) => {
     this.simulationStore.setVolcanicEruptionsVisible(on);
+    log({ action: on ? "VolcanicEruptionsVisible" : "VolcanicEruptionsHidden" });
   };
 
   toggleInteraction = (interaction: IGlobeInteractionName) => {
     const { setInteraction, interaction: currentInteraction } = this.simulationStore;
     setInteraction(currentInteraction === interaction ? "none" : interaction);
+    if (interaction === "crossSection") {
+      log({ action: "CrossSectionDrawingEnabled" });
+    } else if (interaction === "takeRockSample") {
+      log({ action: "RockPickerEnabled" });
+    } else {
+      log({ action: "InteractionUpdated", data: { value: interaction } });
+    }
   };
 
   render() {
@@ -103,6 +117,7 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
 
     const setColorMap = (colorMap: Colormap) => {
       this.simulationStore.setOption("colormap", colorMap);
+      log({ action: "MapTypeUpdated", data: { value: colorMap } });
     };
 
     return (

--- a/js/components/bottom-panel.tsx
+++ b/js/components/bottom-panel.tsx
@@ -13,9 +13,9 @@ import DrawCrossSectionIconSVG from "../../images/draw-cross-section-icon.svg";
 import TakeSampleIconControlSVG from "../../images/take-sample-icon-control.svg";
 import { IGlobeInteractionName } from "../plates-interactions/globe-interactions-manager";
 import { BaseComponent, IBaseProps } from "./base";
+import { log } from "../log";
 
 import "../../css/bottom-panel.less";
-import { log } from "../log";
 
 function toggleFullscreen() {
   if (screenfull.isEnabled) {

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -10,6 +10,7 @@ import ccLogo from "../../images/cc-logo.png";
 import ccLogoSmall from "../../images/cc-logo-small.png";
 import SortableDensities from "./sortable-densities";
 import { BaseComponent, IBaseProps } from "./base";
+import { log } from "../log";
 
 import "../../css/planet-wizard.less";
 
@@ -131,6 +132,7 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
   handleNextButtonClick() {
     const { step } = this.state;
     this.setState({ step: step + 1 });
+    log({ action: "PlanetWizardNextButtonClicked" });
   }
 
   handleBackButtonClick() {
@@ -138,6 +140,7 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
     if (step > 0) {
       this.setState({ step: step - 1 });
     }
+    log({ action: "PlanetWizardBackButtonClicked" });
   }
 
   saveModel() {
@@ -158,6 +161,8 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
     const { loadPresetModel } = this.simulationStore;
     loadPresetModel(presetInfo.name);
     this.handleNextButtonClick();
+
+    log({ action: "PlanetWizardNumberOfPlatesSelected", data: { value: presetInfo.name } });
   }
 
   unloadModel() {

--- a/js/components/side-container.tsx
+++ b/js/components/side-container.tsx
@@ -10,9 +10,11 @@ import { MapType } from "./keys/map-type";
 import { RockTypes } from "./keys/rock-types";
 import { SeismicData } from "./keys/seismic-data";
 import { AdvancedOptions } from "./advanced-options";
+import { log } from "../log";
 
 import "react-tabs/style/react-tabs.less";
 import css from "../../css-modules/side-container.less";
+
 
 const TAB_ORDER: TabName[] = ["map-type", "seismic-data", "options"];
 
@@ -27,11 +29,15 @@ interface IState { }
 export class SideContainer extends BaseComponent<IBaseProps, IState> {
 
   handleTabChange = (newTabIndex: number) => {
-    this.simulationStore.setSelectedTab(TAB_ORDER[newTabIndex]);
+    const newTab = TAB_ORDER[newTabIndex];
+    this.simulationStore.setSelectedTab(newTab);
+    log({ action: "KeysAndOptionsTabChanged", data: { value: newTab } });
   };
 
   toggleKey = () => {
-    this.simulationStore.setKeyVisible(!this.simulationStore.key);
+    const visible = !this.simulationStore.key;
+    this.simulationStore.setKeyVisible(visible);
+    log({ action: visible ? "KeysAndOptionsVisible" : "KeysAndOptionsHidden" });
   };
 
   renderKeyButton() {

--- a/js/components/sortable-densities.tsx
+++ b/js/components/sortable-densities.tsx
@@ -7,6 +7,7 @@ import FontIcon from "react-toolbox/lib/font_icon";
 import config from "../config";
 import { BaseComponent, IBaseProps } from "./base";
 import PlateStore from "../stores/plate-store";
+import { log } from "../log";
 
 import "../../css/sortable-densities.less";
 
@@ -63,6 +64,8 @@ export default class SortableDensities extends BaseComponent<IBaseProps, IState>
       newDensities[plateInfo.id] = index;
     });
     this.simulationStore.setDensities(newDensities);
+
+    log({ action: "PlateDensitiesUpdated", data: { value: newPlateInfos.map((p: any) => p.label) } });
   }
 
   onSortEnd({ oldIndex, newIndex }: { oldIndex: number, newIndex: number }) {
@@ -78,10 +81,10 @@ export default class SortableDensities extends BaseComponent<IBaseProps, IState>
           { config.densityWordInPlanetWizard ? "HIGH" : "BELOW" }
         </div>
         <div className="helper-text">
-          { 
+          {
             config.densityWordInPlanetWizard
               ? "Click and drag to reorder the plate density"
-              : "Click and drag to reorder the plates" 
+              : "Click and drag to reorder the plates"
           }
         </div>
       </div>

--- a/js/components/top-bar.tsx
+++ b/js/components/top-bar.tsx
@@ -3,13 +3,19 @@ import FontIcon from "react-toolbox/lib/font_icon";
 import { Dialog } from "react-toolbox/lib/dialog";
 import ShareDialogContent from "./share-dialog-content";
 import AboutDialogContent from "./about-dialog-content";
+import { log } from "../log";
 
 import css from "../../css-modules/top-bar.less";
 import aboutTheme from "../../css-modules/about-dialog.less";
 import shareTheme from "../../css-modules/share-dialog.less";
 
 function reloadPage() {
-  window.location.reload();
+  log({ action: "ReloadIconClicked" });
+  setTimeout(() => {
+    // Delay reload so the log request can be issued. This feature will be probably removed, so I don't think
+    // it's worth implementing any sophisticated checks if the log message was actually delivered.
+    window.location.reload();
+  }, 150);
 }
 
 function copyTextarea(textAreaId: string) {
@@ -41,10 +47,12 @@ export default class TopBar extends PureComponent<IProps, IState> {
 
   openShareDialog() {
     this.setState({ shareDialogOpen: true, aboutDialogOpen: false });
+    log({ action: "ShareDialogOpened" });
   }
 
   openAboutDialog() {
     this.setState({ aboutDialogOpen: true, shareDialogOpen: false });
+    log({ action: "AboutDialogOpened" });
   }
 
   closeShareDialog() {

--- a/js/log.ts
+++ b/js/log.ts
@@ -1,0 +1,66 @@
+import { log as laraLog } from "@concord-consortium/lara-interactive-api";
+import { Colormap } from "./config";
+import { IGlobeInteractionName } from "./plates-interactions/globe-interactions-manager";
+import { BoundaryType, RockKeyLabel, TabName } from "./types";
+
+type SimulationStarted =  { action: "SimulationStarted", data?: undefined };
+type SimulationStopped = { action: "SimulationStopped", data?: undefined };
+type SimulationReloaded = { action: "SimulationReloaded", data?: undefined };
+type SimulationReset = { action: "SimulationReset", data?: undefined };
+type SimulationStepForward = { action: "SimulationStepForward", data?: undefined };
+type SimulationStepBack = { action: "SimulationStepBack", data?: undefined };
+type EarthquakesVisible = { action: "EarthquakesVisible", data?: undefined };
+type EarthquakesHidden = { action: "EarthquakesHidden", data?: undefined };
+type VolcanicEruptionsVisible = { action: "VolcanicEruptionsVisible", data?: undefined };
+type VolcanicEruptionsHidden = { action: "VolcanicEruptionsHidden", data?: undefined };
+// Colormap: "topo" | "plate" | "age" | "rock"
+type MapTypeUpdated = { action: "MapTypeUpdated", data?: { value: Colormap }};
+type CrossSectionDrawingEnabled = { action: "CrossSectionDrawingEnabled", data?: undefined };
+type RockPickerEnabled = { action: "RockPickerEnabled", data?: undefined };
+// InteractionUpdated does NOT include cross section drawing and rock picker tool that have separate log events
+// as they seem to be the most important.
+// IGlobeInteractionName: "force" | "fieldInfo" | "markField" | "assignBoundary" | "continentDrawing" | "continentErasing" | "none"
+type InteractionUpdated = { action: "InteractionUpdated", data?: { value: IGlobeInteractionName } };
+type FullScreenEnabled = { action: "FullScreenEnabled", data?: undefined };
+type FullScreenDisabled = { action: "FullScreenDisabled", data?: undefined };
+type KeysAndOptionsVisible = { action: "KeysAndOptionsVisible", data?: undefined };
+type KeysAndOptionsHidden = { action: "KeysAndOptionsHidden", data?: undefined };
+// TabName: "map-type" | "seismic-data" | "options"
+type KeysAndOptionsTabChanged = { action: "KeysAndOptionsTabChanged", data?: { value: TabName } };
+// Either by clicking on the earth surface, in the cross-section, or in the rock key directly.
+// RockKeyLabel: all the rock names visible in the rock key
+type RockKeyInfoDisplayed = { action: "RockKeyInfoDisplayed", data?: { value: RockKeyLabel } };
+type AdvancedOptionToggled = { action: "AdvancedOptionToggled", data?: { label: string, value: any } };
+type SimulationSpeedUpdated = { action: "SimulationSpeedUpdated", data?: { value: number } };
+// Model shared using Advanced Options tab
+type ModelShared = { action: "ModelShared", data?: undefined };
+type ShareDialogOpened = { action: "ShareDialogOpened", data?: undefined };
+type AboutDialogOpened = { action: "AboutDialogOpened", data?: undefined };
+type ReloadIconClicked = { action: "ReloadIconClicked", data?: undefined };
+type ResetPlanetOrientationClicked = { action: "ResetPlanetOrientationClicked", data?: undefined };
+type ResetCrossSectionOrientationClicked = { action: "ResetCrossSectionOrientationClicked", data?: undefined };
+type CrossSectionClosed = { action: "CrossSectionClosed", data?: undefined };
+type CrossSectionDrawingFinished = { action: "CrossSectionDrawingFinished", data?: undefined };
+type PlanetWizardNumberOfPlatesSelected = { action: "PlanetWizardNumberOfPlatesSelected", data: { value: string }};
+type ContinentAdded = { action: "ContinentAdded", data?: undefined };
+type ContinentRemoved = { action: "ContinentRemoved", data?: undefined };
+// BoundaryType: "convergent" | "divergent"
+type BoundaryTypeSelected = { action: "BoundaryTypeSelected", data: { value: BoundaryType }};
+// value is array of plate names
+type PlateDensitiesUpdated = { action: "PlateDensitiesUpdated", data: { value: string[] }}
+type PlanetWizardNextButtonClicked = { action: "PlanetWizardNextButtonClicked", data?: undefined };
+type PlanetWizardBackButtonClicked = { action: "PlanetWizardBackButtonClicked", data?: undefined };
+
+type LogEvent = SimulationStarted | SimulationStopped | EarthquakesVisible | EarthquakesHidden |
+  VolcanicEruptionsVisible | VolcanicEruptionsHidden | MapTypeUpdated | CrossSectionDrawingEnabled |
+  RockPickerEnabled | InteractionUpdated | FullScreenEnabled | FullScreenDisabled | SimulationReloaded |
+  SimulationReset | SimulationStepForward | SimulationStepBack | KeysAndOptionsVisible | KeysAndOptionsHidden |
+  KeysAndOptionsTabChanged | RockKeyInfoDisplayed | AdvancedOptionToggled | SimulationSpeedUpdated | ModelShared |
+  ShareDialogOpened | AboutDialogOpened | ReloadIconClicked | ResetPlanetOrientationClicked | ResetCrossSectionOrientationClicked |
+  CrossSectionClosed | CrossSectionDrawingFinished | PlanetWizardNumberOfPlatesSelected | ContinentAdded | ContinentRemoved |
+  BoundaryTypeSelected | PlateDensitiesUpdated | PlanetWizardNextButtonClicked | PlanetWizardBackButtonClicked
+;
+
+export const log = (event: LogEvent) => {
+  laraLog(event.action, event.data);
+};

--- a/js/plates-interactions/cross-section-drawing.ts
+++ b/js/plates-interactions/cross-section-drawing.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import c from "../constants";
 import config from "../config";
+import { log } from "../log";
 
 const CROSS_SECTION_PADDING = 100;
 
@@ -78,6 +79,7 @@ export default class CrossSectionDrawing {
   onPointerUp() {
     if (this.data?.point2) {
       this.emit("crossSectionDrawingEnd", this.data);
+      log({ action: "CrossSectionDrawingFinished" });
     }
     this.data = null;
   }

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -20,6 +20,7 @@ import { rockProps } from "../plates-model/rock-properties";
 import FieldStore from "./field-store";
 import { convertBoundaryTypeToHotSpots, findBoundaryFieldAround, getBoundaryInfo, highlightBoundarySegment, unhighlightBoundary } from "./helpers/boundary-utils";
 import { animateAngleTransition, animateVectorTransition } from "./helpers/animation-utils";
+import { log } from "../log";
 
 export interface ISerializedState {
   version: 4;
@@ -256,6 +257,8 @@ export class SimulationStore {
     if (this.interaction === "crossSection") {
       this.interaction = "none";
     }
+
+    log({ action: "CrossSectionClosed" });
   }
 
   @action.bound setPlanetCameraLocked(value: boolean) {
@@ -287,6 +290,8 @@ export class SimulationStore {
         this.planetCameraAnimating = false;
       })
     });
+
+    log({ action: "ResetPlanetOrientationClicked" });
   }
 
   @action.bound resetCrossSectionCamera() {
@@ -306,6 +311,8 @@ export class SimulationStore {
         this.crossSectionCameraAnimating = false;
       })
     });
+
+    log({ action: "ResetCrossSectionOrientationClicked" });
   }
 
   @action.bound loadPresetModel(presetName: string) {
@@ -417,6 +424,7 @@ export class SimulationStore {
 
   @action.bound stepForward() {
     workerController.postMessageToModel({ type: "stepForward" });
+    log({ action: "SimulationStepForward" });
   }
 
   @action.bound reload() {
@@ -435,6 +443,7 @@ export class SimulationStore {
     }
     this.setKeyVisible(false);
     this.closeCrossSection();
+    log({ action: "SimulationReloaded" });
   }
 
   @action.bound takeLabeledSnapshot(label: string) {
@@ -455,12 +464,14 @@ export class SimulationStore {
     this.playing = false;
     // Make sure that model is paused first. Then restore snapshot.
     workerController.postMessageToModel({ type: "restoreSnapshot" });
+    log({ action: "SimulationStepBack" });
   }
 
   @action.bound restoreInitialSnapshot() {
     this.playing = false;
     // Make sure that model is paused first. Then restore snapshot.
     workerController.postMessageToModel({ type: "restoreInitialSnapshot" });
+    log({ action: "SimulationReset" });
   }
 
   @action.bound setScreenWidth(val: number) {
@@ -515,6 +526,8 @@ export class SimulationStore {
       this.selectedBoundary.type = type;
       this.setAnyHotSpotDefinedByUser(true);
       convertBoundaryTypeToHotSpots(this.selectedBoundary).forEach(hotSpot => this.setHotSpot(hotSpot));
+
+      log({ action: "BoundaryTypeSelected", data: { value: type } });
     }
   }
 
@@ -525,6 +538,9 @@ export class SimulationStore {
       this.setKeyVisible(true);
     }
     this.setSelectedTab("map-type");
+    if (rock) {
+      log({ action: "RockKeyInfoDisplayed", data: { value: rock } });
+    }
   }
 
   @action.bound setSelectedRockFlash(value: boolean) {
@@ -577,10 +593,12 @@ export class SimulationStore {
 
   drawContinent = (position: THREE.Vector3) => {
     workerController.postMessageToModel({ type: "continentDrawing", props: { position } });
+    log({ action: "ContinentAdded" });
   };
 
   eraseContinent = (position: THREE.Vector3) => {
     workerController.postMessageToModel({ type: "continentErasing", props: { position } });
+    log({ action: "ContinentRemoved" });
   };
 
   markIslands = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
+        "@concord-consortium/lara-interactive-api": "^1.5.0",
         "@emotion/react": "^11.6.0",
         "@emotion/styled": "^11.6.0",
         "@mui/material": "^5.1.0",
@@ -1755,6 +1756,18 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@concord-consortium/lara-interactive-api": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.5.0.tgz",
+      "integrity": "sha512-+p9XjiyKLWIIH6HWaSwlGnKi+GXEorSE4UYWTAeXUw6ZkeQv9UGue3MORNUpH1iI5pkn+RxRy2kyUucn4CsjWg==",
+      "dependencies": {
+        "iframe-phone": "^1.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+      }
     },
     "node_modules/@cypress/request": {
       "version": "2.88.10",
@@ -9879,6 +9892,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/iframe-phone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/iframe-phone/-/iframe-phone-1.3.1.tgz",
+      "integrity": "sha512-pipd9e4l5AE0K3+ZcQxb/+zd1pvCWbu6wuQlxdqChIfwe9jnnm2HwcNra/GvLovDxe36+uZusFMN0rNKlFIvdQ=="
     },
     "node_modules/ignore": {
       "version": "5.1.9",
@@ -20455,6 +20473,14 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@concord-consortium/lara-interactive-api": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.5.0.tgz",
+      "integrity": "sha512-+p9XjiyKLWIIH6HWaSwlGnKi+GXEorSE4UYWTAeXUw6ZkeQv9UGue3MORNUpH1iI5pkn+RxRy2kyUucn4CsjWg==",
+      "requires": {
+        "iframe-phone": "^1.3.1"
+      }
+    },
     "@cypress/request": {
       "version": "2.88.10",
       "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
@@ -26786,6 +26812,11 @@
       "requires": {
         "harmony-reflect": "^1.4.6"
       }
+    },
+    "iframe-phone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/iframe-phone/-/iframe-phone-1.3.1.tgz",
+      "integrity": "sha512-pipd9e4l5AE0K3+ZcQxb/+zd1pvCWbu6wuQlxdqChIfwe9jnnm2HwcNra/GvLovDxe36+uZusFMN0rNKlFIvdQ=="
     },
     "ignore": {
       "version": "5.1.9",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "homepage": "https://github.com/concord-consortium/tectonic-explorer#readme",
   "dependencies": {
+    "@concord-consortium/lara-interactive-api": "^1.5.0",
     "@emotion/react": "^11.6.0",
     "@emotion/styled": "^11.6.0",
     "@mui/material": "^5.1.0",


### PR DESCRIPTION
[#178132549]

I've wrapped the lara-interactive-api `log` function in a custom wrapper defined at `js/log.ts`. The main goal of that was to enforce self-documentation using types. It won't be possible to add a new event without documenting it using a new type. I'm planning to provide a link to `js/log.ts` to the project team, so they can always check all the available log messages. I'm trying to keep this file minimal and readable for non-programmers. If I use some external type, I'm adding a comment that lists possible values.

We also have a google spreadsheet with log events that I can't find now. But once I do, I think I'll just copy there a link to this file too. I think this is a more maintainable approach long-term than keeping a separate spreadsheet list.