### PR TITLE
Apply interpolation only to fields that are subducting not to interpolate accretionary wedge

### DIFF
--- a/js/plates-model/get-cross-section.ts
+++ b/js/plates-model/get-cross-section.ts
@@ -178,7 +178,7 @@ function smoothSubductionAreas(plateData: ICrossSectionPlateData) {
   const subductionLine: ICrossSectionPointData[] = [];
   plateData.points.forEach((point: ICrossSectionPointData, idx: number) => {
     const firstOrLast = idx === 0 || idx === plateData.points.length - 1;
-    if (!firstOrLast && point.field && (point.field.subduction || (point.field.canSubduct && subductionLine.length > 0))) {
+    if (!firstOrLast && point.field && point.field.subduction) {
       // `subductionLine` is a continuous line of points that are subducting (or oceanic crust to ignore small artifacts).
       // Don't smooth out first and last point to make sure that it matches neighboring cross-section in the 3D mode.
       subductionLine.push(point);


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179785302

PT story can be a bit confusing. Generally, the project team didn't like "cliffs" visible sometimes. It turns out it was mostly happening when the accretionary wedge was "pressed into" the subducting plate. It's visible below - red line shows the wedge, and green one shows where it's supposed to be:
![1  wege issue](https://user-images.githubusercontent.com/767857/152252937-be153958-056d-46ec-941b-a49e2f62ac3f.png)

This issue was happening only when the subducting plate was drawn from right to left. Left to right was working just fine.

It was caused by the function that smoothes out the subducting plate. This function tries to find which fields should be averaged. Sometimes it was including fields that didn't subduct yet. This doesn't work well when there's an accretionary wedge.

I didn't notice this issue before, as when we're starting processing from left (from fields that were not subducting yet), the first field that gets averaged is actually the field that is already subducting (=> correct). If we start from the other direction, the whole plate gets smoothed out because of the `|| (point.field.canSubduct && subductionLine.length > 0))` condition - subductionLine.length was greater than 0 in this case (as we started from subducting fields). I think this condition was added before accretionary wedges were implemented and it's just not working well now. 
