### PR TITLE
Reset all the options on model reload + hide some UI elements in Planet Wizard

### DIFF
--- a/js/components/planet-view.tsx
+++ b/js/components/planet-view.tsx
@@ -120,12 +120,12 @@ export default class PlanetView extends BaseComponent<IBaseProps, IState> {
   }
 
   render() {
-    const { showPlanetCameraReset, resetPlanetCamera, crossSectionVisible, key, planetWizard } = this.simulationStore;
+    const { showPlanetCameraReset, resetPlanetCamera, crossSectionVisible, keyVisible, planetWizard } = this.simulationStore;
     return (
-      <div className={`planet-view ${crossSectionVisible ? "small" : "full"} ${key ? "narrow" : ""}`} ref={(c) => {
+      <div className={`planet-view ${crossSectionVisible ? "small" : "full"} ${keyVisible ? "narrow" : ""}`} ref={(c) => {
         this.view3dContainer = c;
       }}>
-        <Caveat />
+        { !planetWizard && <Caveat /> }
         {
           // Interaction buttons near the top of the page should be only visible in Planet Wizard or in GEODE mode.
           (planetWizard || config.geode) &&

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -96,6 +96,7 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
     setOption("interaction", "none");
     setOption("renderBoundaries", true);
     setOption("renderForces", true);
+    setOption("colormap", "topo");
     this.setupStepOptions();
   }
 
@@ -191,7 +192,7 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
   endPlanetWizard() {
     const { setOption } = this.simulationStore;
     setOption("planetWizard", false);
-    setOption("playing", true);
+    setOption("playing", config.playing);
     setOption("interaction", "none");
     setOption("colormap", config.colormap);
     setOption("renderBoundaries", config.renderBoundaries);

--- a/js/components/side-container.tsx
+++ b/js/components/side-container.tsx
@@ -107,10 +107,6 @@ export class SideContainer extends BaseComponent<IBaseProps, IState> {
   }
 
   render() {
-    if (this.simulationStore.planetWizard) {
-      // Don't show keys and options button in planet wizard.
-      return null;
-    }
     if (!this.simulationStore.key) {
       return this.renderKeyButton();
     }

--- a/js/components/simulation.tsx
+++ b/js/components/simulation.tsx
@@ -93,7 +93,10 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
           planetWizard &&
           <PlanetWizard canvasRef={this.canvasRef} />
         }
-        <SideContainer />
+        {
+          !planetWizard &&
+          <SideContainer />
+        }
         {
           !planetWizard &&
           <div className="bottom-bar-container">

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -139,6 +139,10 @@ export class SimulationStore {
     return !this.planetWizard && this.showCrossSectionView;
   }
 
+  @computed get keyVisible() {
+    return !this.planetWizard && this.key;
+  }
+
   @computed get renderHotSpots() {
     return this.interaction === "force" || this.renderForces;
   }
@@ -431,6 +435,8 @@ export class SimulationStore {
   }
 
   @action.bound reload() {
+    this.resetOptionsOnReload();
+
     if (config.preset) {
       this.loadPresetModel(config.preset);
     }
@@ -440,13 +446,37 @@ export class SimulationStore {
     if (config.planetWizard) {
       this.planetWizard = true;
     }
-    this.resetPlanetCamera();
-    if (this.colormap !== config.colormap) {
-      this.setOption("colormap", config.colormap);
-    }
-    this.setKeyVisible(false);
-    this.closeCrossSection();
+
     log({ action: "SimulationReloaded" });
+  }
+
+  @action.bound resetOptionsOnReload() {
+    this.interaction = "none";
+    this.showCrossSectionView = false;
+    this.crossSectionPoint1 = null;
+    this.crossSectionPoint2 = null;
+    this.playing = config.playing;
+    this.timestep = config.timestep;
+    this.colormap = config.colormap;
+    this.wireframe = config.wireframe;
+    this.earthquakes = config.earthquakes;
+    this.volcanicEruptions = config.volcanicEruptions;
+    this.metamorphism = config.metamorphism;
+    this.key = config.key;
+    this.selectedTab = DEFAULT_TAB;
+    this.renderVelocities = config.renderVelocities;
+    this.renderForces = config.renderForces;
+    this.renderEulerPoles = config.renderEulerPoles;
+    this.renderBoundaries = config.renderBoundaries;
+    this.renderLatLongLines = config.renderLatLongLines;
+    this.renderPlateLabels = config.renderPlateLabels;
+    this.planetCameraPosition = DEFAULT_PLANET_CAMERA_POSITION;
+    this.crossSectionCameraAngle = DEFAULT_CROSS_SECTION_CAMERA_ANGLE;
+    this.rockLayers = !config.geode;
+    this.selectedBoundary = null;
+    this.anyHotSpotDefinedByUser = false;
+    this.selectedRock = null;
+    this.selectedRockFlash = false;
   }
 
   @action.bound takeLabeledSnapshot(label: string) {


### PR DESCRIPTION
This PR fixes issue pointed out by Saravanan (see the original [comment](https://www.pivotaltracker.com/story/show/180480267/comments/229323808)).

He noticed that the earthquakes caveat is being displayed in the Planet Wizard. This should not happen anymore. I also realized we didn't reset most of the options on model reload. So, the user could go to advanced options, turn on things like wireframe rendering, and he'd be stuck with it in the Planet Wizard mode after reload (aka "plate reset"). There's no clear answer if we should reset all the UI options or not, but it definitely feels safer, as it's less likely users will be stuck with a config that isn't working well in Planet Wizard.