### PR TITLE
Revert "Add continental shelf around plate boundary"

### DIFF
--- a/js/plates-model/plate-draw-tool.ts
+++ b/js/plates-model/plate-draw-tool.ts
@@ -35,34 +35,6 @@ function setupField(field: Field, fieldTypeBeingDrawn: FieldType, distanceRatio:
   }
 }
 
-function minDistanceToBoundary(startingField: Field) {
-  // Continents are drawn or erased using BFS.
-  const queue: Field[] = [];
-  const visited: Record<number, boolean> = {};
-  let minDistToBoundary = TOOL_RADIUS;
-
-  queue.push(startingField);
-  visited[startingField.id] = true;
-
-  while (queue.length > 0) {
-    const field = queue.shift() as Field;
-    if (field.isBoundary()) {
-      const distToStartingField = field.localPos.distanceTo(startingField.localPos);
-      if (distToStartingField < minDistToBoundary) {
-        minDistToBoundary = distToStartingField;
-      }
-    }
-    field.forEachNeighbor((otherField: Field) => {
-      if (!visited[otherField.id] && otherField.localPos.distanceTo(startingField.localPos) <= minDistToBoundary) {
-        visited[otherField.id] = true;
-        queue.push(otherField);
-      }
-    });
-  }
-
-  return minDistToBoundary;
-}
-
 export default function plateDrawTool(plate: Plate, fieldId: number, fieldTypeBeingDrawn: FieldType) {
   const plateSize = plate.size;
   // First, check if continent won't get too big.
@@ -84,12 +56,7 @@ export default function plateDrawTool(plate: Plate, fieldId: number, fieldTypeBe
 
   while (queue.length > 0) {
     const field = queue.shift() as Field;
-    // Make sure that even if user draws a continent next to the plate boundary, there's always a smooth
-    // continental shelf visible. Without calculating minDistanceToBoundary, user would be able to create
-    // a steep "cliff" right at the boundary.
-    const distToBoundary = minDistanceToBoundary(field);
-    const distToCenter = field.localPos.distanceTo(startingField.localPos);
-    const distanceRatio = Math.max(TOOL_RADIUS - distToBoundary, distToCenter) / TOOL_RADIUS;
+    const distanceRatio = field.localPos.distanceTo(startingField.localPos) / TOOL_RADIUS;
     setupField(field, fieldTypeBeingDrawn, distanceRatio);
 
     field.forEachNeighbor((otherField: Field) => {


### PR DESCRIPTION
Reverts concord-consortium/tectonic-explorer#177

Finally, Amy didn't like the continental shelf being automatically added around boundaries, so I'm revering the PR that added that. See:
https://www.pivotaltracker.com/story/show/181127412
https://www.pivotaltracker.com/story/show/181127412/comments/229679395