### PR TITLE
Update continent thickness, orogeny intensity + misc fixes

### DIFF
--- a/js/config.ts
+++ b/js/config.ts
@@ -84,7 +84,7 @@ const DEFAULT_CONFIG = {
   // Density affects plate's inertia tensor.
   oceanDensity: 1,
   continentDensity: 3,
-  // How fast continent is stretching along divergent boundary. Bigger value means it would turn into ocean / see faster.
+  // How fast continent is stretching along divergent boundary. Bigger value means it would turn into ocean / sea faster.
   continentalStretchingRatio: 4,
   // Max length of the cross-section line
   maxCrossSectionLength: 4000, // km

--- a/js/config.ts
+++ b/js/config.ts
@@ -85,7 +85,7 @@ const DEFAULT_CONFIG = {
   oceanDensity: 1,
   continentDensity: 3,
   // How fast continent is stretching along divergent boundary. Bigger value means it would turn into ocean / see faster.
-  continentalStretchingRatio: 8,
+  continentalStretchingRatio: 4,
   // Max length of the cross-section line
   maxCrossSectionLength: 4000, // km
   // Horizontal scaling of cross-section data.

--- a/js/plates-interactions/base-interactions-manager.ts
+++ b/js/plates-interactions/base-interactions-manager.ts
@@ -39,7 +39,6 @@ export class BaseInteractionsManager {
     if (this.activeInteraction) {
       if (this.activeInteraction.cursor) {
         this.view.domElement.style.cursor = "auto";
-        console.log("set cursor auto");
       }
       this.activeInteraction = null;
       this.disableEventHandlers();

--- a/js/plates-interactions/force-drawing.ts
+++ b/js/plates-interactions/force-drawing.ts
@@ -1,9 +1,10 @@
 import * as THREE from "three";
 import { LENGTH_RATIO } from "../plates-view/force-arrow";
+import config from "../config";
 
 // THREE.PlaneGeometry default orientation.
 const DEFAULT_PLANE_ORIENTATION = new THREE.Vector3(0, 0, 1);
-const MAX_FORCE_LEN = 2;
+const MAX_FORCE_LEN = config.userForce;
 
 function limitForceLength(data: any) {
   if (data.force.length() > MAX_FORCE_LEN) {

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -53,7 +53,7 @@ export const WEDGE_ACCUMULATION_INTENSITY = 6;
 // When this value is high, pretty much all the rocks will be redistributed to non-subducting neighbors.
 export const ROCK_SCARPING_INTENSITY = 40;
 
-// These two constants decide about orogeny intensity.
+// These two constants determine orogeny intensity.
 // ROCK_FOLDING_INTENSITY adds some variability to mountains.
 export const ROCK_FOLDING_INTENSITY = 15;
 // ROCK_TRANSFER_INTENSITY moves rocks form subducting plate to the overriding and speed of this transfer is the

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -56,7 +56,7 @@ export const ROCK_SCARPING_INTENSITY = 40;
 // These two constants determine orogeny intensity.
 // ROCK_FOLDING_INTENSITY adds some variability to mountains.
 export const ROCK_FOLDING_INTENSITY = 15;
-// ROCK_TRANSFER_INTENSITY moves rocks form subducting plate to the overriding and speed of this transfer is the
+// ROCK_TRANSFER_INTENSITY moves rocks from subducting plate to the overriding and speed of this transfer is the
 // main factor that affects mountains height.
 export const ROCK_TRANSFER_INTENSITY = 12;
 

--- a/js/plates-model/crust.ts
+++ b/js/plates-model/crust.ts
@@ -28,14 +28,14 @@ export const elevationToCrustThickness = (elevation: number) =>
 
 // ---->
 // When any of these values is updated, most likely color scales in colormaps.ts will have to be updated too.
-export const BASE_OCEAN_ELEVATION = 0;
+export const BASE_OCEAN_ELEVATION = 0.1;
 export const SEA_LEVEL = 0.5;
 export const BASE_CONTINENT_ELEVATION = 0.55;
 export const HIGHEST_MOUNTAIN_ELEVATION = 1;
 // <----
 
 // This constant will decide how deep are the mountain roots.
-export const CRUST_THICKNESS_TO_ELEVATION_RATIO = 0.5;
+export const CRUST_THICKNESS_TO_ELEVATION_RATIO = 0.6;
 export const BASE_OCEANIC_CRUST_THICKNESS = 0.5; // in real world: 6-12km, 7-10km on average
 // This constant shifts elevation so the base oceanic crust is at elevation BASE_OCEAN_ELEVATION (in model units, compare that with SEA_LEVEL value).
 export const CRUST_BELOW_ZERO_ELEVATION = BASE_OCEANIC_CRUST_THICKNESS * CRUST_THICKNESS_TO_ELEVATION_RATIO - BASE_OCEAN_ELEVATION;
@@ -45,16 +45,20 @@ export const MIN_LAYER_THICKNESS = 0.02 * BASE_OCEANIC_CRUST_THICKNESS;
 
 export const MAX_REGULAR_SEDIMENT_THICKNESS = 0.1 * BASE_OCEANIC_CRUST_THICKNESS;
 // These constants decide how thick and how wide the accretionary wedge will be.
-export const MAX_WEDGE_SEDIMENT_THICKNESS = 6 * MAX_REGULAR_SEDIMENT_THICKNESS;
+export const MAX_WEDGE_SEDIMENT_THICKNESS = 5 * MAX_REGULAR_SEDIMENT_THICKNESS;
 export const WEDGE_ACCUMULATION_INTENSITY = 6;
 
 // When the crust subducts, most of its rock layers are transferred to neighboring fields.
 // When this value is low, it will be transferred slower than subduction and most of the rock will be lost.
 // When this value is high, pretty much all the rocks will be redistributed to non-subducting neighbors.
-export const ROCK_SCARPING_INTENSITY = 50;
+export const ROCK_SCARPING_INTENSITY = 40;
 
+// These two constants decide about orogeny intensity.
+// ROCK_FOLDING_INTENSITY adds some variability to mountains.
 export const ROCK_FOLDING_INTENSITY = 15;
-export const ROCK_TRANSFER_INTENSITY = 25;
+// ROCK_TRANSFER_INTENSITY moves rocks form subducting plate to the overriding and speed of this transfer is the
+// main factor that affects mountains height.
+export const ROCK_TRANSFER_INTENSITY = 12;
 
 export const MIN_EROSION_SLOPE = 20;
 export const EROSION_INTENSITY = 0.02;
@@ -341,7 +345,7 @@ export default class Crust {
 
     for (const layer of this.rockLayers) {
       const foldedThickness = layer.thickness * kThicknessMult;
-      layer.thickness -= foldedThickness * 0.9;
+      layer.thickness -= foldedThickness * 0.99;
       const increasePerNeigh = foldedThickness / neighboringCrust.length;
       neighboringCrust.forEach(neighCrust => {
         neighCrust.increaseLayerThickness(layer.rock, increasePerNeigh);

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -52,7 +52,7 @@ const removeUndefinedValues = (obj: any) =>  {
 // until it reaches this value. Then the oceanic crust will be formed instead.
 export const MIN_CONTINENTAL_CRUST_THICKNESS = BASE_OCEANIC_CRUST_THICKNESS * 1.1;
 
-export const LITHOSPHERE_THICKNESS = 0.7;
+export const LITHOSPHERE_THICKNESS = 0.5;
 
 export const NEW_OCEANIC_CRUST_THICKNESS_RATIO = 0.6;
 

--- a/js/plates-view/force-arrow.ts
+++ b/js/plates-view/force-arrow.ts
@@ -1,10 +1,13 @@
 import * as THREE from "three";
 import config from "../config";
+import { BASE_CONTINENT_ELEVATION } from "../plates-model/crust";
+import { getElevationInViewUnits, PLATE_RADIUS } from "./plate-mesh";
 
 const RADIUS = 0.01;
 // Arrow points up when it's created.
 const BASE_ORIENTATION = new THREE.Vector3(0, 1, 0);
 const MIN_LENGTH = 0.01;
+const ARROW_ELEVATION = PLATE_RADIUS + getElevationInViewUnits(BASE_CONTINENT_ELEVATION * 1.1);
 // Keep the size of force arrow always the same, so they're not overlapping or not too short.
 export const LENGTH_RATIO = 0.1 / config.userForce;
 
@@ -65,7 +68,7 @@ export default class ForceArrow {
     this.arrowHead.position.y = len;
   }
 
-  update(props: any) {
+  update(props: { force: THREE.Vector3, position: THREE.Vector3 } | null) {
     if (!props) {
       this.root.visible = false;
       return;
@@ -77,7 +80,8 @@ export default class ForceArrow {
       return;
     }
     this.root.visible = this.visible;
-    this.root.position.copy(position);
+
+    this.root.position.copy(position).setLength(ARROW_ELEVATION);
     const q = new THREE.Quaternion();
     q.setFromUnitVectors(BASE_ORIENTATION, force.clone().normalize());
     this.root.quaternion.copy(q);

--- a/js/plates-view/plate-mesh.ts
+++ b/js/plates-view/plate-mesh.ts
@@ -17,7 +17,6 @@ import PlateStore from "../stores/plate-store";
 import FieldStore from "../stores/field-store";
 import { Rock } from "../plates-model/rock-properties";
 import { getRockPatternImgSrc } from "../colors/rock-colors";
-import { BASE_CONTINENT_ELEVATION } from "../plates-model/crust";
 
 const MIN_SPEED_TO_RENDER_POLE = 0.002;
 // Render every nth velocity arrow (performance).
@@ -27,7 +26,7 @@ const HIGHLIGHT_COLOR = { r: 0.38, g: 0.86, b: 0.04, a: 1 };
 // Special color value that indicates that colormap texture should be used.
 const USE_COLORMAP_COLOR = { r: 0, g: 0, b: 0, a: 0 };
 // Larger value will make mountains in the 3D view more pronounced.
-const ELEVATION_SCALE = 0.06;
+export const ELEVATION_SCALE = 0.06;
 // Colormap elevation range.
 const ELEVATION_RANGE = MAX_ELEVATION - MIN_ELEVATION;
 // PLATE_RADIUS reflects radius of the geodesic mesh in view units. This value should not be changed unless
@@ -94,7 +93,7 @@ Object.keys(ROCK_PATTERN_MAP).forEach((key, idx) => {
   ROCK_PATTERNS_SCALE_ARRAY.push(ROCK_PATTERN_SCALE[rock]);
 });
 
-function getElevationInViewUnits(elevation: number) {
+export function getElevationInViewUnits(elevation: number) {
   return elevation * ELEVATION_SCALE;
 }
 
@@ -386,11 +385,9 @@ export default class PlateMesh {
     }
     if (this.store.renderHotSpots) {
       const hotSpot = this.plate.hotSpot;
-      // Add elevation to arrow position.
-      const elevation = getElevationInViewUnits(BASE_CONTINENT_ELEVATION * 1.1);
       this.forceArrow.update({
         force: hotSpot.force,
-        position: hotSpot.position.clone().setLength(PLATE_RADIUS + elevation)
+        position: hotSpot.position
       });
     }
     this.label.update(this.plate);

--- a/js/presets.ts
+++ b/js/presets.ts
@@ -1,3 +1,4 @@
+import config from "./config";
 import * as THREE from "three";
 
 interface IPreset {
@@ -14,7 +15,7 @@ const presets: Record<string, IPreset> = {
       const yellowPlate = plates[70]; // 70 hue
       bluePlate.density = 1;
       yellowPlate.density = 0;
-      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(2.5, 0, 0));
+      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "divergentBoundary": {
@@ -24,8 +25,8 @@ const presets: Record<string, IPreset> = {
       const yellowPlate = plates[70]; // 70 hue
       bluePlate.density = 1;
       yellowPlate.density = 0;
-      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(-1.5, 0, 0));
-      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(-1.5, 0, 0));
+      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(-config.userForce, 0, 0));
+      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(-config.userForce, 0, 0));
     }
   },
   "plateDivision1": {
@@ -43,8 +44,8 @@ const presets: Record<string, IPreset> = {
       bluePlate.density = 0;
       greenPlate.density = 1;
       pinkPlate.density = 2;
-      greenPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(-1.5, 0, 0));
-      pinkPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(-1.5, 0, 0));
+      greenPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(-config.userForce, 0, 0));
+      pinkPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(-config.userForce, 0, 0));
     }
   },
   "continentalCollision1": {
@@ -54,8 +55,8 @@ const presets: Record<string, IPreset> = {
       const yellowPlate = plates[70]; // 70 hue
       bluePlate.density = 1;
       yellowPlate.density = 0;
-      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(2.5, 0, 0));
-      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(2.5, 0, 0));
+      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce, 0, 0));
+      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "continentalCollision2": {
@@ -65,8 +66,8 @@ const presets: Record<string, IPreset> = {
       const yellowPlate = plates[70]; // 70 hue
       bluePlate.density = 1;
       yellowPlate.density = 0;
-      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(2, 0, 0));
-      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(2, 0, 0));
+      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce, 0, 0));
+      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "continentalCollision3": {
@@ -78,7 +79,7 @@ const presets: Record<string, IPreset> = {
       purplePlate.density = 2;
       bluePlate.density = 1;
       yellowPlate.density = 0;
-      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(1, 0, 0));
+      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "continentalCollision4": {
@@ -88,7 +89,7 @@ const presets: Record<string, IPreset> = {
       const yellowPlate = plates[70]; // 70 hue
       bluePlate.density = 1;
       yellowPlate.density = 0;
-      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(2, 2, 0));
+      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce * 0.7, config.userForce * 0.7, 0));
     }
   },
   "continentOceanCollision": {
@@ -98,8 +99,8 @@ const presets: Record<string, IPreset> = {
       const yellowPlate = plates[70]; // 70 hue
       bluePlate.density = 1;
       yellowPlate.density = 0;
-      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(3, 0, 0));
-      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(3, 0, 0));
+      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce, 0, 0));
+      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, -1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "islandCollision": {
@@ -109,7 +110,7 @@ const presets: Record<string, IPreset> = {
       const yellowPlate = plates[70]; // 70 hue
       bluePlate.density = 1;
       yellowPlate.density = 0;
-      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(2.5, 0, 0));
+      bluePlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "subductionIssue1": {
@@ -121,8 +122,8 @@ const presets: Record<string, IPreset> = {
       greenPlate.density = 2;
       pinkPlate.density = 1;
       yellowPlate.density = 0;
-      pinkPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(-4, 0, 0));
-      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(2, 0, 0));
+      pinkPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(-config.userForce, 0, 0));
+      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "earth": {
@@ -141,7 +142,7 @@ const presets: Record<string, IPreset> = {
       yellowPlate.density = 2;
       greenPlate.density = 1;
       pinkPlate.density = 0;
-      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(3, 0, 0));
+      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "benchmark": {
@@ -157,7 +158,7 @@ const presets: Record<string, IPreset> = {
       yellowPlate.density = 2;
       greenPlate.density = 1;
       pinkPlate.density = 0;
-      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(2, 0, 0));
+      yellowPlate.setHotSpot(new THREE.Vector3(0, 0, 1), new THREE.Vector3(config.userForce, 0, 0));
     }
   },
   "circles": {

--- a/test/plates-model/crust.test.ts
+++ b/test/plates-model/crust.test.ts
@@ -16,8 +16,8 @@ describe("Crust model", () => {
 
     crust = new Crust("continent", 0.5);
     expect(crust.rockLayers).toEqual([
-      { rock: Rock.Limestone, thickness: 0.16000000000000003 },
-      { rock: Rock.Granite, thickness: 0.33999999999999997 }
+      { rock: Rock.Limestone, thickness: 0.125 },
+      { rock: Rock.Granite, thickness: 0.375 }
     ]);
   });
 
@@ -55,7 +55,7 @@ describe("Crust model", () => {
       { rock: Rock.Basalt, thickness: 0.5 },
       { rock: Rock.Gabbro, thickness: 1.0 }
     ];
-    
+
     const crustN1 = new Crust();
     const crustN2 = new Crust();
 
@@ -76,15 +76,15 @@ describe("Crust model", () => {
     crust.fold(1, [crustN1, crustN2], new Vector3(1, 0, 0));
 
     expect(crustN1.rockLayers).toEqual([
-      { rock: Rock.Andesite, thickness: 0.275 },
-      { rock: Rock.Basalt, thickness: 0.275 },
-      { rock: Rock.Gabbro, thickness: 0.55 }
+      { rock: Rock.Andesite, thickness: 0.2525 },
+      { rock: Rock.Basalt, thickness: 0.2525 },
+      { rock: Rock.Gabbro, thickness: 0.505 }
     ]);
 
     expect(crustN2.rockLayers).toEqual([
-      { rock: Rock.Andesite, thickness: 0.275 },
-      { rock: Rock.Basalt, thickness: 0.275 },
-      { rock: Rock.Gabbro, thickness: 0.55 }
+      { rock: Rock.Andesite, thickness: 0.2525 },
+      { rock: Rock.Basalt, thickness: 0.2525 },
+      { rock: Rock.Gabbro, thickness: 0.505 }
     ]);
   });
 
@@ -129,7 +129,7 @@ describe("Crust model", () => {
         { rock: Rock.Basalt, thickness: 0.1 },
         { rock: Rock.Gabbro, thickness: 0.1 }
       ]);
-      
+
       crust.removeLayer(Rock.Basalt);
       expect(crust.rockLayers).toEqual([
         { rock: Rock.OceanicSediment, thickness: 0.1 },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181254099

The main goal of this PR is to update continental crust and mantle thickness. 

Old:
<img width="871" alt="Screenshot 2022-02-24 at 14 47 26" src="https://user-images.githubusercontent.com/767857/155620410-7484ef3d-9a1f-4e3b-b78f-262a5e1e0d5b.png">
New:
<img width="859" alt="Screenshot 2022-02-24 at 14 47 30" src="https://user-images.githubusercontent.com/767857/155620420-5d0c6c02-e2fc-4445-97a1-3f9379289e21.png">

The mantle is easy, as it's just a visual layer. However, there's no single way to update continental thickness without affecting the model output. I've done two things:

1. I've changed the ratio of "mountain roots" (CRUST_THICKNESS_TO_ELEVATION_RATIO). This makes continental crust thinner, as its base elevation is unchanged (0.55). There's less of the crust below zero level.
2. I've shifted base ocean crust elevation a bit higher. That makes oceans shallower and decreases the total height of the continental crust.

However, both these updates make mountains taller, as more of the crust will "float" and also the base elevation is higher. That's why I've been testing and updating other params that affect orogeny strength.

I've also updated presets to use new force values and fixed force arrows in GEODE mode.