### PR TITLE
181392960 time slider

### DIFF
--- a/js/components/advanced-options.tsx
+++ b/js/components/advanced-options.tsx
@@ -31,7 +31,7 @@ interface IState {}
 @observer
 export class AdvancedOptions extends BaseComponent<IProps, IState> {
   changeInteraction: (value: any) => void;
-  changeTargetModelStepsPerSecond: (value: any) => void;
+  changeTargetModelStepsPerSecond: (value: number) => void;
   toggleBoundaries: () => void;
   toggleEulerPoles: () => void;
   toggleForces: () => void;

--- a/js/components/advanced-options.tsx
+++ b/js/components/advanced-options.tsx
@@ -31,7 +31,7 @@ interface IState {}
 @observer
 export class AdvancedOptions extends BaseComponent<IProps, IState> {
   changeInteraction: (value: any) => void;
-  changeTimestep: (value: any) => void;
+  changeTargetModelStepsPerSecond: (value: any) => void;
   toggleBoundaries: () => void;
   toggleEulerPoles: () => void;
   toggleForces: () => void;
@@ -55,7 +55,7 @@ export class AdvancedOptions extends BaseComponent<IProps, IState> {
     this.toggleLatLongLines = this.toggleOption.bind(this, "renderLatLongLines");
     this.togglePlateLabels = this.toggleOption.bind(this, "renderPlateLabels");
     this.changeInteraction = this.handleChange.bind(this, "interaction");
-    this.changeTimestep = this.handleChange.bind(this, "timestep");
+    this.changeTargetModelStepsPerSecond = this.handleChange.bind(this, "targetModelStepsPerSecond");
     this.storedPlayState = true;
   }
 
@@ -153,7 +153,13 @@ export class AdvancedOptions extends BaseComponent<IProps, IState> {
             <ListItem ripple={false} itemContent={
               <div className="list-slider">
                 <label>Model Speed</label>
-                <Slider min={0.01} max={0.4} value={options.timestep} onChange={this.changeTimestep} theme={{ knob: css.sliderKnob }} />
+                <Slider
+                  theme={{ knob: css.sliderKnob }}
+                  min={15} max={60} value={options.targetModelStepsPerSecond}
+                  onChange={this.changeTargetModelStepsPerSecond}
+                  step={1}
+                  pinned={true}
+                />
               </div>
             } />
           }

--- a/js/config.ts
+++ b/js/config.ts
@@ -59,6 +59,9 @@ const DEFAULT_CONFIG = {
   snapshotInterval: 100,
   divisions: 32,
   timestep: 0.1,
+  // Number of models steps per second calculated by the worker thread. Note that it's only a target value,
+  // slower machines might struggle to achieve it.
+  targetModelStepsPerSecond: 30,
   // When set to true, model will always behave in the same way, random events will always have the same results.
   deterministic: true,
   // There are three different integration methods: 'euler', 'verlet' and 'rk4'.

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -63,7 +63,7 @@ export const TRENCH_SLOPE = 0.5;
 export const MAX_AGE = config.oceanicRidgeWidth / c.earthRadius;
 
 // Decides how tall volcanoes become during subduction.
-const VOLCANIC_ACTIVITY_STRENGTH = 0.06;
+const VOLCANIC_ACTIVITY_STRENGTH = 0.1;
 
 // Adjust mass of the field, so simulation works well with given force values.
 const MASS_MODIFIER = 0.000005;

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -68,6 +68,7 @@ export class SimulationStore {
   @observable renderBoundaries = config.renderBoundaries;
   @observable renderLatLongLines = config.renderLatLongLines;
   @observable renderPlateLabels = config.renderPlateLabels;
+  @observable targetModelStepsPerSecond = config.targetModelStepsPerSecond;
   @observable planetCameraPosition = DEFAULT_PLANET_CAMERA_POSITION;
   @observable planetCameraLocked = false;
   @observable planetCameraAnimating = false;
@@ -170,7 +171,8 @@ export class SimulationStore {
       renderHotSpots: this.renderHotSpots,
       renderBoundaries: this.renderBoundaries,
       earthquakes: this.earthquakes,
-      volcanicEruptions: this.volcanicEruptions
+      volcanicEruptions: this.volcanicEruptions,
+      targetModelStepsPerSecond: this.targetModelStepsPerSecond
     };
     return props;
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181392960

Time slider used to change timestep. I've been trying to include timestep in all the simulation rules, but it's still difficult to ensure that model produces a very similar result for various time step values. It is not well-defined and well-known math that could be tested and verified.

So, I've decided to change the time slider so it affects the number of calculations per second. This is a safer approach, even though it might be limited by the performance of the machine. But project team was more concerned about the model being too fast, not too slow, and slowing down should always work.