### PR TITLE
Update Rock Key to differentiate different kinds of metamorphic rocks in each grade

### DIFF
--- a/css-modules/keys/rock-types.less
+++ b/css-modules/keys/rock-types.less
@@ -111,8 +111,9 @@
           width: 259px;
         }
         .selectedRockTitle {
-          margin: 6px 0;
+          margin: 6px 15px;
           font-weight: bold;
+          text-align: center;
         }
         .selectedRockDiagram {
           padding: 5px 0;

--- a/images/rock-key/svg/metamorphic-rock-high-grade-contact-metamorphism-diagram.svg
+++ b/images/rock-key/svg/metamorphic-rock-high-grade-contact-metamorphism-diagram.svg
@@ -1,0 +1,45 @@
+<svg width="259" height="165" viewBox="0 0 259 165" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h259v165H0V0z"/>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="139.644" y="140.667">High</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="54" y="140.667">Low</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="67.686" y="161.667">Temperature</tspan>
+                                        </text>
+        <path fill="#797979" fill-rule="nonzero" d="M52.25 12.333h-5l5.75-12 5.75 12h-5v112.916l112.916.001v-5l12 5.75-12 5.75v-5H52.25z"/>
+        <path d="M55 124h110c0-60.751-49.249-110-110-110v110z" fill="#3D893A" fill-rule="nonzero"/>
+        <path d="M55 124h74.516c0-41.154-33.362-74.516-74.516-74.516V124z" fill="#76AC74" fill-rule="nonzero"/>
+        <path d="M55 124h39.032c0-21.557-17.475-39.032-39.032-39.032V124z" fill="#BAD5B9" fill-rule="nonzero"/>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="25.482" y="123.917">Low</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="22.644" y="24.917">High</tspan>
+                                        </text>
+        <text transform="rotate(-90 8.667 70.083)" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="green">
+                                            <tspan x="-19.174" y="75.417">Pressure</tspan>
+                                        </text>
+        <g>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="52">Low grade</tspan>
+                                        </text>
+            <path fill="#BAD5B9" fill-rule="nonzero" d="M163 51.5h15v15h-15z"/>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="32">Medium grade</tspan>
+                                        </text>
+            <path fill="#76AC74" fill-rule="nonzero" d="M163 31.5h15v15h-15z"/>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="12">High grade</tspan>
+                                        </text>
+            <path fill="#3D893A" fill-rule="nonzero" d="M163 11.5h15v15h-15z"/>
+        </g>
+        <g fill-rule="nonzero">
+            <path d="M149.5 102a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15z" fill="#FFF"/>
+            <path d="M149.5 104a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11z" fill="#434343"/>
+        </g>
+    </g>
+</svg>

--- a/images/rock-key/svg/metamorphic-rock-high-grade-subduction-zone-diagram.svg
+++ b/images/rock-key/svg/metamorphic-rock-high-grade-subduction-zone-diagram.svg
@@ -1,0 +1,45 @@
+<svg width="259" height="165" viewBox="0 0 259 165" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h259v165H0V0z"/>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="139.644" y="140.667">High</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="54" y="140.667">Low</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="67.686" y="161.667">Temperature</tspan>
+                                        </text>
+        <path fill="#797979" fill-rule="nonzero" d="M52.25 12.333h-5l5.75-12 5.75 12h-5v112.916l112.916.001v-5l12 5.75-12 5.75v-5H52.25z"/>
+        <path d="M55 124h110c0-60.751-49.249-110-110-110v110z" fill="#3D893A" fill-rule="nonzero"/>
+        <path d="M55 124h74.516c0-41.154-33.362-74.516-74.516-74.516V124z" fill="#76AC74" fill-rule="nonzero"/>
+        <path d="M55 124h39.032c0-21.557-17.475-39.032-39.032-39.032V124z" fill="#BAD5B9" fill-rule="nonzero"/>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="25.482" y="123.917">Low</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="22.644" y="24.917">High</tspan>
+                                        </text>
+        <text transform="rotate(-90 8.667 70.083)" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="green">
+                                            <tspan x="-19.174" y="75.417">Pressure</tspan>
+                                        </text>
+        <g>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="52">Low grade</tspan>
+                                        </text>
+            <path fill="#BAD5B9" fill-rule="nonzero" d="M163 51.5h15v15h-15z"/>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="32">Medium grade</tspan>
+                                        </text>
+            <path fill="#76AC74" fill-rule="nonzero" d="M163 31.5h15v15h-15z"/>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="12">High grade</tspan>
+                                        </text>
+            <path fill="#3D893A" fill-rule="nonzero" d="M163 11.5h15v15h-15z"/>
+        </g>
+        <g fill-rule="nonzero">
+            <path d="M90.5 25a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15z" fill="#FFF"/>
+            <path d="M90.5 27a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11z" fill="#434343"/>
+        </g>
+    </g>
+</svg>

--- a/images/rock-key/svg/metamorphic-rock-low-grade-subduction-zone-diagram.svg
+++ b/images/rock-key/svg/metamorphic-rock-low-grade-subduction-zone-diagram.svg
@@ -1,0 +1,45 @@
+<svg width="259" height="165" viewBox="0 0 259 165" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h259v165H0V0z"/>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="139.644" y="140.667">High</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="54" y="140.667">Low</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="67.686" y="161.667">Temperature</tspan>
+                                        </text>
+        <path fill="#797979" fill-rule="nonzero" d="M52.25 12.333h-5l5.75-12 5.75 12h-5v112.916l112.916.001v-5l12 5.75-12 5.75v-5H52.25z"/>
+        <path d="M55 124h110c0-60.751-49.249-110-110-110v110z" fill="#3D893A" fill-rule="nonzero"/>
+        <path d="M55 124h74.516c0-41.154-33.362-74.516-74.516-74.516V124z" fill="#76AC74" fill-rule="nonzero"/>
+        <path d="M55 124h39.032c0-21.557-17.475-39.032-39.032-39.032V124z" fill="#BAD5B9" fill-rule="nonzero"/>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="25.482" y="123.917">Low</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="22.644" y="24.917">High</tspan>
+                                        </text>
+        <text transform="rotate(-90 8.667 70.083)" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="green">
+                                            <tspan x="-19.174" y="75.417">Pressure</tspan>
+                                        </text>
+        <g>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="52">Low grade</tspan>
+                                        </text>
+            <path fill="#BAD5B9" fill-rule="nonzero" d="M163 51.5h15v15h-15z"/>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="32">Medium grade</tspan>
+                                        </text>
+            <path fill="#76AC74" fill-rule="nonzero" d="M163 31.5h15v15h-15z"/>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="12">High grade</tspan>
+                                        </text>
+            <path fill="#3D893A" fill-rule="nonzero" d="M163 11.5h15v15h-15z"/>
+        </g>
+        <g fill-rule="nonzero">
+            <path d="M63.5 87.25a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15z" fill="#FFF"/>
+            <path d="M63.5 89.25a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11z" fill="#434343"/>
+        </g>
+    </g>
+</svg>

--- a/images/rock-key/svg/metamorphic-rock-medium-grade-subduction-zone-diagram.svg
+++ b/images/rock-key/svg/metamorphic-rock-medium-grade-subduction-zone-diagram.svg
@@ -1,0 +1,45 @@
+<svg width="259" height="165" viewBox="0 0 259 165" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path d="M0 0h259v165H0V0z"/>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="139.644" y="140.667">High</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="54" y="140.667">Low</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="67.686" y="161.667">Temperature</tspan>
+                                        </text>
+        <path fill="#797979" fill-rule="nonzero" d="M52.25 12.333h-5l5.75-12 5.75 12h-5v112.916l112.916.001v-5l12 5.75-12 5.75v-5H52.25z"/>
+        <path d="M55 124h110c0-60.751-49.249-110-110-110v110z" fill="#3D893A" fill-rule="nonzero"/>
+        <path d="M55 124h74.516c0-41.154-33.362-74.516-74.516-74.516V124z" fill="#76AC74" fill-rule="nonzero"/>
+        <path d="M55 124h39.032c0-21.557-17.475-39.032-39.032-39.032V124z" fill="#BAD5B9" fill-rule="nonzero"/>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="25.482" y="123.917">Low</tspan>
+                                        </text>
+        <text font-family="Lato-Bold, Lato" font-size="12" font-weight="bold" fill="green" transform="translate(0 .333)">
+                                            <tspan x="22.644" y="24.917">High</tspan>
+                                        </text>
+        <text transform="rotate(-90 8.667 70.083)" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold" fill="green">
+                                            <tspan x="-19.174" y="75.417">Pressure</tspan>
+                                        </text>
+        <g>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="52">Low grade</tspan>
+                                        </text>
+            <path fill="#BAD5B9" fill-rule="nonzero" d="M163 51.5h15v15h-15z"/>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="32">Medium grade</tspan>
+                                        </text>
+            <path fill="#76AC74" fill-rule="nonzero" d="M163 31.5h15v15h-15z"/>
+            <text font-family="Lato-Regular, Lato" font-size="12" fill="#434343" transform="translate(163 11)">
+                                            <tspan x="20" y="12">High grade</tspan>
+                                        </text>
+            <path fill="#3D893A" fill-rule="nonzero" d="M163 11.5h15v15h-15z"/>
+        </g>
+        <g fill-rule="nonzero">
+            <path d="M75.5 55a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15z" fill="#FFF"/>
+            <path d="M75.5 57a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11z" fill="#434343"/>
+        </g>
+    </g>
+</svg>

--- a/js/colors/cross-section-colors.ts
+++ b/js/colors/cross-section-colors.ts
@@ -14,6 +14,7 @@ export const MAGMA_SILICA_RICH = "#fd6f79";
 
 export const MAGMA_BLOB_BORDER = "#333";
 
+export const MAGMA_BLOB_BORDER_METAMORPHIC = "rgb(27, 117, 23, 1)";
 export const METAMORPHIC_LOW_GRADE = "rgba(27, 117, 23, 0.3)";
 export const METAMORPHIC_MEDIUM_GRADE = "rgba(27, 117, 23, 0.6)";
 export const METAMORPHIC_HIGH_GRADE = "rgba(27, 117, 23, 0.85)";

--- a/js/components/keys/rock-types.tsx
+++ b/js/components/keys/rock-types.tsx
@@ -8,7 +8,7 @@ import {
 import { IGNEOUS_PURPLE, MANTLE_PURPLE, METAMORPHIC_GREEN, SEDIMENTARY_YELLOW, SEDIMENTS_ORANGE, MAGMA_RED,
   IGNEOUS_PURPLE_LIGHT, MANTLE_PURPLE_LIGHT, METAMORPHIC_GREEN_LIGHT, SEDIMENTARY_YELLOW_LIGHT, SEDIMENTS_ORANGE_LIGHT,
   MAGMA_RED_LIGHT, OTHER_GRAY, OTHER_GRAY_LIGHT, SEDIMENTARY_TITLE_GRAY, CRUST_TYPE, CRUST_TYPE_LIGHT } from "../../colors/rock-colors";
-import { CONTINENTAL_CRUST_COLOR, MAGMA_INTERMEDIATE, MAGMA_IRON_RICH, MAGMA_SILICA_RICH, MANTLE_BRITTLE,
+import { CONTINENTAL_CRUST_COLOR, MAGMA_BLOB_BORDER_METAMORPHIC, MAGMA_INTERMEDIATE, MAGMA_IRON_RICH, MAGMA_SILICA_RICH, MANTLE_BRITTLE,
   MANTLE_DUCTILE, OCEANIC_CRUST_COLOR, OCEAN_COLOR, SKY_COLOR_1, SKY_COLOR_2 } from "../../colors/cross-section-colors";
 import GabbroDiagram from "../../../images/rock-key/svg/gabbro-diagram.svg";
 import GabbroPatternSrc from "../../../images/rock-patterns/gabbro-key.png";
@@ -30,6 +30,7 @@ import HighGradeMetamorphicRockCCDiagram from "../../../images/rock-key/svg/meta
 import LowGradeMetamorphicRockSubductionDiagram from "../../../images/rock-key/svg/metamorphic-rock-low-grade-subduction-zone-diagram.svg";
 import MediumGradeMetamorphicRockSubductionDiagram from "../../../images/rock-key/svg/metamorphic-rock-medium-grade-subduction-zone-diagram.svg";
 import HighGradeMetamorphicRockSubductionDiagram from "../../../images/rock-key/svg/metamorphic-rock-high-grade-subduction-zone-diagram.svg";
+import ContactMetamorphismDiagram from "../../../images/rock-key/svg/metamorphic-rock-high-grade-contact-metamorphism-diagram.svg";
 import SandstoneDiagram from "../../../images/rock-key/svg/sandstone-diagram.svg";
 import SandstonePatternSrc from "../../../images/rock-patterns/sandstone-key.png";
 import ShaleDiagram from "../../../images/rock-key/svg/shale-diagram.svg";
@@ -285,6 +286,19 @@ const TecRockKey: IContainerDef[] = [
             )
           }
         ]
+      },
+      {
+        shortName: "Contact",
+        name: "Contact Metamorphism",
+        pattern: MAGMA_BLOB_BORDER_METAMORPHIC,
+        diagram: <ContactMetamorphismDiagram />,
+        notes: (
+          <div>
+            <p><b>Tectonic Environment:</b> ?</p>
+            <p><b>Origin Rock:</b> any</p>
+            <p><b>Metamorphic Conditions:</b> ?</p>
+          </div>
+        )
       }
     ]
   },

--- a/js/components/keys/rock-types.tsx
+++ b/js/components/keys/rock-types.tsx
@@ -206,7 +206,7 @@ const TecRockKey: IContainerDef[] = [
             diagram: <LowGradeMetamorphicRockCCDiagram />,
             notes: (
               <div>
-                <p><b>Tectonic Environment:</b> shallow collision boundaries</p>
+                <p><b>Tectonic Environment:</b> convergent boundary</p>
                 <p><b>Origin Rock:</b> any</p>
                 <p><b>Metamorphic Conditions:</b> low temperature and low pressure</p>
               </div>
@@ -219,7 +219,7 @@ const TecRockKey: IContainerDef[] = [
             diagram: <LowGradeMetamorphicRockSubductionDiagram />,
             notes: (
               <div>
-                <p><b>Tectonic Environment:</b> shallow subduction zone</p>
+                <p><b>Tectonic Environment:</b> convergent boundary</p>
                 <p><b>Origin Rock:</b> any</p>
                 <p><b>Metamorphic Conditions:</b> low temperature and low pressure</p>
               </div>
@@ -236,9 +236,9 @@ const TecRockKey: IContainerDef[] = [
             diagram: <MediumGradeMetamorphicRockCCDiagram />,
             notes: (
               <div>
-                <p><b>Tectonic Environment:</b> collision boundaries</p>
+                <p><b>Tectonic Environment:</b> convergent boundary</p>
                 <p><b>Origin Rock:</b> any</p>
-                <p><b>Metamorphic Conditions:</b> high temperature and low pressure, or low temperature and high pressure</p>
+                <p><b>Metamorphic Conditions:</b> medium temperature and medium pressure</p>
               </div>
             )
           },
@@ -249,9 +249,9 @@ const TecRockKey: IContainerDef[] = [
             diagram: <MediumGradeMetamorphicRockSubductionDiagram />,
             notes: (
               <div>
-                <p><b>Tectonic Environment:</b> subduction zone</p>
+                <p><b>Tectonic Environment:</b> convergent boundary</p>
                 <p><b>Origin Rock:</b> any</p>
-                <p><b>Metamorphic Conditions:</b> high temperature and low pressure, or low temperature and high pressure</p>
+                <p><b>Metamorphic Conditions:</b> low temperature, medium pressure</p>
               </div>
             )
           },
@@ -266,7 +266,7 @@ const TecRockKey: IContainerDef[] = [
             diagram: <HighGradeMetamorphicRockCCDiagram />,
             notes: (
               <div>
-                <p><b>Tectonic Environment:</b> deep collision boundaries</p>
+                <p><b>Tectonic Environment:</b> convergent boundary</p>
                 <p><b>Origin Rock:</b> any</p>
                 <p><b>Metamorphic Conditions:</b> high temperature and high pressure</p>
               </div>
@@ -279,9 +279,9 @@ const TecRockKey: IContainerDef[] = [
             diagram: <HighGradeMetamorphicRockSubductionDiagram />,
             notes: (
               <div>
-                <p><b>Tectonic Environment:</b> deep subduction zone</p>
+                <p><b>Tectonic Environment:</b> convergent boundary,</p>
                 <p><b>Origin Rock:</b> any</p>
-                <p><b>Metamorphic Conditions:</b> high temperature and high pressure</p>
+                <p><b>Metamorphic Conditions:</b> low temperature, high pressure</p>
               </div>
             )
           }
@@ -294,9 +294,9 @@ const TecRockKey: IContainerDef[] = [
         diagram: <ContactMetamorphismDiagram />,
         notes: (
           <div>
-            <p><b>Tectonic Environment:</b> ?</p>
+            <p><b>Tectonic Environment:</b> convergent boundary</p>
             <p><b>Origin Rock:</b> any</p>
-            <p><b>Metamorphic Conditions:</b> ?</p>
+            <p><b>Metamorphic Conditions:</b> high temperature, low pressure</p>
           </div>
         )
       }

--- a/js/components/keys/rock-types.tsx
+++ b/js/components/keys/rock-types.tsx
@@ -24,9 +24,12 @@ import RhyoliteDiagram from "../../../images/rock-key/svg/rhyolite-diagram.svg";
 import RhyolitePatternSrc from "../../../images/rock-patterns/rhyolite-key.png";
 import MantleBrittleDiagram from "../../../images/rock-key/svg/mantle-brittle-diagram.svg";
 import MantleDuctileDiagram from "../../../images/rock-key/svg/mantle-ductile-diagram.svg";
-import LowGradeMetamorphicRockDiagram from "../../../images/rock-key/svg/metamorphic-rock-low-grade-cc-collision-diagram.svg";
-import MediumGradeMetamorphicRockDiagram from "../../../images/rock-key/svg/metamorphic-rock-medium-grade-cc-collision-diagram.svg";
-import HighGradeMetamorphicRockDiagram from "../../../images/rock-key/svg/metamorphic-rock-high-grade-cc-collision-diagram.svg";
+import LowGradeMetamorphicRockCCDiagram from "../../../images/rock-key/svg/metamorphic-rock-low-grade-cc-collision-diagram.svg";
+import MediumGradeMetamorphicRockCCDiagram from "../../../images/rock-key/svg/metamorphic-rock-medium-grade-cc-collision-diagram.svg";
+import HighGradeMetamorphicRockCCDiagram from "../../../images/rock-key/svg/metamorphic-rock-high-grade-cc-collision-diagram.svg";
+import LowGradeMetamorphicRockSubductionDiagram from "../../../images/rock-key/svg/metamorphic-rock-low-grade-subduction-zone-diagram.svg";
+import MediumGradeMetamorphicRockSubductionDiagram from "../../../images/rock-key/svg/metamorphic-rock-medium-grade-subduction-zone-diagram.svg";
+import HighGradeMetamorphicRockSubductionDiagram from "../../../images/rock-key/svg/metamorphic-rock-high-grade-subduction-zone-diagram.svg";
 import SandstoneDiagram from "../../../images/rock-key/svg/sandstone-diagram.svg";
 import SandstonePatternSrc from "../../../images/rock-patterns/sandstone-key.png";
 import ShaleDiagram from "../../../images/rock-key/svg/shale-diagram.svg";
@@ -53,14 +56,16 @@ const FLASH_ANIMATION_DURATION = 750;
 interface IRockDef {
   name?: RockKeyLabel;
   shortName?: string; // if different than full name
-  pattern: string;
+  pattern?: string;
   image?: JSX.Element;
   diagram?: JSX.Element;
   notes?: JSX.Element;
+  oneOf?: Omit<IRockDef, "oneOf">[];
 }
 
-interface IRockProps extends IRockDef {
+interface IRockProps {
   onRockClick?: (rock: string | null) => void;
+  rock: IRockDef;
 }
 
 interface IContainerDef {
@@ -192,43 +197,94 @@ const TecRockKey: IContainerDef[] = [
     lightColor: METAMORPHIC_GREEN_LIGHT,
     rocks: [
       {
-        shortName: "Low Grade",
-        name: "Low Grade Metamorphic Rock",
-        pattern: MetamorphicLowGradePatternSrc,
-        diagram: <LowGradeMetamorphicRockDiagram />,
-        notes: (
-          <div>
-            <p><b>Tectonic Environment:</b> shallow subduction zone, shallow collision boundaries</p>
-            <p><b>Origin Rock:</b> any</p>
-            <p><b>Metamorphic Conditions:</b> low temperature and low pressure</p>
-          </div>
-        )
+        oneOf: [
+          {
+            shortName: "Low Grade",
+            name: "Low Grade Metamorphic Rock (Continental Collision)",
+            pattern: MetamorphicLowGradePatternSrc,
+            diagram: <LowGradeMetamorphicRockCCDiagram />,
+            notes: (
+              <div>
+                <p><b>Tectonic Environment:</b> shallow collision boundaries</p>
+                <p><b>Origin Rock:</b> any</p>
+                <p><b>Metamorphic Conditions:</b> low temperature and low pressure</p>
+              </div>
+            )
+          },
+          {
+            shortName: "Low Grade",
+            name: "Low Grade Metamorphic Rock (Subduction Zone)",
+            pattern: MetamorphicLowGradePatternSrc,
+            diagram: <LowGradeMetamorphicRockSubductionDiagram />,
+            notes: (
+              <div>
+                <p><b>Tectonic Environment:</b> shallow subduction zone</p>
+                <p><b>Origin Rock:</b> any</p>
+                <p><b>Metamorphic Conditions:</b> low temperature and low pressure</p>
+              </div>
+            )
+          }
+        ]
       },
       {
-        shortName: "Medium Grade",
-        name: "Medium Grade Metamorphic Rock",
-        pattern: MetamorphicMediumGradePatternSrc,
-        diagram: <MediumGradeMetamorphicRockDiagram />,
-        notes: (
-          <div>
-            <p><b>Tectonic Environment:</b> subduction zone, collision boundaries</p>
-            <p><b>Origin Rock:</b> any</p>
-            <p><b>Metamorphic Conditions:</b> high temperature and low pressure, or low temperature and high pressure</p>
-          </div>
-        )
+        oneOf: [
+          {
+            shortName: "Medium Grade",
+            name: "Medium Grade Metamorphic Rock (Continental Collision)",
+            pattern: MetamorphicMediumGradePatternSrc,
+            diagram: <MediumGradeMetamorphicRockCCDiagram />,
+            notes: (
+              <div>
+                <p><b>Tectonic Environment:</b> collision boundaries</p>
+                <p><b>Origin Rock:</b> any</p>
+                <p><b>Metamorphic Conditions:</b> high temperature and low pressure, or low temperature and high pressure</p>
+              </div>
+            )
+          },
+          {
+            shortName: "Medium Grade",
+            name: "Medium Grade Metamorphic Rock (Subduction Zone)",
+            pattern: MetamorphicMediumGradePatternSrc,
+            diagram: <MediumGradeMetamorphicRockSubductionDiagram />,
+            notes: (
+              <div>
+                <p><b>Tectonic Environment:</b> subduction zone</p>
+                <p><b>Origin Rock:</b> any</p>
+                <p><b>Metamorphic Conditions:</b> high temperature and low pressure, or low temperature and high pressure</p>
+              </div>
+            )
+          },
+        ]
       },
       {
-        shortName: "High Grade",
-        name: "High Grade Metamorphic Rock",
-        pattern: MetamorphicHighGradePatternSrc,
-        diagram: <HighGradeMetamorphicRockDiagram />,
-        notes: (
-          <div>
-            <p><b>Tectonic Environment:</b> deep subduction zone, deep collision boundaries</p>
-            <p><b>Origin Rock:</b> any</p>
-            <p><b>Metamorphic Conditions:</b> high temperature and high pressure</p>
-          </div>
-        )
+        oneOf: [
+          {
+            shortName: "High Grade",
+            name: "High Grade Metamorphic Rock (Continental Collision)",
+            pattern: MetamorphicHighGradePatternSrc,
+            diagram: <HighGradeMetamorphicRockCCDiagram />,
+            notes: (
+              <div>
+                <p><b>Tectonic Environment:</b> deep collision boundaries</p>
+                <p><b>Origin Rock:</b> any</p>
+                <p><b>Metamorphic Conditions:</b> high temperature and high pressure</p>
+              </div>
+            )
+          },
+          {
+            shortName: "High Grade",
+            name: "High Grade Metamorphic Rock (Subduction Zone)",
+            pattern: MetamorphicHighGradePatternSrc,
+            diagram: <HighGradeMetamorphicRockSubductionDiagram />,
+            notes: (
+              <div>
+                <p><b>Tectonic Environment:</b> deep subduction zone</p>
+                <p><b>Origin Rock:</b> any</p>
+                <p><b>Metamorphic Conditions:</b> high temperature and high pressure</p>
+              </div>
+            )
+          }
+        ]
       }
     ]
   },
@@ -461,19 +517,35 @@ const Container = (props: IContainerProps) => {
   const midIndex = Math.ceil(rocks.length * 0.5);
   const firstColumn = rocks.slice(0, midIndex);
   const secondColumn = rocks.slice(midIndex);
-  const selectedRockDef = selectedRock ? rocks.find(rock => rock.name === selectedRock) : undefined;
+  let selectedRockDef: IRockDef | undefined;
+  rocks.forEach(rockDef => {
+    if (rockDef.oneOf) {
+      rockDef.oneOf.forEach((subRockDef: IRockDef) => {
+        if (subRockDef.name === selectedRock) {
+          selectedRockDef = subRockDef;
+        }
+      });
+    } else if (rockDef.name === selectedRock) {
+      selectedRockDef = rockDef;
+    }
+  });
   const container = useRef<HTMLDivElement>(null);
 
-  const Rock = (rock: IRockProps) => {
+  const Rock = (rockProps: IRockProps) => {
+    let rock = rockProps.rock;
+    if (rock.oneOf) {
+      rock = rock.oneOf.find(r => r.name === selectedRock) || rock.oneOf[0];
+    }
+
     const isSelected = selectedRock === rock.name;
-    const handleClick = () => rock.name && rock.onRockClick?.(isSelected ? null : rock.name);
+    const handleClick = () => rock.name && props.onRockClick?.(isSelected ? null : rock.name);
 
     return (
       <div className={`${css.rock} ${rock.name ? css.selectable : ""}`} key={rock.name} onClick={handleClick}>
         <TakeSampleBadge backgroundColor={lightColor} borderColor={mainColor} isSelected={selectedRock === rock.name} />
         <div className={`${css.flashContainer} ${flash && isSelected ? css.flash : ""}`}>
           <div className={`${css.patternContainer} ${selectedRock === rock.name ? css.selected: ""}`} style={{ borderColor: mainColor }}>
-            { (rock.pattern).includes("png")
+            { rock.pattern?.includes("png")
               ? <img src={rock.pattern} />
               : <div className={css.patternIcon} style={{ background: rock.pattern }} />
             }
@@ -499,11 +571,11 @@ const Container = (props: IContainerProps) => {
       <div className={css.content}>
         <div className={css.column}>
           { firstColumn.map(rock =>
-            <Rock key={rock.name} {...rock} onRockClick={onRockClick} />) }
+            <Rock key={rock.shortName} rock={rock} onRockClick={onRockClick} />) }
         </div>
         <div className={css.column}>
           { secondColumn.map(rock =>
-            <Rock key={rock.name} {...rock} onRockClick={onRockClick} />) }
+            <Rock key={rock.shortName} rock={rock} onRockClick={onRockClick} />) }
         </div>
         {
           selectedRockDef?.notes &&
@@ -520,9 +592,7 @@ const Container = (props: IContainerProps) => {
   );
 };
 
-interface IState {
-
-}
+interface IState {}
 
 @inject("simulationStore")
 @observer

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -322,6 +322,11 @@ class CrossSectionRenderer {
 
   checkStroke(points: THREE.Vector2[], lineWidth: number) {
     const ctx = this.ctx;
+    if (!ctx.isPointInStroke) {
+      // Environment doesn't support isPointInStroke. Fortunately, it's only IE and Node.js Canvas implementation
+      // used by Jest tests.
+      return false;
+    }
     ctx.beginPath();
     points.forEach((p, idx) => {
       if (idx === 0) {

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -363,9 +363,9 @@ class CrossSectionRenderer {
 
   fillMetamorphicOverlay(interactiveObjectLabel: InteractiveObjectLabel, p1: THREE.Vector2, p2: THREE.Vector2, p3: THREE.Vector2, p4: THREE.Vector2) {
     let color = METAMORPHIC_LOW_GRADE;
-    if (interactiveObjectLabel === "Medium Grade Metamorphic Rock") {
+    if (interactiveObjectLabel.startsWith("Medium Grade Metamorphic Rock")) {
       color = METAMORPHIC_MEDIUM_GRADE;
-    } else if (interactiveObjectLabel === "High Grade Metamorphic Rock") {
+    } else if (interactiveObjectLabel.startsWith("High Grade Metamorphic Rock")) {
       color = METAMORPHIC_HIGH_GRADE;
     }
     // Metamorphic color overlay.
@@ -381,11 +381,11 @@ class CrossSectionRenderer {
       // "Horizontal" metamorphism.
       let possibleInteractiveObjectLabel: InteractiveObjectLabel;
       if (field.subduction < METAMORPHISM_SUBDUCTION_COLOR_STEP_0) {
-        possibleInteractiveObjectLabel = "Low Grade Metamorphic Rock";
+        possibleInteractiveObjectLabel = "Low Grade Metamorphic Rock (Subduction Zone)";
       } else if (field.subduction < METAMORPHISM_SUBDUCTION_COLOR_STEP_1) {
-        possibleInteractiveObjectLabel = "Medium Grade Metamorphic Rock";
+        possibleInteractiveObjectLabel = "Medium Grade Metamorphic Rock (Subduction Zone)";
       } else {
-        possibleInteractiveObjectLabel = "High Grade Metamorphic Rock";
+        possibleInteractiveObjectLabel = "High Grade Metamorphic Rock (Subduction Zone)";
       }
       this.fillMetamorphicOverlay(possibleInteractiveObjectLabel, p1, p2, p3, p4);
     } else {
@@ -403,9 +403,9 @@ class CrossSectionRenderer {
           const p2a = (new THREE.Vector2()).lerpVectors(p2, p3, METAMORPHISM_OROGENY_COLOR_STEP_0);
           const p2b = (new THREE.Vector2()).lerpVectors(p2, p3, METAMORPHISM_OROGENY_COLOR_STEP_1);
 
-          this.fillMetamorphicOverlay("Low Grade Metamorphic Rock", p1, p2, p2a, p1a);
-          this.fillMetamorphicOverlay("Medium Grade Metamorphic Rock", p1a, p2a, p2b, p1b);
-          this.fillMetamorphicOverlay("High Grade Metamorphic Rock", p1b, p2b, p3, p4);
+          this.fillMetamorphicOverlay("Low Grade Metamorphic Rock (Continental Collision)", p1, p2, p2a, p1a);
+          this.fillMetamorphicOverlay("Medium Grade Metamorphic Rock (Continental Collision)", p1a, p2a, p2b, p1b);
+          this.fillMetamorphicOverlay("High Grade Metamorphic Rock (Continental Collision)", p1b, p2b, p3, p4);
         } else {
           // Divide vertical p1-p4 line into 4 sections (p1-p1a, p1a-p1b, p1b-p1c, p1c-p4).
           const p1a = (new THREE.Vector2()).lerpVectors(p1, p4, METAMORPHISM_OROGENY_COLOR_STEP_0);
@@ -416,9 +416,9 @@ class CrossSectionRenderer {
           const p2b = (new THREE.Vector2()).lerpVectors(p2, p3, METAMORPHISM_OROGENY_COLOR_STEP_1);
           const p2c = (new THREE.Vector2()).lerpVectors(p2, p3, METAMORPHISM_OROGENY_COLOR_STEP_2);
 
-          this.fillMetamorphicOverlay("Low Grade Metamorphic Rock", p1a, p2a, p2b, p1b);
-          this.fillMetamorphicOverlay("Medium Grade Metamorphic Rock", p1b, p2b, p2c, p1c);
-          this.fillMetamorphicOverlay("High Grade Metamorphic Rock", p1c, p2c, p3, p4);
+          this.fillMetamorphicOverlay("Low Grade Metamorphic Rock (Continental Collision)", p1a, p2a, p2b, p1b);
+          this.fillMetamorphicOverlay("Medium Grade Metamorphic Rock (Continental Collision)", p1b, p2b, p2c, p1c);
+          this.fillMetamorphicOverlay("High Grade Metamorphic Rock (Continental Collision)", p1c, p2c, p3, p4);
         }
       }
     }

--- a/js/types.ts
+++ b/js/types.ts
@@ -19,8 +19,9 @@ export type IMatrix3Array = [number, number, number, number, number, number, num
 
 export type RockKeyLabel = "Granite" | "Basalt" | "Gabbro" | "Rhyolite" | "Andesite" | "Diorite" | "Limestone" |
   "Shale" | "Sandstone" | "Oceanic Sediments" | "Continental Sediments" | "Mantle (brittle)" | "Mantle (ductile)" |
-  "Low Grade Metamorphic Rock" | "Medium Grade Metamorphic Rock" | "High Grade Metamorphic Rock" | "Silica-rich Magma" |
-  "Intermediate Magma" | "Iron-rich Magma" | "Sky" | "Ocean";
+  "Low Grade Metamorphic Rock (Subduction Zone)" | "Medium Grade Metamorphic Rock (Subduction Zone)" | "High Grade Metamorphic Rock (Subduction Zone)" |
+  "Low Grade Metamorphic Rock (Continental Collision)" | "Medium Grade Metamorphic Rock (Continental Collision)" | "High Grade Metamorphic Rock (Continental Collision)" |
+  "Contact Metamorphism" | "Silica-rich Magma" | "Intermediate Magma" | "Iron-rich Magma" | "Sky" | "Ocean";
 
 export type ICrossSectionWall = "front" | "back" | "top" | "left" | "right";
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180970003

This PR makes a few significant changes to Rock Key. The project team wanted to show different diagrams for Low/Medium/High Grade Metamorphic Rocks depending on whether the user clicked the rock in subduction zone or continent-continent collision.

However, they still wanted to show only one header for each grade. So, TecRock will expand this header with a different diagram, depending on the picked rock. If the user clicks the header directly, it'll open the Continental Collision variant by default. I find this interaction pretty weird, but it was the requirement, and I didn't have a better idea how to handle that (apart from showing 7 different headers in the key, but it wouldn't look great).

That's why Rock Key has now a strange entry called `oneOf` (naming inspired by webpack configuration). It's just a group of rocks, displayed under one header in the key.

I've also added Contact Metarmopism as a separate entry. Users can click on the magma blob border to open it. That's why the border is now wider.