### PR TITLE
Add Planet Wizard validation pattern and check user-set densities

### DIFF
--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -11,6 +11,8 @@ import ccLogoSmall from "../../images/cc-logo-small.png";
 import SortableDensities from "./sortable-densities";
 import { BaseComponent, IBaseProps } from "./base";
 import { log } from "../log";
+import { isDensityDefinedCorrectly } from "../stores/helpers/planet-wizard-model-validators";
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
 
 import "../../css/planet-wizard.less";
 
@@ -26,7 +28,18 @@ interface IStepsData {
   info: (geode: boolean) => string; // label of bottom bar button
   navigationDisabled?: boolean; // whether next/back navigation should be disabled globally
   nextDisabled?: (simulationStore: SimulationStore) => boolean; // whether next navigation should be disabled conditionally
+  validation?: IValidation; // when defined, the test test will be ran before user can go to the next step
 }
+
+interface IValidation {
+  // If this function returns false, user will see a warning dialog that lets him return and fix the configuration.
+  test: (simulationStore: SimulationStore) => boolean;
+  // Warning dialog message.
+  message: string;
+  // Label of the button that lets users go back and fix the model.
+  goBackButton: string;
+}
+
 export const STEPS_DATA: Record<string, IStepsData> = {
   presets: {
     info: () => "Select layout of the planet",
@@ -42,7 +55,12 @@ export const STEPS_DATA: Record<string, IStepsData> = {
     nextDisabled: simulationStore => !simulationStore.anyHotSpotDefinedByUser
   },
   densities: {
-    info: () => "Order plates"
+    info: () => "Order plates",
+    validation: {
+      test: simulationStore => isDensityDefinedCorrectly(simulationStore.model),
+      message: "Oceanic crust should go below continental crust at the boundary. Please reorder the plates to make this possible.",
+      goBackButton: "Re-order plates"
+    }
   }
 };
 
@@ -58,6 +76,7 @@ interface IProps extends IBaseProps {
 
 interface IState {
   step: number;
+  validationDialogOpen: boolean;
 }
 
 @inject("simulationStore")
@@ -66,10 +85,13 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      step: 0
+      step: 0,
+      validationDialogOpen: false
     };
     this.handleNextButtonClick = this.handleNextButtonClick.bind(this);
     this.handleBackButtonClick = this.handleBackButtonClick.bind(this);
+    this.closeDialogAndContinue = this.closeDialogAndContinue.bind(this);
+    this.closeDialog = this.closeDialog.bind(this);
   }
 
   get currentStep() {
@@ -123,9 +145,14 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
   }
 
   handleNextButtonClick() {
-    const { step } = this.state;
-    this.setState({ step: step + 1 });
     log({ action: "PlanetWizardNextButtonClicked" });
+    const { step } = this.state;
+    const validation = STEPS_DATA[this.currentStep].validation;
+    if (validation && !validation.test(this.simulationStore)) {
+      this.openValidationDialog();
+      return;
+    }
+    this.setState({ step: step + 1 });
   }
 
   handleBackButtonClick() {
@@ -134,6 +161,19 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
       this.setState({ step: step - 1 });
     }
     log({ action: "PlanetWizardBackButtonClicked" });
+  }
+
+  openValidationDialog() {
+    this.setState({ validationDialogOpen: true });
+  }
+
+  closeDialogAndContinue() {
+    const { step } = this.state;
+    this.setState({ validationDialogOpen: false, step: step + 1 });
+  }
+
+  closeDialog() {
+    this.setState({ validationDialogOpen: false });
   }
 
   loadModel(presetInfo: any) {
@@ -236,6 +276,31 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
     return (<span className={`label ${activeClass} ${doneClass}`} key={"info" + idx}>{ info }</span>);
   }
 
+  renderValidationDialog() {
+    const { validationDialogOpen } = this.state;
+    const validation = STEPS_DATA[this.currentStep].validation;
+    if (!validation) {
+      return null;
+    }
+
+    return (
+      <Dialog open={validationDialogOpen}>
+        <DialogTitle>
+          Warning
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            { validation.message }
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={this.closeDialogAndContinue}>Continue anyway</Button>
+          <Button onClick={this.closeDialog} autoFocus>{ validation.goBackButton }</Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
   render() {
     const { step } = this.state;
     const stepName = this.currentStep;
@@ -271,6 +336,8 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
           }
           <Button primary raised label={"Back"} disabled={backDisabled} onClick={this.handleBackButtonClick} />
           <Button primary raised label={this.nextButtonLabel} disabled={nextDisabled} onClick={this.handleNextButtonClick} data-test="planet-wizard-next" />
+
+          { this.renderValidationDialog() }
         </div>
       </div>
     );

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -170,10 +170,12 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
   closeDialogAndContinue() {
     const { step } = this.state;
     this.setState({ validationDialogOpen: false, step: step + 1 });
+    log({ action: "PlanetWizardFailedValidationContinueAnywayButtonClicked" });
   }
 
   closeDialog() {
     this.setState({ validationDialogOpen: false });
+    log({ action: "PlanetWizardFailedValidationTryAgainButtonClicked" });
   }
 
   loadModel(presetInfo: any) {

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -28,7 +28,7 @@ interface IStepsData {
   info: (geode: boolean) => string; // label of bottom bar button
   navigationDisabled?: boolean; // whether next/back navigation should be disabled globally
   nextDisabled?: (simulationStore: SimulationStore) => boolean; // whether next navigation should be disabled conditionally
-  validation?: IValidation; // when defined, the test test will be ran before user can go to the next step
+  validation?: IValidation; // when defined, the test will be run before user can go to the next step
 }
 
 interface IValidation {

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -32,7 +32,7 @@ interface IStepsData {
 }
 
 interface IValidation {
-  // If this function returns false, user will see a warning dialog that lets him return and fix the configuration.
+  // If this function returns false, user will see a warning dialog that lets them return and fix the configuration.
   test: (simulationStore: SimulationStore) => boolean;
   // Warning dialog message.
   message: string;

--- a/js/log.ts
+++ b/js/log.ts
@@ -50,6 +50,8 @@ type BoundaryTypeSelected = { action: "BoundaryTypeSelected", data: { value: Bou
 type PlateDensitiesUpdated = { action: "PlateDensitiesUpdated", data: { value: string[] }}
 type PlanetWizardNextButtonClicked = { action: "PlanetWizardNextButtonClicked", data?: undefined };
 type PlanetWizardBackButtonClicked = { action: "PlanetWizardBackButtonClicked", data?: undefined };
+type PlanetWizardFailedValidationContinueAnywayButtonClicked = { action: "PlanetWizardFailedValidationContinueAnywayButtonClicked", data?: undefined };
+type PlanetWizardFailedValidationTryAgainButtonClicked = { action: "PlanetWizardFailedValidationTryAgainButtonClicked", data?: undefined };
 
 type LogEvent = SimulationStarted | SimulationStopped | EarthquakesVisible | EarthquakesHidden |
   VolcanicEruptionsVisible | VolcanicEruptionsHidden | MapTypeUpdated | CrossSectionDrawingEnabled |
@@ -58,7 +60,8 @@ type LogEvent = SimulationStarted | SimulationStopped | EarthquakesVisible | Ear
   KeysAndOptionsTabChanged | RockKeyInfoDisplayed | AdvancedOptionToggled | SimulationSpeedUpdated | ModelShared |
   ShareDialogOpened | AboutDialogOpened | ReloadIconClicked | ResetPlanetOrientationClicked | ResetCrossSectionOrientationClicked |
   CrossSectionClosed | CrossSectionDrawingFinished | PlanetWizardNumberOfPlatesSelected | ContinentAdded | ContinentRemoved |
-  BoundaryTypeSelected | PlateDensitiesUpdated | PlanetWizardNextButtonClicked | PlanetWizardBackButtonClicked
+  BoundaryTypeSelected | PlateDensitiesUpdated | PlanetWizardNextButtonClicked | PlanetWizardBackButtonClicked |
+  PlanetWizardFailedValidationContinueAnywayButtonClicked | PlanetWizardFailedValidationTryAgainButtonClicked
 ;
 
 export const log = (event: LogEvent) => {

--- a/js/plates-model/model.ts
+++ b/js/plates-model/model.ts
@@ -473,7 +473,7 @@ export default class Model {
         // 3. Both fields exist at this position.
         // Higher field should stay in plate1, while lower plate should be moved to subplate (these fields are not
         // part of the simulation anymore, but they're rendered by cross-section so user can reason about past events).
-        if (plate1.density > plate2.density) {
+        if (plate1Field.elevation < plate2Field.elevation) {
           // Move plate1Field to subplate.
           plate1.deleteField(plate1Id);
           plate1.subplate.addExistingField(cloneField(plate1Field, plate1Id));

--- a/js/stores/helpers/planet-wizard-model-validators.ts
+++ b/js/stores/helpers/planet-wizard-model-validators.ts
@@ -1,0 +1,71 @@
+import { BASE_CONTINENT_ELEVATION } from "../../plates-model/crust";
+import FieldStore from "../field-store";
+import ModelStore from "../model-store";
+import { findFieldFromNeighboringPlate, getBoundaryInfo } from "./boundary-utils";
+
+function isContinent(field: FieldStore) {
+  // FieldStore is just a shallow copy of real Field class, so there's no access to rock layers there.
+  // However, elevation is a good way here to check if field is a continent or not.
+  return field.elevation >= BASE_CONTINENT_ELEVATION * 0.9;
+}
+
+function isContinentDensityValid(startField: FieldStore, model: ModelStore, fieldProcessed: Record<number, boolean>) {
+  let result = true;
+  let bordersWithContinent = false;
+
+  const queue: FieldStore[] = [startField];
+  fieldProcessed[startField.id] = true;
+
+  while (queue.length > 0) {
+    const f = queue.shift() as FieldStore;
+    if (f.boundary) {
+      const neighboringField = findFieldFromNeighboringPlate(f, model);
+      if (neighboringField && isContinent(neighboringField)) {
+        // This is continent-continent collision or divergence. In either case continent is defined correctly,
+        // and there's no need to check densities.
+        bordersWithContinent = true;
+      }
+      if (neighboringField && !isContinent(neighboringField) && neighboringField?.plate.density < f.plate.density) {
+        const boundaryInfo = getBoundaryInfo(f, neighboringField, model);
+        if (boundaryInfo?.type === "convergent") {
+          // Continent shares a boundary with ocean that has lower density. This is usually incorrect.
+          // The only case that can save this scenario is another continent on the other side of the boundary
+          // (handled above).
+          result = false;
+        }
+      }
+    }
+
+    f.forEachNeighbor(n => {
+      if (!fieldProcessed[n.id] && isContinent(n)) {
+        fieldProcessed[n.id] = true;
+        queue.push(n);
+      }
+    });
+  }
+
+  return bordersWithContinent || result;
+}
+
+// We have been struggling with how to handle the issue when students set the density of the plates to be opposite what
+// would actually happen with the continent set-up, specifically when it comes to convergence / subduction.
+// This function tries to detect this case. See: https://www.pivotaltracker.com/story/show/181257654
+export function isDensityDefinedCorrectly(model: ModelStore) {
+  let result = true;
+
+  model.plates.forEach(plate => {
+    if (!result) {
+      return;
+    }
+    const fieldProcessed: Record<number, boolean> = {};
+    plate.forEachField(field => {
+      if (!result) {
+        return;
+      }
+      if (!fieldProcessed[field.id] && isContinent(field) && !isContinentDensityValid(field, model, fieldProcessed)) {
+        result = false;
+      }
+    });
+  });
+  return result;
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181257654

A quite common problem in TecRock is that users draw a single continent at the boundary, set boundary type to be convergent, but they set the continental plate density to be higher than the neighboring oceanic plate. This results in an unallowed collision type that adds plenty of friction forces to stop continental subduction. So, the models comes to halt very quickly. Amy was concerned that users are getting confused by that.

This PR adds a new mechanism in Planet Wizard - each step might be validated and the user might be asked to make some changes. It's been used in the density selection step. So, if the validation function detects the use case described above, it'll suggest changing the density setup.

Demo: https://tectonic-explorer.concord.org/branch/density-dialog/index.html?planetWizard=true

A few cases are described below:

1. This setup should result in the warning.
<img width="874" alt="Screenshot 2022-03-07 at 19 27 13" src="https://user-images.githubusercontent.com/767857/157160507-a889422a-9be8-41b3-83d1-f3a453bc9b1c.png">

2. This setup should NOT result in the warning. There are some areas of the continent that will subduct, but I'm assuming this is a valid continent-continent collision.
<img width="889" alt="Screenshot 2022-03-07 at 19 28 28" src="https://user-images.githubusercontent.com/767857/157160619-99722e34-a037-4ac3-b309-66f4e4e0d775.png">

3. This setup will result in a warning no matter how the user setups densities. It cannot be fixed. But user can still select  "Continue anyway" and run the model to see what happens. Or go back to the continent drawing step.
<img width="880" alt="Screenshot 2022-03-07 at 19 30 36" src="https://user-images.githubusercontent.com/767857/157160835-44450f94-a274-4656-93b5-7a7b25537863.png">

