### PR TITLE
Bottom bar tweak

### DIFF
--- a/css/control-group.less
+++ b/css/control-group.less
@@ -10,20 +10,9 @@
   background-color: rgb(var(--theme-primary-color));
   color: rgb(var(--theme-secondary-color));
   border-radius: @component-border-radius @component-border-radius 0 0;
-  // &:first-child {
-  //   border-radius: 0 @component-border-radius 0 0;
-  //   .border-bubble {
-  //     border-radius: 0 @component-border-radius 0 0;
-  //     border-left: none;
-  //   }
-  // }
-  // &:last-child {
-  //   border-radius: @component-border-radius 0 0 0;
-  //   .border-bubble {
-  //     border-radius: @component-border-radius 0 0 0;
-  //     border-right: none;
-  //   }
-  // }
+  &.hideBubble {
+    background-color: rgba(0, 0, 0, .001);
+  }
   &:hover {
     // background-color: rgb(var(--theme-hover-background-color));
     color: rgb(var(--theme-hover-text-color));
@@ -51,6 +40,10 @@
     border: solid 1px rgb(var(--theme-secondary-color));
     border-bottom: none;
     border-radius: @component-border-radius @component-border-radius 0 0;
+
+    &.hideBubble {
+      display: none;
+    }
   }
 
   .buttons {

--- a/js/components/bottom-panel.tsx
+++ b/js/components/bottom-panel.tsx
@@ -168,16 +168,20 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
             </div>
           </ControlGroup>
           { !config.geode && (showTempPressureTool || showTakeSampleButton) &&
-            <ControlGroup>
+            <ControlGroup hideBubble={true}>
               <div className="interactive-tools">
                 { showTempPressureTool &&
-                  <IconHighlightButton active={isMeasuringTempPressure} disabled={!showCrossSectionView} style={{ width: 110 }}
-                    label={<>Measure<br/>Temp/Pressure</>} Icon={TemperatureIconControlSVG} Icon2={PressureIconControlSVG}
-                    onClick={() => this.toggleInteraction("measureTempPressure")} data-test="measure-temp-pressure" /> }
+                  <ControlGroup>
+                    <IconHighlightButton active={isMeasuringTempPressure} disabled={!showCrossSectionView} style={{ width: 110 }}
+                      label={<>Measure<br/>Temp/Pressure</>} Icon={TemperatureIconControlSVG} Icon2={PressureIconControlSVG}
+                      onClick={() => this.toggleInteraction("measureTempPressure")} data-test="measure-temp-pressure" />
+                  </ControlGroup> }
                 { showTakeSampleButton &&
-                  <IconHighlightButton active={isTakingRockSample} disabled={false} style={{ width: 64 }} data-test="take-sample"
-                    label={<>Take<br/>Sample</>} Icon={TakeSampleIconControlSVG}
-                    onClick={() => this.toggleInteraction("takeRockSample")} /> }
+                  <ControlGroup>
+                    <IconHighlightButton active={isTakingRockSample} disabled={false} style={{ width: 64 }} data-test="take-sample"
+                      label={<>Take<br/>Sample</>} Icon={TakeSampleIconControlSVG}
+                      onClick={() => this.toggleInteraction("takeRockSample")} />
+                  </ControlGroup> }
               </div>
             </ControlGroup> }
           { showEventsGroup &&

--- a/js/components/control-group.tsx
+++ b/js/components/control-group.tsx
@@ -5,16 +5,17 @@ import "../../css/control-group.less";
 
 interface IProps {
   className?: string;
+  hideBubble?: boolean;
   first?: boolean;
   last?: boolean;
   disabled?: boolean;
 }
 
 export const ControlGroup: React.FC<IProps> = (props) => {
-  const { className, first, last, children, disabled } = props;
+  const { className, hideBubble = false, first, last, children, disabled } = props;
   return (
-    <div className={classNames("control-group", className, { disabled })}>
-      <div className={classNames("border-bubble", { first }, { last })} />
+    <div className={classNames("control-group", className, { hideBubble, disabled })}>
+      <div className={classNames("border-bubble", { hideBubble, first, last })} />
       { children }
     </div>
   );


### PR DESCRIPTION
PT: [[#181680353]/comment](https://www.pivotaltracker.com/story/show/181680353/comments/230928425)

>Can I ask for one minor detail to be implemented for the bottom control bar: the bubbly top of the buttons should span each button separately -- the Temp/Pressure tool and Take Sample tool -- rather than spanning both. But they should still always sit next to (abut) one another.

Done