### PR TITLE
Downgrade screenfull to the last non-ESM version to avoid problems in older browsers.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tectonic-explorer",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tectonic-explorer",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@concord-consortium/lara-interactive-api": "^1.5.0",
@@ -33,7 +33,7 @@
         "react-toolbox": "2.0.0-beta.13",
         "react-transition-group": "~4.4.2",
         "rollbar": "^2.24.0",
-        "screenfull": "^6.0.1",
+        "screenfull": "^5.2.0",
         "seedrandom": "^3.0.5",
         "shutterbug": "^1.3.2",
         "three": "^0.130.1",
@@ -20203,11 +20203,11 @@
       }
     },
     "node_modules/screenfull": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-6.0.1.tgz",
-      "integrity": "sha512-yzQW+j4zMUBQC51xxWaoDYjxOtl8Kn+xvue3p6v/fv2pIi1jH4AldgVLU8TBfFVgH2x3VXlf3+YiA/AYIPlaew==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=0.10.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -38746,9 +38746,9 @@
       }
     },
     "screenfull": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-6.0.1.tgz",
-      "integrity": "sha512-yzQW+j4zMUBQC51xxWaoDYjxOtl8Kn+xvue3p6v/fv2pIi1jH4AldgVLU8TBfFVgH2x3VXlf3+YiA/AYIPlaew=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
     },
     "seedrandom": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-toolbox": "2.0.0-beta.13",
     "react-transition-group": "~4.4.2",
     "rollbar": "^2.24.0",
-    "screenfull": "^6.0.1",
+    "screenfull": "^5.2.0",
     "seedrandom": "^3.0.5",
     "shutterbug": "^1.3.2",
     "three": "^0.130.1",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/182036906

The last screenful version mentions in their readme:

> This package is ESM. Please [familiarize](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c) yourself with that that implies.
If you cannot use ESM or need to support older browsers without using transpilation, use version 5.2.0.

Chris Lore sent me a screenshot from old Chromebook and it confirms the problem is in the screenfull package source.

I should probably learn more about ESM and its implications and consider some other options. But this looks like a quick and safe fix for now.