### PR TITLE
Boundary stays highlighted in presence of boundary selection dialog

### DIFF
--- a/js/plates-interactions/base-interactions-manager.ts
+++ b/js/plates-interactions/base-interactions-manager.ts
@@ -106,7 +106,10 @@ export class BaseInteractionsManager {
       }
     });
     $elem.on(`pointermove.${this.namespace}`, (event) => {
-      if (!this.isOverDomElement(event.clientX, event.clientY)) {
+      // use boundary test or target test depending on whether interaction requires an overlay
+      if (interaction.emitMoveEventWithOverlay
+            ? !this.isOverDomElement(event.clientX, event.clientY)
+            : (event.target as any) !== this.view.domElement) {
         interaction.onPointerOff?.();
         return;
       }

--- a/js/plates-interactions/cross-section-click.ts
+++ b/js/plates-interactions/cross-section-click.ts
@@ -5,6 +5,7 @@ export interface ICrossSectionClickOptions {
   getIntersection: (mesh: THREE.Mesh) => (THREE.Intersection | undefined);
   wallMesh: Record<ICrossSectionWall, THREE.Mesh>;
   cursor: string;
+  emitMoveEventWithOverlay?: boolean;
   onPointerDown?: (event: { wall: ICrossSectionWall, intersection: THREE.Vector2 }) => void;
   onPointerMove?: (event: { wall: ICrossSectionWall, intersection: THREE.Vector2 }) => void;
   onPointerOff?: () => void;
@@ -13,10 +14,12 @@ export interface ICrossSectionClickOptions {
 // Generic helper that detects click on the planet surface and emits an event with provided name.
 export default class CrossSectionClick {
   options: ICrossSectionClickOptions;
+  emitMoveEventWithOverlay: boolean;
   inProgress: boolean;
 
   constructor(options: ICrossSectionClickOptions) {
     this.options = options;
+    this.emitMoveEventWithOverlay = !!options.emitMoveEventWithOverlay;
   }
 
   get cursor() {

--- a/js/plates-interactions/cross-section-interactions-manager.ts
+++ b/js/plates-interactions/cross-section-interactions-manager.ts
@@ -29,6 +29,7 @@ export default class CrossSectionInteractionsManager extends BaseInteractionsMan
       measureTempPressure: new CrossSectionClick({
         ...baseOptions,
         cursor: "none",
+        emitMoveEventWithOverlay: true,
         onPointerMove: ({ wall, intersection }) => {
           const intersectionData = view.getIntersectionData(wall, intersection);
           if (intersectionData?.field) {

--- a/js/plates-interactions/globe-interactions-manager.ts
+++ b/js/plates-interactions/globe-interactions-manager.ts
@@ -27,7 +27,7 @@ export default class GlobeInteractionsManager extends BaseInteractionsManager {
       markField: new PlanetClick({ ...baseOptions, startEventName: "markField" }),
       continentDrawing: new PlanetClick({ ...baseOptions, startEventName: "continentDrawing", moveEventName: "continentDrawing", endEventName: "continentDrawingEnd" }),
       continentErasing: new PlanetClick({ ...baseOptions, startEventName: "continentErasing", moveEventName: "continentErasing", endEventName: "continentErasingEnd" }),
-      measureTempPressure: new PlanetClick({ ...baseOptions, cursor: "not-allowed" }),
+      measureTempPressure: new PlanetClick({ ...baseOptions, cursor: "not-allowed", emitMoveEventWithOverlay: true }),
       takeRockSample: new PlanetClick({ ...baseOptions, startEventName: "takeRockSampleFromSurface", cursor: TakeRockSampleCursor }),
       assignBoundary: new PlanetClick({ ...baseOptions, startEventName: "assignBoundary", moveEventName: "highlightBoundarySegment", alwaysEmitMoveEvent: true }),
     };

--- a/js/plates-interactions/helpers.ts
+++ b/js/plates-interactions/helpers.ts
@@ -8,6 +8,7 @@ export const TempPressureCursor = `url("${TempPressureCursorPng}") 8 8, crosshai
 
 export interface IInteractionHandler {
   cursor: string;
+  emitMoveEventWithOverlay?: boolean;
   onPointerDown?: (pos: IEventCoords) => boolean;
   onPointerMove?: (pos: IEventCoords) => void;
   onPointerOff?: () => void;

--- a/js/plates-interactions/planet-click.ts
+++ b/js/plates-interactions/planet-click.ts
@@ -9,6 +9,7 @@ interface IPlanetClickOptions {
   endEventName?: string;
   cursor?: string;
   alwaysEmitMoveEvent?: boolean;
+  emitMoveEventWithOverlay?: boolean;
 }
 
 export interface IPlanetClickData {
@@ -27,9 +28,12 @@ export default class PlanetClick {
   cursor: string;
   pointerDown: boolean;
   alwaysEmitMoveEvent: boolean;
+  emitMoveEventWithOverlay: boolean;
 
   constructor(options: IPlanetClickOptions) {
-    const { getIntersection, emit, startEventName, moveEventName, endEventName, alwaysEmitMoveEvent } = options;
+    const {
+      getIntersection, emit, startEventName, moveEventName, endEventName, alwaysEmitMoveEvent, emitMoveEventWithOverlay
+    } = options;
     this.getIntersection = getIntersection;
     this.emit = emit;
     this.startEventName = startEventName;
@@ -37,6 +41,7 @@ export default class PlanetClick {
     this.endEventName = endEventName;
     this.cursor = options.cursor || "crosshair";
     this.alwaysEmitMoveEvent = !!alwaysEmitMoveEvent;
+    this.emitMoveEventWithOverlay = !!emitMoveEventWithOverlay;
     // Test geometry is a sphere with radius 1, which is exactly what is used in the whole model for earth visualization.
     this.earthMesh = new THREE.Mesh(new THREE.SphereGeometry(1.0, 64, 64));
   }


### PR DESCRIPTION
PT: [[#180335792]/comment](https://www.pivotaltracker.com/story/show/180335792/comments/231035077)
Demo: https://tectonic-explorer.concord.org/branch/polar-boundary/index.html

This was actually broken in #207 with the implementation of the temperature/pressure tool, but not noticed until working on the polar cap boundary highlighting story.