### PR TITLE
Implement block faulting around cont-cont divergent boundaries

### DIFF
--- a/js/config.ts
+++ b/js/config.ts
@@ -92,6 +92,8 @@ const DEFAULT_CONFIG = {
   continentDensity: 3,
   // How fast continent is stretching along divergent boundary. Bigger value means it would turn into ocean / sea faster.
   continentalStretchingRatio: 4,
+  // Intensity of the block faulting around divergent continent-continent boundary. 0 will turn it off completely.
+  blockFaultingStrength: 0.2,
   // Max length of the cross-section line
   maxCrossSectionLength: 4000, // km
   // Horizontal scaling of cross-section data.

--- a/js/plates-model/get-cross-section.ts
+++ b/js/plates-model/get-cross-section.ts
@@ -41,6 +41,7 @@ export interface ICrossSectionFieldData {
   canSubduct?: boolean;
   divergentBoundaryMagma?: boolean;
   volcanicEruption?: boolean;
+  blockFaulting?: number;
   marked?: boolean;
   subduction?: number;
   earthquake?: IEarthquake;
@@ -150,6 +151,9 @@ function getFieldRawData(field: Field, props?: IWorkerProps): ICrossSectionField
   }
   if (field.volcanicAct?.magma) {
     result.magma = field.volcanicAct.magma;
+  }
+  if (field.blockFaulting) {
+    result.blockFaulting = field.blockFaulting;
   }
   if (field.marked) {
     result.marked = true;

--- a/js/plates-model/model.ts
+++ b/js/plates-model/model.ts
@@ -334,6 +334,9 @@ export default class Model {
                 props.age = neighbor.age;
                 // When continent is being stretched, move field marker to the new field to emphasise this effect.
                 props.marked = neighbor.marked;
+                // `blockFaulting` value doesn't have physical meaning, but it's used to determine its direction in the
+                // rendering code. 1e6 value is big enough to cover all the visible fields in the cross-section.
+                props.blockFaulting = (neighbor.blockFaulting ?? 1e6) - 1;
                 neighbor.marked = false;
               } else {
                 props.type = "ocean";

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -224,7 +224,7 @@ class CrossSectionRenderer {
 
       let leftBlockFaulting = false;
       let rightBlockFaulting = false;
-      if (config.blockFaultingStrength  && f1.blockFaulting && f2.blockFaulting) {
+      if (config.blockFaultingStrength && f1.blockFaulting && f2.blockFaulting) {
         leftBlockFaulting = f1.blockFaulting < f2.blockFaulting;
         rightBlockFaulting = f1.blockFaulting > f2.blockFaulting;
       }

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -221,9 +221,17 @@ class CrossSectionRenderer {
       if (!f1 || !f2) {
         continue;
       }
+
+      let leftBlockFaulting = false;
+      let rightBlockFaulting = false;
+      if (config.blockFaultingStrength  && f1.blockFaulting && f2.blockFaulting) {
+        leftBlockFaulting = f1.blockFaulting < f2.blockFaulting;
+        rightBlockFaulting = f1.blockFaulting > f2.blockFaulting;
+      }
       // Top of the crust
-      const t1 = new THREE.Vector2(x1, f1.elevation);
-      const t2 = new THREE.Vector2(x2, f2.elevation);
+      // Block faulting moves one of the fields slightly up to create a sharp edge / block corner.
+      const t1 = new THREE.Vector2(x1, f1.elevation + (leftBlockFaulting ? config.blockFaultingStrength : 0));
+      const t2 = new THREE.Vector2(x2, f2.elevation + (rightBlockFaulting ? config.blockFaultingStrength : 0));
       const tMid = new THREE.Vector2((t1.x + t2.x) / 2, (t1.y + t2.y) / 2);
       // Bottom of the crust, top of the lithosphere
       const c1 = new THREE.Vector2(x1, f1.elevation - f1.crustThickness);
@@ -288,6 +296,15 @@ class CrossSectionRenderer {
       }
       if (f2.divergentBoundaryMagma) {
         this.drawDivergentBoundaryMagma(f2, t2, tMid, lMid, l2);
+      }
+      // Add contour lines to block faulting.
+      if (leftBlockFaulting) {
+        this.fillPath2([t1, t2], undefined, "black");
+        this.fillPath2([t2, cMid], undefined, "black");
+      }
+      if (rightBlockFaulting) {
+        this.fillPath2([t1, t2], undefined, "black");
+        this.fillPath2([t1, cMid], undefined, "black");
       }
     }
     this.drawSubductionZoneMagma(subductionZoneMagmaPoints);


### PR DESCRIPTION
[#177579801]

Demo: https://tectonic-explorer.concord.org/branch/block-faulting/index.html?modelId=07823204-632d-4b05-8712-7f055b372e3a&rocks=true

This is as close as I could get to some drafts you posted in the PT story. The diagonal lines are fake, they just go within one column / field, but I think the visual effect works okay. The code turned out to be pretty small / simpler than expected (it also shows a complete round trip of data, from model to cross-section rendering code).

You can also change how strong is the faulting using a new url param:
- stronger: [https://tectonic-explorer.concord.org/branch/block-faulting/index.html?modelId=07823204-632[…]8712-7f055b372e3a&rocks=true&blockFaultingStrength=0.3](https://tectonic-explorer.concord.org/branch/block-faulting/index.html?modelId=07823204-632d-4b05-8712-7f055b372e3a&rocks=true&blockFaultingStrength=0.3)
- weaker: [https://tectonic-explorer.concord.org/branch/block-faulting/index.html?modelId=07823204-632[…]8712-7f055b372e3a&rocks=true&blockFaultingStrength=0.1](https://tectonic-explorer.concord.org/branch/block-faulting/index.html?modelId=07823204-632d-4b05-8712-7f055b372e3a&rocks=true&blockFaultingStrength=0.1)
- disabled: [https://tectonic-explorer.concord.org/branch/block-faulting/index.html?modelId=07823204-632[…]5-8712-7f055b372e3a&rocks=true&blockFaultingStrength=0](https://tectonic-explorer.concord.org/branch/block-faulting/index.html?modelId=07823204-632d-4b05-8712-7f055b372e3a&rocks=true&blockFaultingStrength=0)