### PR TITLE
Add thrust faulting around convergent boundaries

### DIFF
--- a/js/config.ts
+++ b/js/config.ts
@@ -94,6 +94,8 @@ const DEFAULT_CONFIG = {
   continentalStretchingRatio: 4,
   // Intensity of the block faulting around divergent continent-continent boundary. 0 will turn it off completely.
   blockFaultingStrength: 0.2,
+  // Larger value will increase width of the block faulting area around continental collision boundary.
+  orogenyBlockFaultingWidth: 135,
   // Max length of the cross-section line
   maxCrossSectionLength: 4000, // km
   // Horizontal scaling of cross-section data.

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -432,7 +432,7 @@ export default class Field extends FieldBase<Field> {
     this.forEachNeighbor((n) => {
       if (n.oceanicCrust && !n.subduction && n.bendingProgress < possibleNeighBending &&
         // This line below checks if vector that connects neighboring field with this one is pointing the opposite
-        // direction than the velocity the (subducting) plate. This ensures that plate bending progresses
+        // direction than the velocity of the (subducting) plate. This ensures that plate bending progresses
         // against the plate movement direction. It makes sense and lets us avoid some unwanted effects. See:
         // https://www.pivotaltracker.com/story/show/178375945
         n.absolutePos.clone().sub(this.absolutePos).angleTo(this.plate.linearVelocity(this.absolutePos)) > minAngle) {

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -401,7 +401,7 @@ export default class Field extends FieldBase<Field> {
       if (this.blockFaulting === 0) {
         // Add block faulting to the top plate that is part of the continental collision. The actual value has no physical
         // meaning, but larger value will propagate more (check #propagateBlockFaulting()) making the block faulting area
-        // wider. And the difference between between the two neighboring fields defines faulting direction in the rendering code.
+        // wider. And the difference between the two neighboring fields defines faulting direction in the rendering code.
         this.blockFaulting = config.orogenyBlockFaultingWidth * getGrid().fieldDiameter;
         this.shouldPropagateBlockFaulting = true;
       }

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -300,11 +300,11 @@ class CrossSectionRenderer {
       // Add contour lines to block faulting.
       if (leftBlockFaulting) {
         this.fillPath2([t1, t2], undefined, "black");
-        this.fillPath2([t2, cMid], undefined, "black");
+        this.fillPath2([t2, c1], undefined, "black");
       }
       if (rightBlockFaulting) {
         this.fillPath2([t1, t2], undefined, "black");
-        this.fillPath2([t1, cMid], undefined, "black");
+        this.fillPath2([t1, c2], undefined, "black");
       }
     }
     this.drawSubductionZoneMagma(subductionZoneMagmaPoints);


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181799189

Demo: https://tectonic-explorer.concord.org/branch/thrust-faulting/index.html?modelId=550f18df-ad6e-4714-bc24-f021c64c5f2d&rocks=true

This PR adds thrust faulting around convergent continent-continent boundaries. PT story has a bit unclear description (I guess copied over from divergent boundary version) and the draft image there is very optimistic. But this is what I could do for now. Let's see what's the project team feedback.