### PR TITLE
Tweak block faulting

### DIFF
--- a/js/config.ts
+++ b/js/config.ts
@@ -93,9 +93,9 @@ const DEFAULT_CONFIG = {
   // How fast continent is stretching along divergent boundary. Bigger value means it would turn into ocean / sea faster.
   continentalStretchingRatio: 4,
   // Intensity of the block faulting around divergent continent-continent boundary. 0 will turn it off completely.
-  blockFaultingStrength: 0.2,
-  // Larger value will increase width of the block faulting area around continental collision boundary.
-  orogenyBlockFaultingWidth: 135,
+  blockFaultingStrength: 0.12,
+  // How deep the block faulting line goes into the crust. 0.5 => 50%.
+  blockFaultingDepth: 0.5,
   // Max length of the cross-section line
   maxCrossSectionLength: 4000, // km
   // Horizontal scaling of cross-section data.

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -300,11 +300,11 @@ class CrossSectionRenderer {
       // Add contour lines to block faulting.
       if (leftBlockFaulting) {
         this.fillPath2([t1, t2], undefined, "black");
-        this.fillPath2([t2, c1], undefined, "black");
+        this.fillPath2([t2, t1.clone().lerp(c1, config.blockFaultingDepth)], undefined, "black");
       }
       if (rightBlockFaulting) {
         this.fillPath2([t1, t2], undefined, "black");
-        this.fillPath2([t1, c2], undefined, "black");
+        this.fillPath2([t1, t2.clone().lerp(c2, config.blockFaultingDepth)], undefined, "black");
       }
     }
     this.drawSubductionZoneMagma(subductionZoneMagmaPoints);


### PR DESCRIPTION
[#177579801]
[#181799189]

The project team requested a few changes:
- Shallower block faulting lines. They mentioned 40km, but not sure what that means. I've made that configurable.
- Weaker faulting. I've updated the default config balue.
- No faulting in the subducting plate during orogeny / continental collision. It's removed now.
- Sequential propagation of the faulting in the top blat during orogeny / continental collision rather than immediate change. I've done it by simplifying the logic. I don't propagate `blockFaulting` value anymore. Instead, I've just set it using subducting progress of the plate underneath. This makes the faults appear in succession.