### PR TITLE
Extend range of the crust age visualization

### DIFF
--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -227,7 +227,7 @@ export default class Field extends FieldBase<Field> {
   // to crust age visualization required to extend it to larger values, so we show broader range of the fresh crust.
   // TODO: rename this property? It should not break serialization as long as `.age` is not changed.
   get normalizedAge() {
-    return this.age / MATURE_CRUST_AGE;
+    return Math.min(MAX_NORMALIZED_AGE, this.age / MATURE_CRUST_AGE);
   }
 
   get rockType() {

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -118,8 +118,11 @@ export default class Field extends FieldBase<Field> {
 
     this.blockFaulting = blockFaulting;
 
-    const baseCrustThickness = crustThickness !== undefined ?
-      crustThickness : (type === "ocean" ? BASE_OCEANIC_CRUST_THICKNESS * (NEW_OCEANIC_CRUST_THICKNESS_RATIO + (1 - NEW_OCEANIC_CRUST_THICKNESS_RATIO) * this.normalizedAge) : BASE_CONTINENTAL_CRUST_THICKNESS);
+    const baseCrustThickness = crustThickness !== undefined
+      ? crustThickness
+      : (type === "ocean" ?
+        BASE_OCEANIC_CRUST_THICKNESS * (NEW_OCEANIC_CRUST_THICKNESS_RATIO + (1 - NEW_OCEANIC_CRUST_THICKNESS_RATIO) * this.normalizedAge)
+        : BASE_CONTINENTAL_CRUST_THICKNESS);
     this.crust = new Crust(type, baseCrustThickness, this.normalizedAge === 1);
 
     // Adjacent is a special type of field that only tracks noCollisionDist. Eventually this field may become a "real" field.

--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -61,7 +61,12 @@ export const TRENCH_MAX_DEPTH = 0.085;
 export const TRENCH_SLOPE = 0.5;
 
 // Max age of the field defines how fast the new oceanic crust cools down and goes from ridge elevation to its base elevation.
-export const MAX_AGE = config.oceanicRidgeWidth / c.earthRadius;
+// When `age` property reaches this value, `normalizedAge` will be equal to 1.
+export const MATURE_CRUST_AGE = config.oceanicRidgeWidth / c.earthRadius;
+// This value is used by the crust age visualization. It defines for how long the crust is considered `fresh`
+// and when it reaches the max age that equals to `PREEXISTING_CRUST_AGE`.
+export const MAX_NORMALIZED_AGE = 5;
+export const PREEXISTING_CRUST_AGE = MAX_NORMALIZED_AGE * MATURE_CRUST_AGE;
 
 // Decides how tall volcanoes become during subduction.
 const VOLCANIC_ACTIVITY_STRENGTH = 0.1;
@@ -218,8 +223,11 @@ export default class Field extends FieldBase<Field> {
     return this.absolutePos.clone().cross(this.force);
   }
 
+  // Historically this getter would return value between 0 and 1 (hence `normalized`). However, the new approach
+  // to crust age visualization required to extend it to larger values, so we show broader range of the fresh crust.
+  // TODO: rename this property? It should not break serialization as long as `.age` is not changed.
   get normalizedAge() {
-    return Math.min(1, this.age / MAX_AGE);
+    return this.age / MATURE_CRUST_AGE;
   }
 
   get rockType() {
@@ -377,7 +385,7 @@ export default class Field extends FieldBase<Field> {
 
     if (this.crust.hasOceanicRocks && this.normalizedAge < 1) {
       // Basalt and gabbro are added only at the beginning of oceanic crust lifecycle.
-      this.crust.addBasaltAndGabbro((1 - NEW_OCEANIC_CRUST_THICKNESS_RATIO) * (BASE_OCEANIC_CRUST_THICKNESS - MAX_REGULAR_SEDIMENT_THICKNESS) * ageDiff / MAX_AGE);
+      this.crust.addBasaltAndGabbro((1 - NEW_OCEANIC_CRUST_THICKNESS_RATIO) * (BASE_OCEANIC_CRUST_THICKNESS - MAX_REGULAR_SEDIMENT_THICKNESS) * ageDiff / MATURE_CRUST_AGE);
       if (this.normalizedAge > 0.7) {
         this.crust.addSediment(0.02 * timestep);
       }

--- a/js/plates-model/generate-plates.ts
+++ b/js/plates-model/generate-plates.ts
@@ -2,7 +2,7 @@ import { hsv } from "d3-hsv";
 import Sphere from "../peels/sphere";
 import config from "../config";
 import Plate from "./plate";
-import { MAX_AGE, FieldType } from "./field";
+import { PREEXISTING_CRUST_AGE, FieldType } from "./field";
 import { elevationToCrustThickness, BASE_OCEAN_ELEVATION, HIGHEST_MOUNTAIN_ELEVATION } from "./crust";
 
 type HSV = { h: number; s: number; v: number; };
@@ -35,7 +35,7 @@ export default function generatePlates(imgData: ImageData, initFunction?: ((plat
     if (plates[key] === undefined) {
       plates[key] = new Plate({ hue: color.h, density: Object.keys(plates).length });
     }
-    plates[key].addField({ id: fieldId, age: MAX_AGE, type, crustThickness: elevationToCrustThickness(elevation) });
+    plates[key].addField({ id: fieldId, age: PREEXISTING_CRUST_AGE, type, crustThickness: elevationToCrustThickness(elevation) });
   });
   Object.keys(plates).map(key => plates[key]).forEach(plate => {
     plate.updateInertiaTensor();

--- a/js/plates-model/get-cross-section.ts
+++ b/js/plates-model/get-cross-section.ts
@@ -63,6 +63,8 @@ export interface ICrossSectionPlateData {
   points: ICrossSectionPointData[];
 }
 
+export const DIV_BOUNDARY_NORMALIZED_AGE = 0.2;
+
 const SAMPLING_DIST = 5; // km
 // Affects smoothing strength.
 const SMOOTHING_PERIOD = 6;
@@ -312,7 +314,7 @@ function setupDivergentBoundaryField(divBoundaryPoint: ICrossSectionPointData, p
       ],
       lithosphereThickness: 0.2,
       subduction: 0,
-      normalizedAge: 0.2,
+      normalizedAge: DIV_BOUNDARY_NORMALIZED_AGE,
       id: -1,
       plateId: -1
     };

--- a/js/plates-view/plate-mesh.ts
+++ b/js/plates-view/plate-mesh.ts
@@ -17,6 +17,7 @@ import PlateStore from "../stores/plate-store";
 import FieldStore from "../stores/field-store";
 import { Rock } from "../plates-model/rock-properties";
 import { getRockPatternImgSrc } from "../colors/rock-colors";
+import { MAX_NORMALIZED_AGE } from "../plates-model/field";
 
 const MIN_SPEED_TO_RENDER_POLE = 0.002;
 // Render every nth velocity arrow (performance).
@@ -437,7 +438,7 @@ export default class PlateMesh {
     if (colormap === "topo" || colormap === "plate") {
       this.geoAttributes.colormapValue.setX(id, normalizeElevation(field.elevation));
     } else if (colormap === "age") {
-      this.geoAttributes.colormapValue.setX(id, field.normalizedAge);
+      this.geoAttributes.colormapValue.setX(id, field.normalizedAge / MAX_NORMALIZED_AGE);
     } else if (colormap === "rock") {
       // colormapValue will be used to pick the texture in plate-mesh-fragment.glsl.
       this.geoAttributes.patternIdx.setX(id, ROCK_PATTERN_IDX[field.rockType] || 0);

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -2,8 +2,6 @@ import * as THREE from "three";
 import config from "../config";
 import { scaleLinear } from "d3-scale";
 import { interpolateHcl } from "d3-interpolate";
-import { hsv } from "d3-hsv";
-import { rgb } from "d3-color";
 import { depthToColor, drawEarthquakeShape } from "./earthquake-helpers";
 import { drawVolcanicEruptionShape } from "./volcanic-eruption-helpers";
 import {
@@ -12,8 +10,8 @@ import {
   MAGMA_BLOB_BORDER, MAGMA_BLOB_BORDER_METAMORPHIC
 } from "../colors/cross-section-colors";
 import { getRockCanvasPattern } from "../colors/rock-colors";
-import { IEarthquake, ICrossSectionFieldData, IMagmaBlobData, IRockLayerData } from "../plates-model/get-cross-section";
-import { Metamorphism, SEA_LEVEL } from "../plates-model/crust";
+import { IEarthquake, ICrossSectionFieldData, IMagmaBlobData, IRockLayerData, DIV_BOUNDARY_NORMALIZED_AGE } from "../plates-model/get-cross-section";
+import { SEA_LEVEL } from "../plates-model/crust";
 import { Rock, rockProps } from "../plates-model/rock-properties";
 import { RockKeyLabel } from "../types";
 import { getDivergentBoundaryMagmaAnimProgress, getDivergentBoundaryMagmaFrame  } from "./magma-frames-divergent-boundary";
@@ -263,9 +261,9 @@ class CrossSectionRenderer {
         }
       }
       // New crust around divergent boundary is highlighted for a while.
-      const divergentBoundaryPosition = firstPoint.field?.normalizedAge === 0.2
+      const divergentBoundaryPosition = firstPoint.field?.normalizedAge === DIV_BOUNDARY_NORMALIZED_AGE
         ? "left"
-        : (lastPoint.field?.normalizedAge === 0.2 ? "right" : undefined);
+        : (lastPoint.field?.normalizedAge === DIV_BOUNDARY_NORMALIZED_AGE ? "right" : undefined);
 
       this.renderFreshCrustOverlay(f1, t1, tMid, cMid, c1, divergentBoundaryPosition);
       this.renderFreshCrustOverlay(f2, tMid, t2, c2, cMid, divergentBoundaryPosition);

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -283,7 +283,7 @@ class CrossSectionRenderer {
       }
       // Debug info, optional
       if (config.debugCrossSection) {
-        this.debugInfo(l1, b1, [i, f1.normalizedAge?.toFixed(2) ?? 0, f2.normalizedAge?.toFixed(2) ?? 0]);
+        this.debugInfo(l1, b1, [i, `${f1.id} (${f1.plateId})`, x1.toFixed(1) + " km"]);
       }
       if (f1.magma && f1.magma.length > 0) {
         this.drawMagma(f1.magma, f1, l1);


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180997501

This is only the beginning of the work. I've extended range of `normalizedAge` value from [0, 1] to [0, 5]. That let me easily show a wider range of crust age and it's more or less matching Michael's mocks. 
See: https://www.pivotaltracker.com/story/show/180997501/comments/230961040

`normalizedAge` is used in multiple places in the model, so I think it's important that this getter still behaves the same in [0,1] range. Multiple places in the model check if it's < 1, which seems fine here and saves us and makes implementation simpler.

A new property could also work, but it might be more confusing to have two separate concepts of age, more data to send between threads and to serialize.

I guess we could update the name of the getter. Suggestions are welcome. I haven't had a better idea, so I've left it. Maybe it's fine with the comments I've added. It's normalized up to some point. 😉 

So, the remaining work is to update colormap and deal with distinct pre-existing crust.

Also, the current age is based on traveled distance only. So, if the plates get merged together, we'll see the "fresh" crust coloring forever. I wonder if it should become dark blue / gray over time. If so, we should replace distance with passed time. In this case, it might require a new property.

I think the old age uses distance so the shape of the oceanic ridge doesn't depend on the speed of the plate. If it's based on time only, if the plate is moving slowly, the ridge will have a very gentle slope. If it's moving very fast, it'll have a very steep slope.

Old:
<img width="795" alt="Screenshot 2022-05-05 at 20 18 42" src="https://user-images.githubusercontent.com/767857/167061516-fa12e47e-330e-4fd3-b16c-6e0445102645.png">

New:
<img width="790" alt="Screenshot 2022-05-05 at 20 18 10" src="https://user-images.githubusercontent.com/767857/167061536-2a775f22-3f8f-493d-843a-9dbc34fe191a.png">

