### PR TITLE
Always include `geode` param in authored urls [#182089196]

### DIFF
--- a/js/components/authoring.tsx
+++ b/js/components/authoring.tsx
@@ -227,7 +227,8 @@ export default class Authoring extends PureComponent<IProps, IState> {
       }
       // don't include TecRocks-only options in geode urls
       if (!(this.state.geode && TECROCKS_ONLY_OPTIONS.includes(name))) {
-        if (value !== configValue) {
+        // only include values that are different than the defaults in the url
+        if (value !== configValue || name === "geode") { // always include "geode" (skip mode selector)
           if (value === true) {
             url += `&${name}`;
           } else {


### PR DESCRIPTION
PT: [[#182089196]](https://www.pivotaltracker.com/story/show/182089196)
Demo: https://tectonic-explorer.concord.org/branch/author-url/index.html?authoring