### PR TITLE
Implement new elevation (topographic) key design [#180992693]

### DIFF
--- a/css-modules/keys/elevation-descriptions.less
+++ b/css-modules/keys/elevation-descriptions.less
@@ -1,0 +1,34 @@
+.elevationDescriptions {
+  position: relative;
+  width: 96px;
+
+  .elevationDescription {
+    position: absolute;
+    margin-left: 2px;
+    width: 160px;
+    display: flex;
+    align-items: center;
+
+    .elevationDescDash {
+      margin-left: 3px;
+    }
+
+    .elevationDescText {
+      margin-left: 2px;
+      width: 70px;
+      text-align: center;
+      line-height: 1.2;
+    }
+
+    // Sea Level
+    &:nth-child(2) {
+      .elevationDescText {
+        position: absolute;
+        width: 64px;
+        left: 13px;
+        top: 1px;
+        background: white;
+      }
+    }
+  }
+}

--- a/css-modules/keys/elevation-labels.less
+++ b/css-modules/keys/elevation-labels.less
@@ -1,0 +1,13 @@
+.elevationLabels {
+  position: relative;
+  width: 70px;
+  display: flex;
+  flex-direction: column;
+  margin-left: -20px;
+
+  .elevationLabel {
+    position: absolute;
+    width: 70px;
+    text-align: right;
+  }
+}

--- a/css-modules/keys/map-type.less
+++ b/css-modules/keys/map-type.less
@@ -77,127 +77,31 @@
       display: flex;
       justify-content: center;
 
-      .elevationLabels {
-        width: 70px;
-        display: flex;
-        flex-direction: column;
-        padding-top: 14px;
-        margin-left: -20px;
-
-        .elevationLabel {
-          margin-top: 5px;
-        }
-      }
-
       .plateColorGradient {
         margin-left: 5px;
       }
-
-      .elevationDescriptions {
-        position: relative;
-        padding-top: 14px;
-        width: 96px;
-
-        .elevationDescription {
-          position: absolute;
-          margin-left: 2px;
-          width: 160px;
-          display: flex;
-          align-items: center;
-
-          .elevationDescDash {
-            margin-left: 3px;
-          }
-
-          .elevationDescText {
-            margin-left: 2px;
-            width: 70px;
-            text-align: center;
-            line-height: 1.2;
-          }
-
-          // Highest Mountains
-          &:nth-child(1) {
-            top: 12px;
-          }
-
-          // Sea Level
-          &:nth-child(2) {
-            top: 68px;
-
-            .elevationDescText {
-              position: absolute;
-              width: 64px;
-              left: 13px;
-              top: 1px;
-              background: white;
-            }
-          }
-
-          // Deepest Trenches
-          &:nth-child(3) {
-            top: 110px;
-          }
-        }
-      }
     }
   }
 
-  .keyTable {
-    color: #434343;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  &.elevationKey {
+    position: relative;
+    width: 320px;
+    height: 180px;
 
-    th {
-      font-size: 14px;
+    .elevationTitle {
       font-weight: bold;
-      margin: 5px 0 5px 0;
-      border-spacing: 10px 5px;
-      height: 25px;
-      padding-bottom: 0;
       text-align: center;
+    }
 
-      &.subheader {
-        font-size: 1.2em;
-        height: 18px;
+    .elevationColors {
+      margin-top: 4px;
+      display: flex;
+      justify-content: center;
+
+      .topographicKey {
+        padding-top: 24px;
+        margin-left: 5px;
       }
     }
-
-    tr {
-      min-height: 23px;
-    }
-  }
-
-  .colorKeyContainer {
-    text-align: right;
-  }
-
-  .canvases {
-    display: inline-block;
-  }
-
-  .topo {
-    canvas {
-      height: 80px;
-      width: 22px;
-    }
-  }
-
-  .plate, .age {
-    canvas {
-      height: 80px;
-      width: 15px;
-    }
-  }
-
-  .labels {
-    display: inline-block;
-    vertical-align: top;
-  }
-
-  p {
-    margin-left: 5px;
   }
 }

--- a/cypress/integration/basic/keysandoptions.js
+++ b/cypress/integration/basic/keysandoptions.js
@@ -24,10 +24,10 @@ describe("Keys And Options", function() {
 
   it("Map Type Tab", function() {
     BottomContainer.getTakeSample().click();
-    KeyAndOptions.getMapTypeKey().should("be.visible").should("contain", "Key: Elevation");
+    KeyAndOptions.getMapTypeKey().should("be.visible").should("contain", "Key: Topographic (Elevation)");
     KeyAndOptions.getKeyRockType().should("be.visible").get(".rock-types--title--tectonic-explorer").should("contain", "Key: Rock Type");
 
-    //verfiy different rock types displayed
+    //verify different rock types displayed
     KeyAndOptions.getRockKeyNumOption("1").get(".rock-types--headerLabel--tectonic-explorer").contains("Igneous Rocks");
 
     KeyAndOptions.getRockKeyNumOption("1").get(".rock-types--flashContainer--tectonic-explorer")

--- a/images/topographic-color-key.svg
+++ b/images/topographic-color-key.svg
@@ -1,0 +1,28 @@
+<svg width="30" height="110" viewBox="0 0 30 110" xmlns="http://www.w3.org/2000/svg">
+    <g fill="none" fill-rule="evenodd">
+        <path fill="#0B161E" d="M0 105h30v5H0z"/>
+        <path fill="#0E1D29" d="M0 100h30v5H0z"/>
+        <path fill="#0F2433" d="M0 95h30v5H0z"/>
+        <path fill="#122B3E" d="M0 90h30v5H0z"/>
+        <path fill="#15344B" d="M0 85h30v5H0z"/>
+        <path fill="#1E5073" d="M0 80h30v5H0z"/>
+        <path fill="#276C9B" d="M0 75h30v5H0z"/>
+        <path fill="#3188C3" d="M0 70h30v5H0z"/>
+        <path fill="#50A7E0" d="M0 65h30v5H0z"/>
+        <path fill="#82C9EF" d="M0 60h30v5H0z"/>
+        <path fill="#B5EBFE" d="M0 55h30v5H0z"/>
+        <path fill="#A7DFD2" d="M0 50h30v5H0z"/>
+        <path fill="#94BF8B" d="M0 45h30v5H0z"/>
+        <path fill="#A8C68F" d="M0 40h30v5H0z"/>
+        <path fill="#BDCC96" d="M0 35h30v5H0z"/>
+        <path fill="#EFEBC0" d="M0 30h30v5H0z"/>
+        <path fill="#DED6A3" d="M0 25h30v5H0z"/>
+        <path fill="#AA8753" d="M0 20h30v5H0z"/>
+        <path fill="#AC9A7C" d="M0 15h30v5H0z"/>
+        <path fill="#CAC3B8" d="M0 10h30v5H0z"/>
+        <path fill="#F5F4F2" d="M0 5h30v5H0z"/>
+        <path fill="#FFF" d="M0 0h30v5H0z"/>
+        <path stroke="#434343" d="M.5.5h29v109H.5z"/>
+        <path stroke="#FFF" stroke-dasharray="2,2" d="M2 55h26"/>
+    </g>
+</svg>

--- a/js/components/keys/elevation-descriptions.tsx
+++ b/js/components/keys/elevation-descriptions.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { keyBaseHeight } from "./key-types";
+
+import css from "../../../css-modules/keys/elevation-descriptions.less";
+
+interface IProps {
+  keyHeight: number;
+}
+
+// top values for keys with the base height
+const descriptionBaseTops = [12, 68, 110];
+
+export const ElevationDescriptions = ({ keyHeight = keyBaseHeight }: IProps) => {
+  const descriptions = ["Highest Mountains", "Sea Level", "Deepest Trenches"];
+  const diffHeight = keyHeight - keyBaseHeight;
+  const descriptionStyles = descriptionBaseTops.map((top, i) => ({
+    // distribute additional space evenly between the descriptions
+    top: top + (i - 1) * diffHeight / 2
+  }));
+  return (
+    <div className={css.elevationDescriptions}>
+      { descriptions.map((description, i) => (
+        <div className={css.elevationDescription} key={`description-${i}`} style={descriptionStyles[i]}>
+          { i !== 1 && <div className={css.elevationDescDash}>–</div> }
+          { i === 1 &&
+            // dashed line behind "Sea Level"
+            <svg className={css.elevationDescSeaLevel} >
+              <line x1="0" y1="11" x2="96" y2="11" stroke="#434343" strokeDasharray="2"/>
+            </svg> }
+          <div className={css.elevationDescText}>{ description }</div>
+        </div>)) }
+    </div>
+  );
+};

--- a/js/components/keys/elevation-key.tsx
+++ b/js/components/keys/elevation-key.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { ElevationDescriptions } from "./elevation-descriptions";
+import { ElevationLabels } from "./elevation-labels";
+import { elevationKeyHeight } from "./key-types";
+import TopographicColorKey from "../../../images/topographic-color-key.svg";
+
+import css from "../../../css-modules/keys/map-type.less";
+
+export const ElevationKey = () => {
+  return (
+    <div className={`${css.mapType} ${css.elevationKey}`} data-test="map-type-key">
+      <div className={css.elevationTitle}>Key: Topographic (Elevation)</div>
+      <div className={css.elevationColors}>
+        <ElevationLabels keyHeight={elevationKeyHeight}/>
+        <TopographicColorKey className={css.topographicKey}/>
+        <ElevationDescriptions keyHeight={elevationKeyHeight}/>
+      </div>
+    </div>
+  );
+};

--- a/js/components/keys/elevation-labels.tsx
+++ b/js/components/keys/elevation-labels.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { keyBaseHeight } from "./key-types";
+
+import css from "../../../css-modules/keys/elevation-labels.less";
+
+interface IProps {
+  keyHeight: number;
+}
+
+// top values for keys with the base height
+const labelBaseTops = [19, 43.5, 68, 92.5, 117];
+
+export const ElevationLabels = ({ keyHeight = keyBaseHeight }: IProps) => {
+  const labels = ["8,000m\u00a0–", "4,000m\u00a0–", "0m\u00a0–", "–4,000m\u00a0–", "–8,000m\u00a0–"];
+  const diffHeight = keyHeight - keyBaseHeight;
+  const labelStyles = labelBaseTops.map((top, i) => ({
+    // distribute additional space evenly between the labels
+    top: top + (i - 2) * diffHeight / 4
+  }));
+  return (
+    <div className={css.elevationLabels}>
+      { labels.map((label, i) => {
+        return <div className={css.elevationLabel} key={`label-${i}`} style={labelStyles[i]}>{ label }</div>;
+      }) }
+    </div>
+  );
+};

--- a/js/components/keys/key-types.ts
+++ b/js/components/keys/key-types.ts
@@ -1,0 +1,4 @@
+export const elevationKeyHeight = 110;
+export const plateColorKeyHeight = 100;
+// positional calculations are based on the height of the plate color gradient bar
+export const keyBaseHeight = plateColorKeyHeight;

--- a/js/components/keys/map-type.tsx
+++ b/js/components/keys/map-type.tsx
@@ -1,105 +1,25 @@
 import React from "react";
 import { inject, observer } from "mobx-react";
 import { CrustAgeKey } from "./crust-age-key";
+import { ElevationKey } from "./elevation-key";
 import { PlateColorKey } from "./plate-color-key";
-import { topoColor } from "../../colors/topographic-colors";
 import { BaseComponent, IBaseProps } from "../base";
-import { Colormap } from "../../config";
-import { RGBAFloatToCssColor } from "../../colors/utils";
-
-import css from "../../../css-modules/keys/map-type.less";
-
-function renderTopoScale(canvas: any) {
-  const width = canvas.width;
-  const height = canvas.height;
-  const ctx = canvas.getContext("2d");
-  const step = 0.01;
-  for (let i = 0; i <= 1; i += step) {
-    ctx.fillStyle = RGBAFloatToCssColor(topoColor(-1 + i * 1.5));
-    ctx.fillRect(0, (1 - i) * height * 0.5 + height * 0.5, width, height * step);
-  }
-  for (let i = 0; i <= 1; i += step) {
-    ctx.fillStyle = RGBAFloatToCssColor(topoColor(0.5 + i * 0.5));
-    ctx.fillRect(0, (1 - i) * height * 0.5, width, height * step);
-  }
-}
-
-const KEY_TITLE: Partial<Record<Colormap, string>> = {
-  topo: "Elevation"
-};
 
 interface IState {}
 
 @inject("simulationStore")
 @observer
 export class MapType extends BaseComponent<IBaseProps, IState> {
-  plateCanvas: any;
-  topoCanvas: any;
-
-  componentDidMount() {
-    this.renderCanvases();
-  }
-
-  componentDidUpdate() {
-    this.renderCanvases();
-  }
-
-  renderCanvases() {
-    const { colormap, key } = this.simulationStore;
-    if (key === true) {
-      if (colormap === "topo") {
-        renderTopoScale(this.topoCanvas);
-      }
-    }
-  }
 
   render() {
     const { colormap, model } = this.simulationStore;
-    this.plateCanvas = {};
 
     switch (colormap) {
     case "age": return <CrustAgeKey/>;
+    case "topo": return <ElevationKey/>;
     case "plate": return <PlateColorKey model={model} />;
     }
 
-    if (!KEY_TITLE[colormap]) {
-      // For example, rock key won't be displayed as it's handled by a separate component.
-      return null;
-    }
-
-    return (
-      <div className={css.mapType} data-test="map-type-key">
-        <table className={css.keyTable}>
-          <tbody className={css.colorKeyContainer} data-test="map-type-key-plates">
-            <tr>
-              <th colSpan={4}>Key: { KEY_TITLE[colormap] }</th>
-            </tr>
-            <tr>
-              <td colSpan={2}>&nbsp;</td>
-              <td>
-                <div className={css.canvases + " " + css[colormap]}>
-                  {
-                    colormap === "topo" &&
-                    <canvas ref={(c) => {
-                      this.topoCanvas = c;
-                    }} />
-                  }
-                </div>
-              </td>
-              <td>
-                <div className={css.labels}>
-                  { (colormap === "topo") &&
-                    <div>
-                      <p style={{ marginTop: 0 }}>8000m</p>
-                      <p style={{ marginTop: 20 }}>0m</p>
-                      <p style={{ marginTop: 20 }}>-8000m</p>
-                    </div> }
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    );
+    return null;
   }
 }

--- a/js/components/keys/plate-color-key.tsx
+++ b/js/components/keys/plate-color-key.tsx
@@ -1,5 +1,8 @@
 import { observer } from "mobx-react";
 import React from "react";
+import { ElevationDescriptions } from "./elevation-descriptions";
+import { ElevationLabels } from "./elevation-labels";
+import { plateColorKeyHeight } from "./key-types";
 import ModelStore from "../../stores/model-store";
 import Plate1Color from "../../../images/plate-1-color.svg";
 import Plate2Color from "../../../images/plate-2-color.svg";
@@ -28,38 +31,11 @@ export const PlateColorKey = observer(({ model }: IProps) => {
     <div className={`${css.mapType} ${css.plateColorKey}`} data-test="map-type-key">
       <div className={css.plateColorTitle}>Key: Plate Color (with elevation)</div>
       <div className={css.plateColorGradients}>
-        <ElevationLabels/>
+        <ElevationLabels keyHeight={plateColorKeyHeight}/>
         { plateColors.map((PlateColorGradient, i) => (
           <PlateColorGradient className={css.plateColorGradient} key={`key-plate-${i}`} />)) }
-        <ElevationDescriptions/>
+        <ElevationDescriptions keyHeight={plateColorKeyHeight}/>
       </div>
     </div>
   );
 });
-
-const ElevationLabels = () => {
-  const labels = ["8,000m\u00a0–", "4,000m\u00a0–", "0m\u00a0–", "–4,000m\u00a0–", "–8,000m\u00a0–"];
-  return (
-    <div className={css.elevationLabels}>
-      { labels.map((label, i) => <div className={css.elevationLabel} key={`label-${i}`}>{ label }</div>) }
-    </div>
-  );
-};
-
-const ElevationDescriptions = () => {
-  const descriptions = ["Highest Mountains", "Sea Level", "Deepest Trenches"];
-  return (
-    <div className={css.elevationDescriptions}>
-      { descriptions.map((description, i) => (
-        <div className={css.elevationDescription} key={`description-${i}`}>
-          { i !== 1 && <div className={css.elevationDescDash}>–</div> }
-          { i === 1 &&
-            // dashed line behind "Sea Level"
-            <svg className={css.elevationDescSeaLevel} >
-              <line x1="0" y1="11" x2="96" y2="11" stroke="#434343" strokeDasharray="2"/>
-            </svg> }
-          <div className={css.elevationDescText}>{ description }</div>
-        </div>)) }
-    </div>
-  );
-};


### PR DESCRIPTION
PT: [[#180992693]](https://www.pivotaltracker.com/story/show/180992693)
Demo: https://tectonic-explorer.concord.org/branch/elevation-key/index.html?rocks&preset=benchmark

Changes look more extensive than they really are due to moving `ElevationLabels` and `ElevationDescriptions` components out of the `PlateColorKey` component and into their own components since they're now shared with the new `ElevationKey` component. Since the two keys are different heights the layout code computes the vertical position of the labels in JavaScript rather than in CSS.