### PR TITLE
Fix tabs styles

### DIFF
--- a/css-modules/side-container.less
+++ b/css-modules/side-container.less
@@ -28,6 +28,8 @@
       margin: @tabListMarginTop 0 0 0;
       height: @tabListHeight;
       border-bottom: none;
+      position: relative;
+      z-index: 100; // Tab list slightly overlaps with the containers below.
     }
 
     .tab {


### PR DESCRIPTION
Before:
<img width="347" alt="Screenshot 2022-05-24 at 18 22 22" src="https://user-images.githubusercontent.com/767857/170085018-a2100c03-53a5-4f24-85f1-7bdd96f32ffc.png">
Now:
<img width="342" alt="Screenshot 2022-05-24 at 18 22 02" src="https://user-images.githubusercontent.com/767857/170085030-24e5a729-dca5-461b-a1a6-3b23b44e9419.png">

It got broken a while ago, not sure when, so fixing it before I definitely leave the project. :)

