### PR TITLE
Plate color key tweaks

### DIFF
--- a/css-modules/keys/elevation-descriptions.less
+++ b/css-modules/keys/elevation-descriptions.less
@@ -22,6 +22,8 @@
 
     // Sea Level
     &:nth-child(2) {
+      margin-left: -2px;
+
       .elevationDescText {
         position: absolute;
         width: 64px;

--- a/js/components/keys/elevation-descriptions.tsx
+++ b/js/components/keys/elevation-descriptions.tsx
@@ -12,7 +12,7 @@ interface IProps {
 const descriptionBaseTops = [12, 68, 110];
 
 export const ElevationDescriptions = ({ keyHeight = keyBaseHeight, seaLevelOffset = 0 }: IProps) => {
-  const descriptions = ["Highest Mountains", "Sea Level", "Deepest Trenches"];
+  const descriptions = ["Highest mountains", "Sea level", "Deepest trenches"];
   const diffHeight = keyHeight - keyBaseHeight;
   const descriptionStyles = descriptionBaseTops.map((top, i) => ({
     // distribute additional space evenly between the descriptions


### PR DESCRIPTION
[[#180992870]/comment](https://www.pivotaltracker.com/story/show/180992870/comments/231492751)

Fixes capitalization of elevation descriptions and adjusts the horizontal placement of the `Sea level` label.