### PR TITLE
Fix initial location of oceanic sediment

### DIFF
--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -133,7 +133,7 @@ export default class Field extends FieldBase<Field> {
       : (type === "ocean" ?
         BASE_OCEANIC_CRUST_THICKNESS * (NEW_OCEANIC_CRUST_THICKNESS_RATIO + (1 - NEW_OCEANIC_CRUST_THICKNESS_RATIO) * this.normalizedAge)
         : BASE_CONTINENTAL_CRUST_THICKNESS);
-    this.crust = new Crust(type, baseCrustThickness, this.normalizedAge === 1);
+    this.crust = new Crust(type, baseCrustThickness, this.normalizedAge === MAX_NORMALIZED_AGE);
 
     // Adjacent is a special type of field that only tracks noCollisionDist. Eventually this field may become a "real" field.
     if (adjacent) {


### PR DESCRIPTION
[#182716231]

When I was working on the new crust age visualization (see: https://github.com/concord-consortium/tectonic-explorer/commit/a32429e93c2e37cbfd738422b83695a51fd3a537), I overlooked changing === 1 to new MAX_NORMALIZED_AGE.

This caused issues well described in the PT story: https://www.pivotaltracker.com/story/show/182716231
