### PR TITLE
Magma slug in convergent boundary should be measurable with temp/pressure tool

### DIFF
--- a/js/plates-interactions/cross-section-interactions-manager.ts
+++ b/js/plates-interactions/cross-section-interactions-manager.ts
@@ -32,7 +32,7 @@ export default class CrossSectionInteractionsManager extends BaseInteractionsMan
         emitMoveEventWithOverlay: true,
         onPointerMove: ({ wall, intersection }) => {
           const intersectionData = view.getIntersectionData(wall, intersection);
-          if (intersectionData?.field) {
+          if (intersectionData?.field || intersectionData?.label) {
             const pressure = getPressure(simulationStore.model, intersectionData, intersection);
             const temperature = getTemperature(simulationStore.model, intersectionData, intersection);
             simulationStore?.setTempAndPressure(temperature, pressure);

--- a/js/plates-model/get-temp-and-pressure.ts
+++ b/js/plates-model/get-temp-and-pressure.ts
@@ -18,12 +18,15 @@ const rockBasedPressure: Partial<Record<RockKeyLabel, TempPressureValue>> = {
   "High Grade Metamorphic Rock (Continental Collision)": "High",
   "Low Grade Metamorphic Rock (Subduction Zone)": "Med",
   "Medium Grade Metamorphic Rock (Subduction Zone)": "Med",
-  "High Grade Metamorphic Rock (Subduction Zone)": "High"
+  "High Grade Metamorphic Rock (Subduction Zone)": "High",
+  "Iron-rich Magma": "High"
 };
 
 export const getPressure = (model: ModelStore, intersectionData: IIntersectionData, intersectionCoords: THREE.Vector2): TempPressureValue => {
   const { field } = intersectionData;
-  if (!field) return null;
+  if (!field) {
+    return rockBasedPressure[intersectionData.label] || null;
+  }
   const rockBasedResult: TempPressureValue = rockBasedPressure[intersectionData.label] || null;
   let depthBasedResult: TempPressureValue = null;
 
@@ -81,7 +84,9 @@ const rockBasedTemperature: Partial<Record<RockKeyLabel, TempPressureValue>> = {
 
 export const getTemperature = (model: ModelStore, intersectionData: IIntersectionData, intersectionCoords: THREE.Vector2): TempPressureValue => {
   const { field } = intersectionData;
-  if (!field) return null;
+  if (!field) {
+    return rockBasedTemperature[intersectionData.label] || null;
+  }
 
   const rockBasedResult: TempPressureValue = rockBasedTemperature[intersectionData.label] || null;
 


### PR DESCRIPTION
[[#182716184]](https://www.pivotaltracker.com/story/show/182716184)

Magma slug in convergent boundary isn't related to one field - it uses averaged position of multiple fields. That's why interaction doesn't return a single field object. But it returns rock type label. So, this PR updates the Measure Pressure/Temp tool to handle a case when only the rock label is available.