### PR TITLE
Fix black column at boundary during continental divergence

### DIFF
--- a/js/colors/rock-colors.ts
+++ b/js/colors/rock-colors.ts
@@ -93,6 +93,7 @@ export const getRockCanvasPattern = (ctx: CanvasRenderingContext2D, rock: Patter
 };
 
 export const getRockCanvasPatternGivenNormalizedAge = (ctx: CanvasRenderingContext2D, rock: PatternName, normalizedAge: number) => {
+  // #333 is a good base for red overlay rendered around **oceanic** divergent boundaries.
   return normalizedAge < 0.8 ? "#333" : getRockCanvasPattern(ctx, rock);
 };
 


### PR DESCRIPTION
[[#182974865]](https://www.pivotaltracker.com/story/show/182974865)

The problem was caused by the divergent boundary field that didn't specify normalized age. So, late it was assumed to be 0 and this was causing `getRockCanvasPatternGivenNormalizedAge` function to return `#333` colo. This color should be only used for the oceanic divergent boundary as a base for the red overlay.