### PR TITLE
Reduce subduction magma slug width

### DIFF
--- a/js/config.ts
+++ b/js/config.ts
@@ -106,7 +106,7 @@ const DEFAULT_CONFIG = {
   crossSectionPxPerKm: 0.2, // px per km
   // Default range of elevation is [0, 1] (the deepest trench, the highest mountain). However subducting plates go
   // deeper and this variable sets the proportion between this depth and normal topography.
-  subductionMinElevation: -3.3,
+  subductionMinElevation: -4,
   oceanicRidgeElevation: 0.4,
   oceanicRidgeWidth: 650, // km
   // Width of the area around continent which acts as it's bumper / buffer. When this area is about to subduct,
@@ -138,7 +138,7 @@ const DEFAULT_CONFIG = {
   // Subduction progress range for which magma blobs are generated. 0 is plate boundary, 1 is where subducting plate disappears.
   magmaRange: [0.4, 0.5],
   // Width scale of the magma slug rendered in the subduction area. 1 is the default width.
-  subductionMagmaSlugWidth: 1,
+  subductionMagmaSlugWidth: 0.6,
   // Length of force vector applied in Planet Wizard in the boundary selection step.
   userForce: 10,
   // Width of the continental shelf of user-drawn continents.

--- a/js/config.ts
+++ b/js/config.ts
@@ -137,6 +137,8 @@ const DEFAULT_CONFIG = {
   magmaProbability: 3,
   // Subduction progress range for which magma blobs are generated. 0 is plate boundary, 1 is where subducting plate disappears.
   magmaRange: [0.4, 0.5],
+  // Width scale of the magma slug rendered in the subduction area. 1 is the default width.
+  subductionMagmaSlugWidth: 1,
   // Length of force vector applied in Planet Wizard in the boundary selection step.
   userForce: 10,
   // Width of the continental shelf of user-drawn continents.

--- a/js/plates-view/render-cross-section.ts
+++ b/js/plates-view/render-cross-section.ts
@@ -666,7 +666,7 @@ class CrossSectionRenderer {
     const nativeWidth = 189;
     const nativeHeight = 70;
     const scale = 0.7;
-    const scaledWidth = scale * nativeWidth;
+    const scaledWidth = scale * nativeWidth * config.subductionMagmaSlugWidth;
     const scaledHeight = scale * nativeHeight;
     const scaledLeft = scaleX(avgLocation.x) - 0.5 * scaledWidth;
     const scaledTop = scaleY(avgLocation.y) - 0.5 * scaledHeight;
@@ -678,6 +678,11 @@ class CrossSectionRenderer {
     ctx.beginPath();
     ctx.ellipse(scaleX(avgLocation.x), scaleY(avgLocation.y), 0.45 * scaledWidth, 0.4 * scaledHeight,
       2 * Math.PI, 0, 2 * Math.PI);
+
+    // uncomment these lines to visualize/debug the hit-testing shape
+    // ctx.lineWidth = 1;
+    // ctx.strokeStyle = "black";
+    // ctx.stroke();
 
     if (this.testPoint && ctx.isPointInPath(this.testPoint.x, this.testPoint.y)) {
       this.intersection = { label: "Iron-rich Magma" };


### PR DESCRIPTION
The issue is well described in the PT story: https://www.pivotaltracker.com/story/show/182716121

This PR adds two params that will make the slug slightly smaller and make subduction plate subduct steeper (only visually) to avoid overlap of the subducting plate and the magma slug.