### PR TITLE
Fix earthquakes rendering

### DIFF
--- a/js/plates-view/temporal-event-fragment.glsl
+++ b/js/plates-view/temporal-event-fragment.glsl
@@ -5,5 +5,5 @@ varying vec2 vUv;
 
 void main() {
     gl_FragColor = vColor * texture2D(textureUniform, vUv);
-    if (gl_FragColor.a < ALPHATEST) discard;
+    if (gl_FragColor.a < 0.5) discard;
 }

--- a/js/plates-view/temporal-events.ts
+++ b/js/plates-view/temporal-events.ts
@@ -86,14 +86,12 @@ export default class TemporalEvents {
         uniforms: { textureUniform: { value: this.texture } },
         vertexShader,
         fragmentShader,
-        transparent: true,
-        alphaTest: 0.5
+        transparent: true
       });
     } else {
       this.material = new THREE.MeshBasicMaterial({
         map: this.texture,
-        transparent: true,
-        alphaTest: 0.5
+        transparent: true
       });
     }
 


### PR DESCRIPTION
[[#183487545]](https://www.pivotaltracker.com/n/projects/2441249/stories/183487545)

This PR fixes an issue most likely caused by the THREE.JS version upgrade. ALPHATEST uniform is no longer available. I've tried to use `alphaTest` that seemed to be the right name based on the source code, but it still didn't work. It's not really critical, so I just hardcoded 0.5 (we could also not discard these pixels and nothing bad would happen).