### PR TITLE
183681490 popup

### DIFF
--- a/css-modules/boundary-config-dialog.less
+++ b/css-modules/boundary-config-dialog.less
@@ -1,37 +1,6 @@
 .boundaryConfigDialog {
-
-  :global(.MuiDialogTitle-root) {
-    font-size: 14px;
-    font-weight: bold;
-    padding: 5px;
-    text-align: center;
-
-    // close-icon
-    svg {
-      float: right;
-      cursor: pointer;
-      path:nth-child(2) {
-        fill: #777777;
-
-        &:hover {
-          fill: #bebebe;
-        }
-      }
-    }
-  }
-
-  :global(.MuiBackdrop-root) {
-    background-color: transparent;
-  }
-
-  .dividerLine {
-    width: 197px;
-    margin: -4px 1px 0 9px;
-    border: solid 1px #979797;
-  }
-
   :global(.MuiDialogActions-root) {
-    padding: 5px;
+    padding: 0;
   }
 
   .boundaryOption {

--- a/css-modules/draggable-dialog.less
+++ b/css-modules/draggable-dialog.less
@@ -69,6 +69,7 @@
   .dividerLine {
     width: calc(100% - @padding);
     border: solid 1px #979797;
+    margin-bottom: 5px;
   }
 
   :global(.MuiDialogActions-root) {

--- a/css-modules/draggable-dialog.less
+++ b/css-modules/draggable-dialog.less
@@ -1,0 +1,77 @@
+.draggableDialog {
+  @padding: 5px;
+
+  &.horizontalCenter {
+    :global(.MuiDialog-container) {
+      justify-content: center;
+    }
+  }
+  &.horizontalLeft {
+    :global(.MuiDialog-container) {
+      justify-content: flex-start;
+    }
+  }
+  &.horizontalRight {
+    :global(.MuiDialog-container) {
+      justify-content: flex-end;
+    }
+  }
+  &.verticalCenter {
+    :global(.MuiDialog-container) {
+      align-items: center;
+    }
+  }
+  &.verticalTop {
+    :global(.MuiDialog-container) {
+      align-items: flex-start;
+    }
+  }
+  &.verticalBottom {
+    :global(.MuiDialog-container) {
+      align-items: flex-end;
+    }
+  }
+
+  :global(.MuiPaper-root) {
+    padding: @padding;
+    font-size: 14px;
+  }
+
+  :global(.MuiDialogTitle-root) {
+    font-size: 14px;
+    font-weight: bold;
+    text-align: center;
+    padding: 0;
+
+    .closeIcon {
+      float: right;
+      height: 24px;
+      cursor: pointer;
+      svg {
+        path:nth-child(2) {
+          fill: #777777;
+        }
+      }
+      &:hover {
+        svg {
+          path:nth-child(2) {
+            fill: #bebebe;
+          }
+        }
+      }
+    }
+  }
+
+  :global(.MuiBackdrop-root) {
+    background-color: transparent;
+  }
+
+  .dividerLine {
+    width: calc(100% - @padding);
+    border: solid 1px #979797;
+  }
+
+  :global(.MuiDialogActions-root) {
+    padding: @padding;
+  }
+}

--- a/css-modules/relative-motion-stopped-dialog.less
+++ b/css-modules/relative-motion-stopped-dialog.less
@@ -1,0 +1,5 @@
+.relativeMotionStoppedDialogContent {
+  width: 395px;
+  text-align: center;
+  padding: 5px;
+}

--- a/js/components/bottom-panel.tsx
+++ b/js/components/bottom-panel.tsx
@@ -131,7 +131,7 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
       showDrawCrossSectionButton, showTempPressureTool, showTakeSampleButton, showEarthquakesSwitch, showVolcanoesSwitch
     } = config;
     const { interaction, colormap, showCrossSectionView } = this.simulationStore;
-    const { reload, restoreSnapshot, restoreInitialSnapshot, stepForward } = this.simulationStore;
+    const { reload, restoreSnapshot, restoreInitialSnapshot, stepForward, simulationDisabled } = this.simulationStore;
     const options = this.options;
     const isDrawingCrossSection = interaction === "crossSection";
     const isMeasuringTempPressure = interaction === "measureTempPressure";
@@ -163,8 +163,8 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
               { config.planetWizard && <ReloadButton onClick={reload} data-test="reload-button" /> }
               <RestartButton disabled={!options.snapshotAvailable} onClick={restoreInitialSnapshot} data-test="restart-button" />
               <StepBackButton disabled={!options.snapshotAvailable} onClick={restoreSnapshot} data-test="step-back-button" />
-              <PlayPauseButton isPlaying={options.playing} onClick={this.togglePlayPause} data-test="playPause-button" />
-              <StepForwardButton disabled={options.playing} onClick={stepForward} data-test="step-forward-button" />
+              <PlayPauseButton disabled={simulationDisabled} isPlaying={options.playing} onClick={this.togglePlayPause} data-test="playPause-button" />
+              <StepForwardButton disabled={simulationDisabled || options.playing} onClick={stepForward} data-test="step-forward-button" />
             </div>
           </ControlGroup>
           { !config.geode && (showTempPressureTool || showTakeSampleButton) &&

--- a/js/components/boundary-config-dialog.tsx
+++ b/js/components/boundary-config-dialog.tsx
@@ -1,14 +1,10 @@
 import { observer } from "mobx-react";
 import * as React from "react";
-import Draggable from "react-draggable";
-import Dialog from "@mui/material/Dialog";
+import { DraggableDialog } from "./draggable-dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContentText from "@mui/material/DialogContentText";
-import DialogTitle from "@mui/material/DialogTitle";
-import Paper, { PaperProps } from "@mui/material/Paper";
 import { BoundaryOrientation, BoundaryType, IBoundaryInfo, IEventCoords } from "../types";
 import { plateHues } from "../plates-model/plate";
-import CloseIcon from "../../images/rock-key/svg/close-icon.svg";
 import BoundarySvg from "../../images/boundary.svg";
 import PlateArrow from "../../images/plate-arrow.svg";
 
@@ -23,38 +19,20 @@ interface IProps {
 }
 // patterned after https://mui.com/components/dialogs/#draggable-dialog
 const BoundaryConfigDialog = ({ boundary, offset, getPlateHue, onAssign, onClose }: IProps) => {
-
-  function PaperComponent(props: PaperProps) {
-    return (
-      <Draggable
-        defaultPosition={offset}
-        bounds=".planet-wizard"
-        handle="#draggable-dialog-title"
-        cancel={'[class*="MuiDialogContent-root"]'}
-      >
-        <Paper {...props} />
-      </Draggable>
-    );
-  }
-
   return (boundary &&
-    <Dialog
-      className={css.boundaryConfigDialog}
-      open={!!boundary}
+    <DraggableDialog
+      offset={offset}
       onClose={onClose}
-      PaperComponent={PaperComponent}
-      aria-labelledby="draggable-dialog-title"
+      backdrop={false}
+      title="Plate Boundary Type"
     >
-      <DialogTitle style={{ cursor: "move" }} id="draggable-dialog-title">
-        Plate Boundary Type
-        <CloseIcon onClick={onClose} />
-      </DialogTitle>
-      <div className={css.dividerLine} />
-      <DialogActions>
-        <BoundaryOption boundary={boundary} type="convergent" getPlateHue={getPlateHue} onAssign={onAssign}/>
-        <BoundaryOption boundary={boundary} type="divergent" getPlateHue={getPlateHue} onAssign={onAssign}/>
-      </DialogActions>
-    </Dialog>
+      <div className={css.boundaryConfigDialog}>
+        <DialogActions>
+          <BoundaryOption boundary={boundary} type="convergent" getPlateHue={getPlateHue} onAssign={onAssign}/>
+          <BoundaryOption boundary={boundary} type="divergent" getPlateHue={getPlateHue} onAssign={onAssign}/>
+        </DialogActions>
+      </div>
+    </DraggableDialog>
   );
 };
 export default BoundaryConfigDialog;

--- a/js/components/draggable-dialog.tsx
+++ b/js/components/draggable-dialog.tsx
@@ -36,7 +36,7 @@ interface IProps {
 }
 
 // patterned after https://mui.com/components/dialogs/#draggable-dialog
-export const DraggableDialog: React.FC<IProps> = ({ backdrop, onClose, offset, initialPosition, children }) => {
+export const DraggableDialog: React.FC<IProps> = ({ backdrop, onClose, title, offset, initialPosition, children }) => {
   function PaperComponent(props: PaperProps) {
     return (
       <Draggable
@@ -63,7 +63,7 @@ export const DraggableDialog: React.FC<IProps> = ({ backdrop, onClose, offset, i
       aria-labelledby="draggable-dialog-title"
     >
       <DialogTitle style={{ cursor: "move" }} id="draggable-dialog-title">
-        Model Stopped
+        { title }
         <div className={css.closeIcon} onClick={onClose}><CloseIcon /></div>
       </DialogTitle>
       <div className={css.dividerLine} />

--- a/js/components/draggable-dialog.tsx
+++ b/js/components/draggable-dialog.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import classNames from "classnames";
+import Draggable from "react-draggable";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import Paper, { PaperProps } from "@mui/material/Paper";
+import CloseIcon from "../../images/rock-key/svg/close-icon.svg";
+
+import css from "../../css-modules/draggable-dialog.less";
+
+const hideBackdropProps = {
+  disableEnforceFocus: true,
+  style: { pointerEvents: "none" as const },
+  PaperProps: { style: { pointerEvents: "auto" as const } }
+};
+
+const horizontalPositionClassName = {
+  center: "horizontalCenter",
+  left: "horizontalLeft",
+  right: "horizontalRight"
+};
+
+const verticalPositionClassName = {
+  center: "verticalCenter",
+  top: "verticalTop",
+  bottom: "verticalBottom"
+};
+
+interface IProps {
+  onClose: () => void;
+  backdrop: boolean;
+  title: string;
+  initialPosition?: { horizontal: "center" | "left" | "right", vertical: "center" | "top" | "bottom" },
+  offset?: { x: number, y: number },
+  children?: React.ReactNode;
+}
+
+// patterned after https://mui.com/components/dialogs/#draggable-dialog
+export const DraggableDialog: React.FC<IProps> = ({ backdrop, onClose, offset, initialPosition, children }) => {
+  function PaperComponent(props: PaperProps) {
+    return (
+      <Draggable
+        defaultPosition={offset}
+        handle="#draggable-dialog-title"
+        bounds="#app"
+        cancel={'[class*="MuiDialogContent-root"]'}
+      >
+        <Paper {...props} />
+      </Draggable>
+    );
+  }
+
+  const vertClassName = verticalPositionClassName[initialPosition?.vertical || "center"];
+  const horClassName = horizontalPositionClassName[initialPosition?.horizontal || "center"];
+
+  return (
+    <Dialog
+      {...(backdrop ? {} : hideBackdropProps)}
+      className={classNames(css.draggableDialog, css[vertClassName], css[horClassName])}
+      open={true}
+      onClose={onClose}
+      PaperComponent={PaperComponent}
+      aria-labelledby="draggable-dialog-title"
+    >
+      <DialogTitle style={{ cursor: "move" }} id="draggable-dialog-title">
+        Model Stopped
+        <div className={css.closeIcon} onClick={onClose}><CloseIcon /></div>
+      </DialogTitle>
+      <div className={css.dividerLine} />
+      { children }
+    </Dialog>
+  );
+};

--- a/js/components/planet-wizard.tsx
+++ b/js/components/planet-wizard.tsx
@@ -142,6 +142,8 @@ export default class PlanetWizard extends BaseComponent<IProps, IState> {
     } else if (stepName === undefined) {
       this.endPlanetWizard();
     }
+    // This will close the boundary type dialog. It should always happen when user clicks next or previous button.
+    this.simulationStore.clearSelectedBoundary();
   }
 
   handleNextButtonClick() {

--- a/js/components/relative-motion-stopped-dialog.tsx
+++ b/js/components/relative-motion-stopped-dialog.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { DraggableDialog } from "./draggable-dialog";
+
+import css from "../../css-modules/relative-motion-stopped-dialog.less";
+
+interface IProps {
+  onClose: () => void;
+}
+
+// patterned after https://mui.com/components/dialogs/#draggable-dialog
+export const RelativeMotionStoppedDialog = ({ onClose }: IProps) => {
+  return (
+    <DraggableDialog
+      title="Model Stopped"
+      onClose={onClose}
+      backdrop={false}
+      initialPosition={{ vertical: "center", horizontal: "left" }}
+    >
+      <div className={css.relativeMotionStoppedDialogContent}>
+        <p> All tectonic plate interactions have reached their endpoint.<br/>No more plate movement is possible.</p>
+        <br/>
+        <p>Use the buttons in the toolbar to continue to explore this model or click <b>Reset Plates</b> to design a new model.</p>
+      </div>
+    </DraggableDialog>
+  );
+};

--- a/js/components/simulation.tsx
+++ b/js/components/simulation.tsx
@@ -15,6 +15,7 @@ import { BaseComponent, IBaseProps } from "./base";
 import { BoundaryType } from "../types";
 import { SideContainer } from "./side-container";
 import { TempPressureOverlay } from "./temp-pressure-overlay";
+import { RelativeMotionStoppedDialog } from "./relative-motion-stopped-dialog";
 
 import "../../css/simulation.less";
 import "../../css/react-toolbox-theme.less";
@@ -62,6 +63,7 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
         dialogOffset.y = Math.max(dialogOffset.y, topBarHeight - (bounds.height - dialogSize.height) / 2);
       }
     }
+    console.log(dialogOffset);
     return dialogOffset;
   }
 
@@ -70,16 +72,20 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
     return plate?.hue;
   };
 
-  handleAssign = (type: BoundaryType) => {
+  handleBoundaryAssign = (type: BoundaryType) => {
     this.simulationStore.setSelectedBoundaryType(type);
   };
 
-  handleClose = () => {
+  handleBoundaryDialogClose = () => {
     this.simulationStore.clearSelectedBoundary();
   };
 
+  handleRelativeMotionDialogClose = () => {
+    this.simulationStore.closeRelativeMotionDialog();
+  };
+
   render() {
-    const { planetWizard, modelState, savingModel, selectedBoundary, interaction } = this.simulationStore;
+    const { planetWizard, modelState, savingModel, selectedBoundary, interaction, relativeMotionStoppedDialogVisible } = this.simulationStore;
     const isMeasuringTempPressure = interaction === "measureTempPressure";
     return (
       <div className={APP_CLASS_NAME} ref={this.appRef} >
@@ -114,8 +120,12 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
           selectedBoundary &&
           <BoundaryConfigDialog
             boundary={selectedBoundary} offset={this.getDialogOffset()} getPlateHue={this.getPlateHue}
-            onAssign={this.handleAssign} onClose={this.handleClose}
+            onAssign={this.handleBoundaryAssign} onClose={this.handleBoundaryDialogClose}
           />
+        }
+        {
+          relativeMotionStoppedDialogVisible &&
+          <RelativeMotionStoppedDialog onClose={this.handleRelativeMotionDialogClose} />
         }
       </div>
     );

--- a/js/components/simulation.tsx
+++ b/js/components/simulation.tsx
@@ -63,7 +63,6 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
         dialogOffset.y = Math.max(dialogOffset.y, topBarHeight - (bounds.height - dialogSize.height) / 2);
       }
     }
-    console.log(dialogOffset);
     return dialogOffset;
   }
 

--- a/js/config.ts
+++ b/js/config.ts
@@ -114,7 +114,7 @@ const DEFAULT_CONFIG = {
   continentBufferWidth: 1000,
   // Keeps model running. When all the plates reach the point when they move in the same direction, with the same speed,
   // model will add some random forces and divide big plates (see minSizeRatioForDivision).
-  enforceRelativeMotion: true,
+  enforceRelativeMotion: false,
   // When two plates have almost identical angular velocity, they'll be merged into single plate.
   mergePlates: false,
   // When two plates have almost identical angular velocity, they'll be grouped together and behave like one rigid object.

--- a/js/plates-model/model-output.ts
+++ b/js/plates-model/model-output.ts
@@ -49,6 +49,7 @@ export interface IModelOutput {
   time: number;
   fieldMarkers: THREE.Vector3[];
   plates: IPlateOutput[];
+  relativeMotionStopped: boolean;
   crossSection?: ICrossSectionOutput;
   debugMarker?: THREE.Vector3;
 }
@@ -178,7 +179,7 @@ let prevPlatesIds = "";
 
 export default function modelOutput(model: Model | null, props: IWorkerProps | null = null, forcedUpdate = false): IModelOutput {
   if (!model) {
-    return { stepIdx: 0, time: 0, plates: [], fieldMarkers: [] };
+    return { stepIdx: 0, time: 0, plates: [], fieldMarkers: [], relativeMotionStopped: false };
   }
 
   // When some plates are added or removed, it's very likely all the fields should be updated.
@@ -194,7 +195,8 @@ export default function modelOutput(model: Model | null, props: IWorkerProps | n
     time: model.time,
     debugMarker,
     fieldMarkers: [],
-    plates: model.plates.map((plate: Plate) => plateOutput(plate, props, model.stepIdx, forcedUpdate))
+    plates: model.plates.map((plate: Plate) => plateOutput(plate, props, model.stepIdx, forcedUpdate)),
+    relativeMotionStopped: model.relativeMotionStopped
   };
   if (props?.crossSectionPoint1 && props.crossSectionPoint2 && props.crossSectionPoint3 &&  props.crossSectionPoint4 &&
     props.showCrossSectionView && (forcedUpdate || shouldUpdate("crossSection", model.stepIdx))) {

--- a/js/plates-model/model-worker.ts
+++ b/js/plates-model/model-worker.ts
@@ -40,7 +40,7 @@ interface ISetPlateProps { type: "setPlateProps"; props: { id: number, visible?:
 // Messages sent by worker:
 export type ModelWorkerMsg = IOutputMsg | ISavedModelMsg | IFieldInfoResponseMsg;
 
-interface ISavedModelMsg { type: "savedModel"; data: { savedModel: string; } }
+interface ISavedModelMsg { type: "savedModel"; data: string; }
 interface IOutputMsg { type: "output"; data: IModelOutput }
 interface IFieldInfoResponseMsg { type: "fieldInfo"; requestId: number; response: ISerializedField; }
 
@@ -216,7 +216,7 @@ self.onmessage = function modelWorkerMsgHandler(event: { data: IncomingModelWork
     }
   } else if (data.type === "saveModel") {
     // Stringify model as it seems to greatly improve overall performance of saving (together with Firebase saving).
-    self.postMessage({ type: "savedModel", data: { savedModel: JSON.stringify(model?.serialize()) } });
+    self.postMessage({ type: "savedModel", data: JSON.stringify(model?.serialize()) });
   } else if (data.type === "markField") {
     const pos = (new THREE.Vector3()).copy(data.props.position as THREE.Vector3);
     const field = model?.topFieldAt(pos, { visibleOnly: true });

--- a/js/plates-model/model.ts
+++ b/js/plates-model/model.ts
@@ -241,7 +241,9 @@ export default class Model {
     this.forEachPlate((plate: Plate) => {
       this.forEachPlate((otherPlate: Plate) => {
         if (plate.id < otherPlate.id) {
-          sum += plate.angularVelocity.clone().sub(otherPlate.angularVelocity).length();
+          if (!plate.mergedWith(otherPlate)) {
+            sum += plate.angularVelocity.clone().sub(otherPlate.angularVelocity).length();
+          }
         }
       });
     });
@@ -276,7 +278,10 @@ export default class Model {
 
     if (this.relativeMotion < MIN_RELATIVE_MOTION) {
       this.lowRelativeMotionStepsCount += 1;
+    } else {
+      this.lowRelativeMotionStepsCount = 0;
     }
+
     if (this.kineticEnergy > 500) {
       this._diverged = true;
       throw new Error("model has diverged!");

--- a/js/plates-model/model.ts
+++ b/js/plates-model/model.ts
@@ -20,8 +20,11 @@ const MAX_PLATE_SPEED = 0.04;
 // How many steps between plate centers are recalculated.
 const CENTER_UPDATE_INTERVAL = 15;
 
-const MIN_RELATIVE_MOTION = 0.01;
+const MIN_RELATIVE_MOTION = 0.005;
 const MIN_RELATIVE_MOTION_TO_MERGE_PLATES = 0.001;
+// How many steps it takes to assume that relative motion has stopped. In practice, larger value will delay
+// stopping the model and displaying a dialog to user.
+const MIN_RELATIVE_MOTION_STEPS_COUNT = 100;
 
 function sortByDensityAsc(plateA: Plate, plateB: Plate) {
   return plateA.density - plateB.density;
@@ -34,6 +37,7 @@ export interface ISerializedModel {
   seedrandomState: any;
   plates: ISerializedPlate[];
   nextPlateId: number;
+  lowRelativeMotionStepsCount: number;
 }
 
 export default class Model {
@@ -43,6 +47,7 @@ export default class Model {
   plates: Plate[];
   nextPlateId = 0;
   _diverged: boolean;
+  lowRelativeMotionStepsCount: number;
 
   constructor(imgData: ImageData | null, initFunction?: ((plates: Record<number, Plate>) => void) | null, seedrandomState?: any) {
     if (config.deterministic && seedrandomState) {
@@ -53,6 +58,7 @@ export default class Model {
     this.time = 0;
     this.stepIdx = 0;
     this.lastPlateDivisionOrMerge = 0;
+    this.lowRelativeMotionStepsCount = 0;
     this.plates = [];
     if (imgData) {
       // It's very important to keep plates sorted, so if some new plates will be added to this list,
@@ -71,7 +77,8 @@ export default class Model {
       lastPlateDivisionOrMerge: this.lastPlateDivisionOrMerge,
       seedrandomState: seedrandom.getState(),
       plates: this.plates.map((plate: Plate) => plate.serialize()),
-      nextPlateId: this.nextPlateId
+      nextPlateId: this.nextPlateId,
+      lowRelativeMotionStepsCount: this.lowRelativeMotionStepsCount
     };
   }
 
@@ -98,6 +105,7 @@ export default class Model {
       }
     });
     model.nextPlateId = props.nextPlateId || Math.max(...model.plates.map(p => p.id)) + 1;
+    model.lowRelativeMotionStepsCount = props.lowRelativeMotionStepsCount;
     model.calculateDynamicProperties(false);
     return model;
   }
@@ -229,16 +237,19 @@ export default class Model {
   }
 
   get relativeMotion() {
-    const sum = new THREE.Vector3();
+    let sum = 0;
     this.forEachPlate((plate: Plate) => {
       this.forEachPlate((otherPlate: Plate) => {
         if (plate.id < otherPlate.id) {
-          const diff = plate.angularVelocity.clone().sub(otherPlate.angularVelocity);
-          sum.add(diff);
+          sum += plate.angularVelocity.clone().sub(otherPlate.angularVelocity).length();
         }
       });
     });
-    return sum.length();
+    return sum;
+  }
+
+  get relativeMotionStopped() {
+    return this.lowRelativeMotionStepsCount >= MIN_RELATIVE_MOTION_STEPS_COUNT;
   }
 
   step(timestep: number) {
@@ -262,9 +273,13 @@ export default class Model {
     // Detect collisions, update geological processes, add new fields and remove unnecessary ones.
     this.simulatePlatesInteractions(timestep, this.stepIdx);
     this.calculateDynamicProperties(true);
+
+    if (this.relativeMotion < MIN_RELATIVE_MOTION) {
+      this.lowRelativeMotionStepsCount += 1;
+    }
     if (this.kineticEnergy > 500) {
-      window.alert("Model has diverged, time: " + this.time);
       this._diverged = true;
+      throw new Error("model has diverged!");
     }
   }
 

--- a/js/stores/model-store.ts
+++ b/js/stores/model-store.ts
@@ -9,6 +9,7 @@ export default class ModelStore {
   @observable time = 0;
   @observable platesMap = new Map<number, PlateStore>();
   @observable fieldMarkers: IVector3[] = [];
+  @observable relativeMotionStopped = false;
 
   constructor() {
     makeObservable(this);
@@ -46,6 +47,8 @@ export default class ModelStore {
     this.stepIdx = data.stepIdx;
     this.time = data.time;
     this.fieldMarkers = data.fieldMarkers;
+    this.relativeMotionStopped = data.relativeMotionStopped;
+
     const platePresent: Record<string, boolean> = {};
     data.plates.forEach((plateData: IPlateOutput) => {
       platePresent[plateData.id] = true;

--- a/js/worker-controller.ts
+++ b/js/worker-controller.ts
@@ -3,7 +3,7 @@ import { IncomingModelWorkerMsg, isResponseMsg, ModelWorkerMsg } from "./plates-
 import * as THREE from "three";
 import { ISerializedField } from "./plates-model/field";
 
-export type EventName = "output" | "savedModel";
+export type EventName = ModelWorkerMsg["type"];
 export type ResponseHandler = (response: any) => void;
 
 let _requestId = 0;
@@ -30,8 +30,9 @@ class WorkerController {
           this.postQueuedModelMessages();
         }
         this.emit("output", data.data);
-      } else if (data.type === "savedModel") {
-        this.emit("savedModel", data.data.savedModel);
+      } else {
+        // Other messages don't require any special handling.
+        this.emit(data.type, (data as any).data);
       }
     });
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183681490

I think the PT story description provides a good context.

It's an example of a change where I had to modify the code ran in the web worker and then send the new property to the UI thread. See model-store.ts and `relativeMotionStopped`. If that's not very clear, we could meet tomorrow and we can review that in 5-10 minutes on Zoom. Another option would be to send a postMessage when the model is stopped, but I thought that using a property might be easier/cleaner. I'd probably try to limit the number of postMessages traveling back and forth, as it's more difficult to follow for me.

The new dialog is based on `DraggableDialog`. I've extracted it from the existing dialog used to configure the boundary type.
