### PR TITLE
Update styles of earthquakes caveat notice to avoid conflicts with cross section buttons

### DIFF
--- a/css-modules/caveat-notice.less
+++ b/css-modules/caveat-notice.less
@@ -1,9 +1,13 @@
 .caveat {
+  // pointer-events: none is set to avoid blocking some important buttons that might collide with this message container.
+  // See: https://www.pivotaltracker.com/story/show/183763407
+  pointer-events: none;
   color: #eeeeee;
   position: absolute;
-  left: 0px;
-  top: 100px;
-  width: 140px;
+  left: 3px;
+  top: 75px;
+  width: 230px;
+  text-align: justify;
   z-index: 1;
   padding-left: 10px;
   font-weight: 200;


### PR DESCRIPTION
[[#183763407]](https://www.pivotaltracker.com/story/show/183763407)

I think the issue was caused by the caveat notice:
<img width="790" alt="issue" src="https://user-images.githubusercontent.com/767857/203832488-32b19e47-6a21-44f5-ab0a-346108494189.png">
Even if it's invisible, it's container was in the DOM. So, the main fix was to add `pointer-events: none` not to block the buttons that it overlaps.

Also, I've slightly updated styles to make it less likely to overlap the cross-section. Before:
<img width="1076" alt="before" src="https://user-images.githubusercontent.com/767857/203832699-b0c8f568-e91f-4191-b6f2-51702ea2781a.png">
After:
<img width="1077" alt="after" src="https://user-images.githubusercontent.com/767857/203832714-97f71dee-579b-4f69-a3b2-97226dfe0e8c.png">

