### PR TITLE
Fix boundary highlighting

### DIFF
--- a/js/components/planet-view.tsx
+++ b/js/components/planet-view.tsx
@@ -113,6 +113,11 @@ export default class PlanetView extends BaseComponent<IBaseProps, IState> {
       simulationStore?.markIslands();
     });
     this.interactions.on("highlightBoundarySegment", ({ globePosition }: IPlanetClickData) => {
+      if (simulationStore?.selectedBoundary) {
+        // It means that boundary is currently selected and boundary type dialog visible.
+        // Do not highlight any other boundary.
+        return;
+      }
       if (globePosition) {
         simulationStore?.highlightBoundarySegment(globePosition);
       } else {


### PR DESCRIPTION
[#183681490]

This PR ensures that when you are selecting boundary type (Planet Wizard, 2nd step), the model won't highlight any other boundary segment.