### PR TITLE
Update model to avoid low elevation areas trapped between mountains

### DIFF
--- a/js/plates-model/field.ts
+++ b/js/plates-model/field.ts
@@ -255,7 +255,7 @@ export default class Field extends FieldBase<Field> {
   //  - [config.subductionMinElevation, 0] -> ocean trench and subduction range
   get elevation() {
     let modifier = 0;
-    if (this.bendingProgress) {
+    if (this.bendingProgress && this.oceanicCrust) {
       modifier += config.subductionMinElevation * this.bendingProgress;
     }
     if (this.normalizedAge < 1) {
@@ -422,7 +422,7 @@ export default class Field extends FieldBase<Field> {
     if (this.subduction) {
       // Note that field is subducting both in case of a normal subduction (top plate is oceanic) and orogeny
       // (top plate is a continent).
-      this.crust.subductOrFold(timestep, neighboringCrust, this.subduction.relativeVelocity);
+      this.crust.subduct(timestep, neighboringCrust, this.subduction.relativeVelocity);
     }
     // When sediment layer is too thick, sediments will be transferred to neighbors.
     this.crust.spreadOceanicSediment(timestep, neighboringCrust);


### PR DESCRIPTION
[[#183128190]](https://www.pivotaltracker.com/story/show/183128190)

PT story provides a good description of the issue. I've modified a few separate parts of the model to avoid the steep slopes around the convergent boundary that was creating these deep valleys, often lower than the sea level (hence the blue color and impression of "water" being trapped there).

You can compare the new and old behavior:
- [New version](https://tectonic-explorer.concord.org/branch/continental-collision/index.html?modelId=dcd796fb-9c59-428b-9421-0aa77431b7c3&rocks=true)
- [Old version](https://tectonic-explorer.concord.org/branch/master/index.html?modelId=dcd796fb-9c59-428b-9421-0aa77431b7c3&rocks=true)

There's no water in the updated version, although there's still some valley following the boundary. If you look at the cross-section, you can also see some differences. Shale, limestone, and sandstone are being accumulated around the edge instead of being pushed underground.

Amy seems to like the new behavior, so I'm opening the PR.