### PR TITLE
Add data collection draft UI, disabled by default

### DIFF
--- a/css-modules/data-collection-dialog.less
+++ b/css-modules/data-collection-dialog.less
@@ -1,0 +1,22 @@
+.dataCollectionDialogContent {
+  width: 350px;
+  font-size: 16px;
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    table-layout: fixed;
+
+    td {
+      border: 1px solid rgba(0,0,0,0.1);
+      padding: 3px;
+
+      &:first-child {
+        width: 90px;
+      }
+      &:last-child {
+        font-weight: bold;
+      }
+    }
+  }
+}

--- a/js/components/cross-section.tsx
+++ b/js/components/cross-section.tsx
@@ -44,7 +44,9 @@ export default class CrossSection extends BaseComponent<IBaseProps, IState> {
   };
 
   render() {
-    const { crossSectionVisible, showCrossSectionCameraReset, closeCrossSection } = this.simulationStore;
+    const { crossSectionVisible, showCrossSectionCameraReset, closeCrossSection, interaction } = this.simulationStore;
+    const isCollectingData = interaction === "collectData";
+
     return (
       <div className="cross-section" data-test="cross-section">
         <TransitionGroup>
@@ -53,7 +55,7 @@ export default class CrossSection extends BaseComponent<IBaseProps, IState> {
               <div key="cross-section" className="cross-section-content">
                 <div className="container">
                   <CrossSection3D onCreateScene={this.handleCreateScene}/>
-                  <CrossSectionControls showResetCamera={showCrossSectionCameraReset} onClose={closeCrossSection}
+                  <CrossSectionControls showResetCamera={showCrossSectionCameraReset} onClose={isCollectingData ? undefined : closeCrossSection}
                     onZoomIn={this.handleZoomIn} onZoomOut={this.handleZoomOut} onResetCamera={this.handleResetCamera} />
                 </div>
               </div>
@@ -67,7 +69,7 @@ export default class CrossSection extends BaseComponent<IBaseProps, IState> {
 
 interface ICrossSectionControlsProps {
   showResetCamera: boolean;
-  onClose: () => void;
+  onClose?: () => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
   onResetCamera: () => void;
@@ -76,7 +78,7 @@ const CrossSectionControls = ({ showResetCamera, onClose, onZoomIn, onZoomOut, o
   return (
     <div className="cross-section-controls">
       <div className="cross-section-controls-title">Cross-section</div>
-      <CrossSectionButton Icon={ModelCloseIconSVG} tooltip="Close" onClick={onClose} />
+      { onClose && <CrossSectionButton Icon={ModelCloseIconSVG} tooltip="Close" onClick={onClose} /> }
       <CrossSectionButton Icon={ZoomInIconSVG} tooltip="Zoom In" onClick={onZoomIn} />
       <CrossSectionButton Icon={ZoomOutIconSVG} tooltip="Zoom Out" onClick={onZoomOut} />
       { showResetCamera &&

--- a/js/components/data-collection-dialog.tsx
+++ b/js/components/data-collection-dialog.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { DraggableDialog } from "./draggable-dialog";
+import { Button, DialogActions } from "@mui/material";
+import { IUserCollectedData } from "../types";
+
+import css from "../../css-modules/data-collection-dialog.less";
+
+interface IProps {
+  onClose: () => void;
+  onSubmit: () => void;
+  collectedData: IUserCollectedData;
+}
+
+// patterned after https://mui.com/components/dialogs/#draggable-dialog
+export const DataCollectionDialog = ({ collectedData, onClose, onSubmit }: IProps) => {
+  return (
+    <DraggableDialog
+      title="Selected Rock Data"
+      onClose={onClose}
+      backdrop={false}
+      initialPosition={{ vertical: "center", horizontal: "center" }}
+    >
+      <div className={css.dataCollectionDialogContent}>
+        <table>
+          <tbody>
+            <tr><td>Rock</td><td>{ collectedData.rock }</td></tr>
+            <tr><td>Temperature</td><td>{ collectedData.temperature }</td></tr>
+            <tr><td>Pressure</td><td>{ collectedData.temperature }</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <DialogActions>
+        <Button onClick={onSubmit}>Submit</Button>
+        <Button onClick={onClose}>Discard</Button>
+      </DialogActions>
+    </DraggableDialog>
+  );
+};

--- a/js/components/simulation.tsx
+++ b/js/components/simulation.tsx
@@ -16,6 +16,7 @@ import { BoundaryType } from "../types";
 import { SideContainer } from "./side-container";
 import { TempPressureOverlay } from "./temp-pressure-overlay";
 import { RelativeMotionStoppedDialog } from "./relative-motion-stopped-dialog";
+import { DataCollectionDialog } from "./data-collection-dialog";
 
 import "../../css/simulation.less";
 import "../../css/react-toolbox-theme.less";
@@ -83,8 +84,19 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
     this.simulationStore.closeRelativeMotionDialog();
   };
 
+  handleDataCollectionDialogClose = () => {
+    this.simulationStore.clearCollectedData();
+  };
+
+  handleDataCollectionSubmit = () => {
+    this.simulationStore.submitCollectedData();
+  };
+
   render() {
-    const { planetWizard, modelState, savingModel, selectedBoundary, interaction, relativeMotionStoppedDialogVisible } = this.simulationStore;
+    const {
+      planetWizard, modelState, savingModel, selectedBoundary, interaction, relativeMotionStoppedDialogVisible,
+      collectedData
+    } = this.simulationStore;
     const isMeasuringTempPressure = interaction === "measureTempPressure";
     return (
       <div className={APP_CLASS_NAME} ref={this.appRef} >
@@ -125,6 +137,10 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
         {
           relativeMotionStoppedDialogVisible &&
           <RelativeMotionStoppedDialog onClose={this.handleRelativeMotionDialogClose} />
+        }
+        {
+          collectedData &&
+          <DataCollectionDialog collectedData={collectedData} onSubmit={this.handleDataCollectionSubmit} onClose={this.handleDataCollectionDialogClose} />
         }
       </div>
     );

--- a/js/components/temp-pressure-overlay.tsx
+++ b/js/components/temp-pressure-overlay.tsx
@@ -7,7 +7,7 @@ import TemperatureToolSvg from "../../images/temp-tool.svg";
 import TemperaturePressureCursor from "../../images/temp-pressure-cursor.png";
 import { SimulationStore } from "../stores/simulation-store";
 import { useAnimationFrame } from "./use-animation-frame";
-import { TempPressureValue } from "../plates-model/get-temp-and-pressure";
+import { TempPressureValue } from "../types";
 
 import "../../css/temp-pressure-overlay.less";
 

--- a/js/config.ts
+++ b/js/config.ts
@@ -29,6 +29,8 @@ const DEFAULT_CONFIG = {
   showDrawCrossSectionButton: true,
   // If true, show the Take Sample button in the bottom bar
   showTakeSampleButton: true,
+  // If true, show the Collect Data button in the bottom bar
+  showCollectDataButton: false,
   // If true, show the temperature/pressure tool button in the bottom bar
   showTempPressureTool: true,
   // If true, show the earthquakes switch in the bottom bar

--- a/js/log.ts
+++ b/js/log.ts
@@ -1,5 +1,6 @@
 import { log as laraLog } from "@concord-consortium/lara-interactive-api";
 import { Colormap } from "./config";
+import { ICrossSectionInteractionName } from "./plates-interactions/cross-section-interactions-manager";
 import { IGlobeInteractionName } from "./plates-interactions/globe-interactions-manager";
 import { BoundaryType, RockKeyLabel, TabName } from "./types";
 
@@ -21,10 +22,12 @@ type MeasureTempPressureEnabled = { action: "MeasureTempPressureEnabled", data?:
 type MeasureTempPressureDisabled = { action: "MeasureTempPressureDisabled", data?: undefined };
 type RockPickerEnabled = { action: "RockPickerEnabled", data?: undefined };
 type RockPickerDisabled = { action: "RockPickerDisabled", data?: undefined };
+type DataCollectionEnabled = { action: "DataCollectionEnabled", data?: undefined };
+type DataCollectionDisabled = { action: "DataCollectionDisabled", data?: undefined };
 // InteractionUpdated does NOT include cross section drawing and rock picker tool that have separate log events
 // as they seem to be the most important.
 // IGlobeInteractionName: "force" | "fieldInfo" | "markField" | "assignBoundary" | "continentDrawing" | "continentErasing" | "none"
-type InteractionUpdated = { action: "InteractionUpdated", data?: { value: IGlobeInteractionName } };
+type InteractionUpdated = { action: "InteractionUpdated", data?: { value: IGlobeInteractionName | ICrossSectionInteractionName | "none" } };
 type FullScreenEnabled = { action: "FullScreenEnabled", data?: undefined };
 type FullScreenDisabled = { action: "FullScreenDisabled", data?: undefined };
 type KeysAndOptionsVisible = { action: "KeysAndOptionsVisible", data?: undefined };
@@ -69,7 +72,7 @@ export type LogEvent = SimulationStarted | SimulationStopped | EarthquakesVisibl
   CrossSectionClosed | CrossSectionZoomInClicked | CrossSectionZoomOutClicked |
   PlanetWizardNumberOfPlatesSelected | ContinentAdded | ContinentRemoved | BoundaryTypeSelected | PlateDensitiesUpdated |
   PlanetWizardNextButtonClicked | PlanetWizardBackButtonClicked | PlanetWizardFailedValidationContinueAnywayButtonClicked |
-  PlanetWizardFailedValidationTryAgainButtonClicked
+  PlanetWizardFailedValidationTryAgainButtonClicked | DataCollectionEnabled | DataCollectionDisabled
 ;
 
 export const log = (event: LogEvent) => {

--- a/js/plates-interactions/cross-section-interactions-manager.ts
+++ b/js/plates-interactions/cross-section-interactions-manager.ts
@@ -5,7 +5,7 @@ import { BaseInteractionsManager } from "./base-interactions-manager";
 import { SimulationStore } from "../stores/simulation-store";
 import { getPressure, getTemperature } from "../plates-model/get-temp-and-pressure";
 
-export type ICrossSectionInteractionName = "measureTempPressure" | "takeRockSample";
+export type ICrossSectionInteractionName = "measureTempPressure" | "takeRockSample" | "collectData";
 
 export type ICrossSectionInteractions = Record<ICrossSectionInteractionName, IInteractionHandler>;
 
@@ -54,6 +54,24 @@ export default class CrossSectionInteractionsManager extends BaseInteractionsMan
         onPointerDown: ({ wall, intersection }) => {
           simulationStore?.setSelectedRock(view.getIntersectionData(wall, intersection)?.label || null);
           simulationStore?.setSelectedRockFlash(true);
+        }
+      }),
+      collectData: new CrossSectionClick({
+        ...baseOptions,
+        cursor: TakeRockSampleCursor,
+        onPointerDown: ({ wall, intersection }) => {
+          const intersectionData = view.getIntersectionData(wall, intersection);
+          if (intersectionData?.label) {
+            const pressure = getPressure(simulationStore.model, intersectionData, intersection);
+            const temperature = getTemperature(simulationStore.model, intersectionData, intersection);
+            simulationStore?.setCollectedData({
+              rock: intersectionData.label,
+              pressure,
+              temperature
+            });
+            simulationStore?.setSelectedRock(intersectionData.label || null);
+            simulationStore?.setSelectedRockFlash(true);
+          }
         }
       }),
     };

--- a/js/plates-model/get-temp-and-pressure.ts
+++ b/js/plates-model/get-temp-and-pressure.ts
@@ -1,9 +1,7 @@
 import * as THREE from "three";
 import { IIntersectionData, invScaleY } from "../plates-view/render-cross-section";
 import ModelStore from "../stores/model-store";
-import { RockKeyLabel } from "../types";
-
-export type TempPressureValue = null | "Low" | "Med" | "High";
+import { RockKeyLabel, TempPressureValue } from "../types";
 
 const tempPressureValueOrder = {
   Low: 1,

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -15,12 +15,11 @@ import { IGlobeInteractionName } from "../plates-interactions/globe-interactions
 import { ICrossSectionInteractionName } from "../plates-interactions/cross-section-interactions-manager";
 import {
   BoundaryType, DEFAULT_CROSS_SECTION_CAMERA_ANGLE, DEFAULT_CROSS_SECTION_CAMERA_ZOOM,
-  IBoundaryInfo, IEventCoords, IHotSpot, IVec3Array, RockKeyLabel, TabName
+  IBoundaryInfo, IEventCoords, IHotSpot, IUserCollectedData, IVec3Array, RockKeyLabel, TabName, TempPressureValue
 } from "../types";
 import { ISerializedModel } from "../plates-model/model";
 import getGrid from "../plates-model/grid";
 import { firstNonSedimentaryRockLayer, rockProps } from "../plates-model/rock-properties";
-import { TempPressureValue } from "../plates-model/get-temp-and-pressure";
 import FieldStore from "./field-store";
 import { convertBoundaryTypeToHotSpots, findBoundaryFieldAround, getBoundaryInfo, highlightBoundarySegment, unhighlightBoundary } from "./helpers/boundary-utils";
 import { animateAngleAndZoomTransition, animateVectorTransition } from "./helpers/animation-utils";
@@ -88,6 +87,7 @@ export class SimulationStore {
   @observable currentHotSpot: { position: THREE.Vector3; force: THREE.Vector3; } | null = null;
   @observable screenWidth = Infinity;
   @observable selectedBoundary: IBoundaryInfo | null = null;
+  @observable collectedData: IUserCollectedData | null = null;
   @observable anyHotSpotDefinedByUser = false;
   @observable selectedRock: RockKeyLabel | null = null;
   @observable selectedRockFlash = false;
@@ -290,8 +290,11 @@ export class SimulationStore {
       this.setKeyVisible(true);
       this.setSelectedTab("map-type");
     }
-    if (interaction === "crossSection" || interaction === "measureTempPressure") {
+    if (interaction === "crossSection" || interaction === "measureTempPressure" || interaction === "collectData") {
       this.playing = false;
+    }
+    if (interaction !== "collectData") {
+      this.clearCollectedData();
     }
   }
 
@@ -671,6 +674,22 @@ export class SimulationStore {
       });
       this.highlightedBoundaries = [];
     }
+  }
+
+  @action.bound setCollectedData(data: IUserCollectedData) {
+    this.collectedData = data;
+  }
+
+  @action.bound clearCollectedData() {
+    if (this.collectedData) {
+      this.collectedData = null;
+      this.setSelectedRock(null);
+    }
+  }
+
+  @action.bound submitCollectedData() {
+    // TODO: save collected data in the interactive state.
+    this.clearCollectedData();
   }
 
   // Helpers.

--- a/js/types.ts
+++ b/js/types.ts
@@ -36,6 +36,14 @@ export interface IBoundaryInfo {
   canvasClickPos?: IEventCoords; // position of boundary click in canvas
 }
 
+export type TempPressureValue = null | "Low" | "Med" | "High";
+
+export interface IUserCollectedData {
+  rock: RockKeyLabel;
+  temperature: TempPressureValue;
+  pressure: TempPressureValue;
+}
+
 export interface IHotSpot {
   position: THREE.Vector3;
   force: THREE.Vector3;


### PR DESCRIPTION
[#183946366]

This PR adds a new button named "Collect Data". It can be used to pick a point in the cross-section. UI is in a very draft state, we don't have UI mocks/specs yet. But this UI will be disabled by default, so I think it make sense to keep merging updates rather than keep all the work in a branch.

Demo:
https://tectonic-explorer.concord.org/branch/data-collection/index.html?rocks=true&preset=subduction&showCollectDataButton=true