### PR TITLE
Manage LARA interactive state with dataset

### DIFF
--- a/js/components/data-collection-dialog.tsx
+++ b/js/components/data-collection-dialog.tsx
@@ -1,18 +1,18 @@
 import * as React from "react";
 import { DraggableDialog } from "./draggable-dialog";
 import { Button, DialogActions } from "@mui/material";
-import { IUserCollectedData } from "../types";
+import { IDataSample } from "../types";
 
 import css from "../../css-modules/data-collection-dialog.less";
 
 interface IProps {
   onClose: () => void;
   onSubmit: () => void;
-  collectedData: IUserCollectedData;
+  currentDataSample: IDataSample;
 }
 
 // patterned after https://mui.com/components/dialogs/#draggable-dialog
-export const DataCollectionDialog = ({ collectedData, onClose, onSubmit }: IProps) => {
+export const DataCollectionDialog = ({ currentDataSample, onClose, onSubmit }: IProps) => {
   return (
     <DraggableDialog
       title="Selected Rock Data"
@@ -23,15 +23,15 @@ export const DataCollectionDialog = ({ collectedData, onClose, onSubmit }: IProp
       <div className={css.dataCollectionDialogContent}>
         <table>
           <tbody>
-            <tr><td>Rock</td><td>{ collectedData.rock }</td></tr>
-            <tr><td>Temperature</td><td>{ collectedData.temperature }</td></tr>
-            <tr><td>Pressure</td><td>{ collectedData.temperature }</td></tr>
+            <tr><td>Rock</td><td>{ currentDataSample.rockLabel }</td></tr>
+            <tr><td>Temperature</td><td>{ currentDataSample.temperature }</td></tr>
+            <tr><td>Pressure</td><td>{ currentDataSample.temperature }</td></tr>
           </tbody>
         </table>
       </div>
       <DialogActions>
-        <Button onClick={onSubmit}>Submit</Button>
         <Button onClick={onClose}>Discard</Button>
+        <Button onClick={onSubmit}>Submit</Button>
       </DialogActions>
     </DraggableDialog>
   );

--- a/js/components/simulation.tsx
+++ b/js/components/simulation.tsx
@@ -85,17 +85,17 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
   };
 
   handleDataCollectionDialogClose = () => {
-    this.simulationStore.clearCollectedData();
+    this.simulationStore.clearCurrentDataSample();
   };
 
   handleDataCollectionSubmit = () => {
-    this.simulationStore.submitCollectedData();
+    this.simulationStore.submitCurrentDataSample();
   };
 
   render() {
     const {
       planetWizard, modelState, savingModel, selectedBoundary, interaction, relativeMotionStoppedDialogVisible,
-      collectedData
+      currentDataSample
     } = this.simulationStore;
     const isMeasuringTempPressure = interaction === "measureTempPressure";
     return (
@@ -139,8 +139,8 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
           <RelativeMotionStoppedDialog onClose={this.handleRelativeMotionDialogClose} />
         }
         {
-          collectedData &&
-          <DataCollectionDialog collectedData={collectedData} onSubmit={this.handleDataCollectionSubmit} onClose={this.handleDataCollectionDialogClose} />
+          currentDataSample &&
+          <DataCollectionDialog currentDataSample={currentDataSample} onSubmit={this.handleDataCollectionSubmit} onClose={this.handleDataCollectionDialogClose} />
         }
       </div>
     );

--- a/js/plates-interactions/cross-section-interactions-manager.ts
+++ b/js/plates-interactions/cross-section-interactions-manager.ts
@@ -4,6 +4,7 @@ import { TakeRockSampleCursor, IInteractionHandler } from "./helpers";
 import { BaseInteractionsManager } from "./base-interactions-manager";
 import { SimulationStore } from "../stores/simulation-store";
 import { getPressure, getTemperature } from "../plates-model/get-temp-and-pressure";
+import { v4 as uuidv4 } from "uuid";
 
 export type ICrossSectionInteractionName = "measureTempPressure" | "takeRockSample" | "collectData";
 
@@ -64,8 +65,11 @@ export default class CrossSectionInteractionsManager extends BaseInteractionsMan
           if (intersectionData?.label) {
             const pressure = getPressure(simulationStore.model, intersectionData, intersection);
             const temperature = getTemperature(simulationStore.model, intersectionData, intersection);
-            simulationStore?.setCollectedData({
-              rock: intersectionData.label,
+            simulationStore?.setCurrentDataSample({
+              id: uuidv4(),
+              crossSectionWall: wall,
+              coords: intersection,
+              rockLabel: intersectionData.label,
               pressure,
               temperature
             });

--- a/js/types.ts
+++ b/js/types.ts
@@ -1,4 +1,5 @@
 import FieldStore from "./stores/field-store";
+import { IDataset, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
 
 export interface IVector3 {
   x: number;
@@ -38,12 +39,6 @@ export interface IBoundaryInfo {
 
 export type TempPressureValue = null | "Low" | "Med" | "High";
 
-export interface IUserCollectedData {
-  rock: RockKeyLabel;
-  temperature: TempPressureValue;
-  pressure: TempPressureValue;
-}
-
 export interface IHotSpot {
   position: THREE.Vector3;
   force: THREE.Vector3;
@@ -51,8 +46,24 @@ export interface IHotSpot {
 
 export type TabName = "map-type" | "seismic-data" | "options";
 
+export interface IDataSample {
+  id: string;
+  crossSectionWall: ICrossSectionWall;
+  coords: IEventCoords;
+  rockLabel: RockKeyLabel;
+  temperature: TempPressureValue;
+  pressure: TempPressureValue;
+}
+
+export interface IInteractiveState extends IRuntimeInteractiveMetadata {
+  dataset: IDataset;
+}
+
+export const DATASET_PROPS: Array<keyof IDataSample> = ["id", "rockLabel", "temperature", "pressure"];
+
 export const DEFAULT_CROSS_SECTION_CAMERA_ANGLE = 3;
 export const DEFAULT_CROSS_SECTION_CAMERA_ZOOM = 1;
 export const MIN_CAMERA_ZOOM = 0.8;
 export const MAX_CAMERA_ZOOM = 4.0;
 export const CAMERA_ZOOM_STEP = 0.1;
+


### PR DESCRIPTION
[[#183946419]](https://www.pivotaltracker.com/story/show/183946419)

This PR adds LARA Interactive API support. Tectonic Explorer can now save and load interactive state that mostly includes dataset that is going to be rendered by a new table interactive.