### PR TITLE
Render data samples in the cross-section view

### DIFF
--- a/js/components/cross-section-3d.tsx
+++ b/js/components/cross-section-3d.tsx
@@ -38,7 +38,7 @@ export default class CrossSection3D extends BaseComponent<IProps, IState> {
     // Keep observers separate, as we don't want to re-render the whole cross-section each time the camera angle is changed.
     this.disposeObserver.push(autorun(() => {
       this.view.setScreenWidth(store.screenWidth);
-      this.view.setCrossSectionData(store.crossSectionOutput, store.crossSectionSwapped, {
+      this.view.setCrossSectionData(store.crossSectionOutput, store.crossSectionDataSamples, store.crossSectionSwapped, {
         rockLayers: store.rockLayers,
         metamorphism: store.metamorphism
       });

--- a/js/plates-view/cross-section-3d.ts
+++ b/js/plates-view/cross-section-3d.ts
@@ -3,7 +3,14 @@ import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import renderCrossSection, { getIntersectionWithTestPoint, ICrossSectionOptions, IIntersectionData } from "./render-cross-section";
 import getThreeJSRenderer from "../get-threejs-renderer";
 import { ICrossSectionOutput } from "../plates-model/model-output";
-import { ICrossSectionWall, MAX_CAMERA_ZOOM, MIN_CAMERA_ZOOM } from "../types";
+import { ICrossSectionWall, IDataSample, MAX_CAMERA_ZOOM, MIN_CAMERA_ZOOM } from "../types";
+
+interface IDataSamples {
+  front: IDataSample[];
+  back: IDataSample[];
+  left: IDataSample[];
+  right: IDataSample[];
+}
 
 const HORIZONTAL_MARGIN = 200; // px
 const VERTICAL_MARGIN = 80; // px
@@ -93,6 +100,7 @@ export default class CrossSection3D {
   screenWidth: any;
   suppressCameraChangeEvent: any;
   data: ICrossSectionOutput;
+  dataSamples: IDataSamples;
   options: ICrossSectionOptions;
   swapped: boolean;
 
@@ -188,21 +196,22 @@ export default class CrossSection3D {
     this.screenWidth = value;
   }
 
-  setCrossSectionData(data: ICrossSectionOutput, swapped: boolean, options: ICrossSectionOptions) {
+  setCrossSectionData(data: ICrossSectionOutput, dataSamples: IDataSamples, swapped: boolean, options: ICrossSectionOptions) {
     this.data = data;
+    this.dataSamples = dataSamples;
     this.swapped = swapped;
     this.options = options;
 
     // Since THREE.JS v135 textures cannot be resized. They need to be disposed and recreated.
     this.createTextures();
 
-    renderCrossSection(this.frontWallCanvas, data.dataFront, options);
+    renderCrossSection(this.frontWallCanvas, data.dataFront, dataSamples.front, options);
     this.frontWallTexture.needsUpdate = true;
-    renderCrossSection(this.rightWallCanvas, data.dataRight, options);
+    renderCrossSection(this.rightWallCanvas, data.dataRight, dataSamples.right, options);
     this.rightWallTexture.needsUpdate = true;
-    renderCrossSection(this.backWallCanvas, data.dataBack, options);
+    renderCrossSection(this.backWallCanvas, data.dataBack, dataSamples.back, options);
     this.backWallTexture.needsUpdate = true;
-    renderCrossSection(this.leftWallCanvas, data.dataLeft, options);
+    renderCrossSection(this.leftWallCanvas, data.dataLeft, dataSamples.left, options);
     this.leftWallTexture.needsUpdate = true;
 
     const width = this.frontWallCanvas.width;
@@ -247,13 +256,13 @@ export default class CrossSection3D {
     case "top":
       return { label: "Sky" };
     case "front":
-      return getIntersectionWithTestPoint(this.frontWallCanvas, this.data.dataFront, this.options, testPoint);
+      return getIntersectionWithTestPoint(this.frontWallCanvas, this.data.dataFront, this.dataSamples.front, this.options, testPoint);
     case "left":
-      return getIntersectionWithTestPoint(this.leftWallCanvas, this.data.dataLeft, this.options, testPoint);
+      return getIntersectionWithTestPoint(this.leftWallCanvas, this.data.dataLeft, this.dataSamples.left, this.options, testPoint);
     case "right":
-      return getIntersectionWithTestPoint(this.rightWallCanvas, this.data.dataRight, this.options, testPoint);
+      return getIntersectionWithTestPoint(this.rightWallCanvas, this.data.dataRight, this.dataSamples.right, this.options, testPoint);
     case "back":
-      return getIntersectionWithTestPoint(this.backWallCanvas, this.data.dataBack, this.options, testPoint);
+      return getIntersectionWithTestPoint(this.backWallCanvas, this.data.dataBack, this.dataSamples.back, this.options, testPoint);
     }
   }
 

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -16,7 +16,7 @@ import { IGlobeInteractionName } from "../plates-interactions/globe-interactions
 import { ICrossSectionInteractionName } from "../plates-interactions/cross-section-interactions-manager";
 import {
   BoundaryType, DEFAULT_CROSS_SECTION_CAMERA_ANGLE, DEFAULT_CROSS_SECTION_CAMERA_ZOOM,
-  IBoundaryInfo, IEventCoords, IHotSpot, IDataSample, IVec3Array, RockKeyLabel, TabName, TempPressureValue, IInteractiveState, DATASET_PROPS
+  IBoundaryInfo, IEventCoords, IHotSpot, IDataSample, IVec3Array, RockKeyLabel, TabName, TempPressureValue, IInteractiveState, DATASET_PROPS, ICrossSectionWall
 } from "../types";
 import { ISerializedModel } from "../plates-model/model";
 import getGrid from "../plates-model/grid";
@@ -187,6 +187,20 @@ export class SimulationStore {
 
   @computed get simulationDisabled() {
     return this.model.relativeMotionStopped;
+  }
+
+  @computed get crossSectionDataSamples() {
+    const result: Record<ICrossSectionWall, IDataSample[]> = {
+      front: this.dataSamples.filter(s => s.crossSectionWall === "front"),
+      back: this.dataSamples.filter(s => s.crossSectionWall === "back"),
+      left: this.dataSamples.filter(s => s.crossSectionWall === "left"),
+      right: this.dataSamples.filter(s => s.crossSectionWall === "right"),
+      top: []
+    };
+    if (this.currentDataSample) {
+      result[this.currentDataSample.crossSectionWall].push(this.currentDataSample);
+    }
+    return result;
   }
 
   @computed get workerProperties() {

--- a/test/plates-view/render-cross-section.test.ts
+++ b/test/plates-view/render-cross-section.test.ts
@@ -164,7 +164,7 @@ describe("render cross-section helpers", () => {
     it("renders test data without any errors", () => {
       const data: ICrossSectionPlateViewData[] = [testPlateData];
       const canvas = document.createElement("canvas");
-      expect(() => renderCrossSection(canvas, data, options)).not.toThrow();
+      expect(() => renderCrossSection(canvas, data, [], options)).not.toThrow();
       // If you need to update test-cross-section.png or just want to see what is being tested, you can
       // generate a new image using:
       // console.log(canvas.toDataURL());
@@ -176,24 +176,24 @@ describe("render cross-section helpers", () => {
       const data: ICrossSectionPlateViewData[] = [testPlateData];
       const canvas = document.createElement("canvas");
       let testPoint = new THREE.Vector2(1, 1);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Sky");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Sky");
       testPoint = new THREE.Vector2(1, 70);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Sandstone");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Sandstone");
       testPoint = new THREE.Vector2(1, 180);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Mantle (brittle)");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Mantle (brittle)");
       testPoint = new THREE.Vector2(1, 270);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Mantle (ductile)");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Mantle (ductile)");
       testPoint = new THREE.Vector2(350, 110);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Gabbro");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Gabbro");
       // Magma blobs
       testPoint = new THREE.Vector2(100, 60);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Granite");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Granite");
       testPoint = new THREE.Vector2(100, 90);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Iron-poor Magma");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Iron-poor Magma");
       testPoint = new THREE.Vector2(100, 150);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Intermediate Magma");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Intermediate Magma");
       testPoint = new THREE.Vector2(100, 205);
-      expect(getIntersectionWithTestPoint(canvas, data, options, testPoint)?.label).toEqual("Iron-rich Magma");
+      expect(getIntersectionWithTestPoint(canvas, data, [], options, testPoint)?.label).toEqual("Iron-rich Magma");
     });
   });
 });


### PR DESCRIPTION
[[#184003233]](https://www.pivotaltracker.com/story/show/184003233)

The basic cross-section markers rendering. They are going to have different shapes and need to be interactive most likely, so this is just a temporal solution.
<img width="707" alt="Screenshot 2022-12-12 at 19 34 48" src="https://user-images.githubusercontent.com/767857/207126548-0b13dfec-2ba6-4b65-816f-e544e64016ca.png">
