### PR TITLE
Save globe view and cross-section snapshots in interactive state

### DIFF
--- a/js/plates-view/cross-section-3d.ts
+++ b/js/plates-view/cross-section-3d.ts
@@ -5,6 +5,8 @@ import getThreeJSRenderer from "../get-threejs-renderer";
 import { ICrossSectionOutput } from "../plates-model/model-output";
 import { ICrossSectionWall, IDataSample, MAX_CAMERA_ZOOM, MIN_CAMERA_ZOOM } from "../types";
 
+export const CROSS_SECTION_CANVAS_ID = "cross-section-canvas";
+
 interface IDataSamples {
   front: IDataSample[];
   back: IDataSample[];
@@ -122,6 +124,7 @@ export default class CrossSection3D {
     if (this.domElement.className.indexOf("canvas-3d") === -1) {
       this.domElement.className += " canvas-3d";
     }
+    this.domElement.id = CROSS_SECTION_CANVAS_ID;
     (this.domElement as any).render = this.render.bind(this);
 
     this.requestAnimFrame = this.requestAnimFrame.bind(this);

--- a/js/plates-view/planet-view.ts
+++ b/js/plates-view/planet-view.ts
@@ -14,6 +14,8 @@ import { SimulationStore } from "../stores/simulation-store";
 
 import "../../css/planet-view.less";
 
+export const PLANET_VIEW_CANVAS_ID = "planet-view-canvas";
+
 // Mantle color is actually blue, as it's visible where two plates are diverging.
 // This crack should represent oceanic ridge.
 const MANTLE_DUCTILE = RGBAFloatToHexNumber(topoColor(0.40));
@@ -69,6 +71,7 @@ export default class PlanetView {
     if (this.domElement.className.indexOf("canvas-3d") === -1) {
       this.domElement.className += " canvas-3d";
     }
+    this.domElement.id = PLANET_VIEW_CANVAS_ID;
     this.domElement.render = this.render.bind(this);
 
     this.requestAnimFrame = this.requestAnimFrame.bind(this);

--- a/js/shutterbug-support.ts
+++ b/js/shutterbug-support.ts
@@ -1,4 +1,6 @@
 import Shutterbug from "shutterbug";
+import { CROSS_SECTION_CANVAS_ID } from "./plates-view/cross-section-3d";
+import { PLANET_VIEW_CANVAS_ID } from "./plates-view/planet-view";
 
 export function enableShutterbug(appClassName: string) {
   Shutterbug.enable("." + appClassName);
@@ -19,3 +21,37 @@ function beforeSnapshotHandler() {
     }
   });
 }
+
+export function takeSnapshot(selectorOrDomElement: string | HTMLElement) {
+  return new Promise((resolve, reject) => {
+    Shutterbug.snapshot({
+      selector: selectorOrDomElement,
+      done: (snapshotUrl: string) => {
+        resolve(snapshotUrl);
+      },
+      fail: (jqXHR: any, textStatus: string, errorThrown: any) => {
+        console.error("Shutterbug request failed", textStatus, errorThrown);
+        reject(errorThrown);
+      }
+    });
+  });
+}
+
+export function takePlanetViewSnapshot() {
+  return takeSnapshot(`#${PLANET_VIEW_CANVAS_ID}`);
+}
+
+export function takeCrossSectionSnapshot() {
+  const canvas = document.getElementById(CROSS_SECTION_CANVAS_ID);
+  let oldBgColor = "";
+  if (canvas) {
+    oldBgColor = canvas.style.backgroundColor;
+    canvas.style.backgroundColor = "black";
+  }
+  const promise = takeSnapshot(`#${CROSS_SECTION_CANVAS_ID}`);
+  if (canvas) {
+    canvas.style.backgroundColor = oldBgColor;
+  }
+  return promise;
+}
+

--- a/js/types.ts
+++ b/js/types.ts
@@ -57,6 +57,9 @@ export interface IDataSample {
 
 export interface IInteractiveState extends IRuntimeInteractiveMetadata {
   dataset: IDataset;
+  snapshotRequestTimestamp?: number;
+  planetViewSnapshot?: string;
+  crossSectionSnapshot?: string;
 }
 
 export const DATASET_PROPS: Array<keyof IDataSample> = ["id", "rockLabel", "temperature", "pressure"];


### PR DESCRIPTION
[#184027345]

Tectonic Explorer will now save two screenshots when it saves the interactive state. It isn't visible for users (until they look at the TecRock Table), and I'm trying to ensure that we never overwrite newer screenshots with older ones. This could happen easily, as the Shutterbug response time is very variable and usually the first request is the slowest.