### PR TITLE
Fix issues related to data saving

### DIFF
--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -825,13 +825,15 @@ export class SimulationStore {
             console.error(error);
           }
         })
-        .finally(() => {
+        .finally(action(() => {
           // Mark the request as processed.
           if (requestTimestamp === this.lastSnapshotRequestTimestamp) {
             this.lastSnapshotRequestTimestamp = null;
           }
-          setNavigation({ enableForwardNav: true, message: "" });
-        });
+          // Slightly delay enabling forward navigation, as Activity Player also takes some time to save the updated
+          // interactive state in Firestore. This possibly should be managed better by AP itself in the future.
+          setTimeout(() => setNavigation({ enableForwardNav: true, message: "" }), 500);
+        }));
     }), 100);
   }
 

--- a/js/stores/simulation-store.ts
+++ b/js/stores/simulation-store.ts
@@ -336,9 +336,8 @@ export class SimulationStore {
       }
       this.playing = false;
       this.clearDataSamples();
-      this.saveInteractiveState();
     }
-    if (this.interaction === "collectData" && interaction !== "collectData") {
+    if (this.interaction === "collectData" && interaction !== "collectData" && this.dataSamples.length > 0) {
       this.dataSavingDialogVisible = true;
     }
     this.interaction = interaction;


### PR DESCRIPTION
[#184074513]
[#184074641]

This PR disables initial interactive state saving, as that's not really useful and it was causing some issues.
Also, the dialog informing about data saving won't be shown if there are samples to save.
Finally, the forward navigation is re-enabled with a small delay, so it's less likely user is able to change page when AP is saving the updated state in Firestore. Plus I've added one MobX `action` wrapper to avoid warnings.