### PR TITLE
TecRock Table updates

### DIFF
--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,7 +1,9 @@
-import { IDataset, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
+import { IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
 
-export interface IInteractiveState extends IRuntimeInteractiveMetadata {
-  dataset: IDataset;
+export interface ITectonicExplorerInteractiveState extends IRuntimeInteractiveMetadata {
+  version: 1;
+  dataSamples: IDataSample[];
+  dataSampleColumns: DataSampleColumnName[];
   planetViewSnapshot?: string;
   crossSectionSnapshot?: string;
 }

--- a/packages/tecrock-table/src/components/app.tsx
+++ b/packages/tecrock-table/src/components/app.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { BaseQuestionApp } from "@concord-consortium/question-interactives-helpers/src/components/base-question-app";
-import { IAuthoredState, ITectonicExplorerInteractiveState } from "../types";
+import { ITectonicExplorerInteractiveState } from "@concord-consortium/tecrock-shared";
+import { IAuthoredState } from "../types";
 import { Runtime } from "./runtime";
 import { JSONSchema6 } from "json-schema";
 

--- a/packages/tecrock-table/src/components/runtime.scss
+++ b/packages/tecrock-table/src/components/runtime.scss
@@ -20,23 +20,38 @@
     flex-direction: row;
 
     .table {
-      width: 50%;
+      overflow-x: auto;
+      margin-right: 10px;
+      vertical-align: top;
+
       table {
-        width: 98%;
         border-collapse: collapse;
-        table-layout: fixed;
-        th:first-child {
-          width: 200px;
-        }
-        td {
-          border: 1px solid rgba(0,0,0,0.1);
-          padding: 3px;
+        table-layout: auto;
+
+        td, th {
+          border: 0.5px solid #979797;
+          padding: 4px;
+          text-align: center;
+
+          &:first-child {
+            width: 90px;
+          }
+          &:last-child {
+            font-weight: bold;
+          }
+
+          &.temperatureAndPressure {
+            max-width: 100px;
+          }
+          &.type {
+            max-width: 200px;
+          }
         }
       }
     }
 
     .snapshots {
-      width: 48%;
+      max-width: 30%;
       img {
         width: 100%;
       }

--- a/packages/tecrock-table/src/types.ts
+++ b/packages/tecrock-table/src/types.ts
@@ -1,15 +1,6 @@
-import { IAuthoringInteractiveMetadata, IDataset, IRuntimeInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
+import { IAuthoringInteractiveMetadata } from "@concord-consortium/lara-interactive-api";
 
 export interface IAuthoredState extends IAuthoringInteractiveMetadata {
   version: number;
   dataSourceInteractive?: string;
-}
-
-export interface IInteractiveState extends IRuntimeInteractiveMetadata {}
-
-// This should be kept in sync with the ITectonicExplorerInteractiveState in the tectonic-explorer repository.
-export interface ITectonicExplorerInteractiveState extends IRuntimeInteractiveMetadata {
-  dataset: IDataset;
-  planetViewSnapshot?: string;
-  crossSectionSnapshot?: string;
 }


### PR DESCRIPTION
[[#184185704]](https://www.pivotaltracker.com/story/show/184185704)

Two main changes in this PR:
1. I've given up on using `IDataset` in Tectonic Explorer interactive state. It became pointless, as this dataset cannot be rendered by any generic interactive. Most of the data in the table are derived from rock type, and there are plenty of SVGs that need to be injected. Also, now TecRock Table and Tectonic Explorer live in the same repository and use `shared` package, so there's no problem in sharing the interactive state interface between them.
2. I've updated TecRock Table rendering to match table in the Tectonic Explorer Data Collection dialog.