### PR TITLE
Add notes support

### DIFF
--- a/packages/shared/data-sample-info.tsx
+++ b/packages/shared/data-sample-info.tsx
@@ -78,6 +78,21 @@ export const dataSampleColumnLabel: Record<DataSampleColumnName, string> = {
   notes: "Notes"
 };
 
+export const dataSampleColumnOrder: Record<DataSampleColumnName, number> = {
+  category: 1,
+  type: 2,
+  temperatureAndPressure: 3,
+  ironContent: 4,
+  cooling: 5,
+  metamorphicGrade: 6,
+  particlesSize: 7,
+  magmaTemperature: 8,
+  notes: 9
+};
+
+export const getSortedColumns = (columns: DataSampleColumnName[]) =>
+  columns.slice().sort((a, b) => dataSampleColumnOrder[a] - dataSampleColumnOrder[b]);
+
 export const dataSampleInfo: Record<RockKeyLabel, IDataSampleInfo> = {
   // --- Igneous Rocks ---
   "Andesite": {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -47,5 +47,3 @@ export interface IDataSampleInfo {
   particlesSize?: JSX.Element; // Sedimentary Rocks
   magmaTemperature?: JSX.Element; // Magma
 }
-
-export const DATASET_PROPS: Array<keyof IDataSample> = ["id", "type", "temperature", "pressure", "notes"];

--- a/packages/tecrock-table/src/components/runtime.scss
+++ b/packages/tecrock-table/src/components/runtime.scss
@@ -33,19 +33,17 @@
           padding: 4px;
           text-align: center;
 
-          &:first-child {
-            width: 90px;
-          }
-          &:last-child {
-            font-weight: bold;
-          }
-
           &.temperatureAndPressure {
             max-width: 100px;
           }
           &.type {
             max-width: 200px;
           }
+        }
+
+        td.notes {
+          min-width: 200px;
+          text-align: left;
         }
       }
     }

--- a/packages/tecrock-table/src/components/runtime.tsx
+++ b/packages/tecrock-table/src/components/runtime.tsx
@@ -56,7 +56,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       <div className={css.tableAndSnapshots}>
         <div className={css.table}>
         <table>
-          <tbody>
+          <thead>
             <tr>
               {
                 dataSampleColumns && dataSampleColumns.map((column: DataSampleColumnName) => (
@@ -64,6 +64,8 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
                 ))
               }
             </tr>
+          </thead>
+          <tbody>
             {
               dataSamples && dataSamples.map(sample => dataSampleToTableRow(sample)).map((rockRowData, idx) => (
                 <tr key={idx}>

--- a/packages/tecrock-table/src/components/runtime.tsx
+++ b/packages/tecrock-table/src/components/runtime.tsx
@@ -7,7 +7,7 @@ import { useLinkedInteractiveId } from "@concord-consortium/question-interactive
 import { DecorateChildren } from "@concord-consortium/text-decorator";
 import { renderHTML } from "@concord-consortium/question-interactives-helpers/src/utilities/render-html";
 import { useGlossaryDecoration } from "@concord-consortium/question-interactives-helpers/src/hooks/use-glossary-decoration";
-import { dataSampleColumnLabel, DataSampleColumnName, dataSampleToTableRow, ITectonicExplorerInteractiveState } from "@concord-consortium/tecrock-shared";
+import { dataSampleColumnLabel, DataSampleColumnName, dataSampleToTableRow, getSortedColumns, ITectonicExplorerInteractiveState } from "@concord-consortium/tecrock-shared";
 import css from "./runtime.scss";
 
 interface IProps extends IRuntimeQuestionComponentProps<IAuthoredState, ITectonicExplorerInteractiveState> {}
@@ -42,7 +42,9 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
     };
   }, [dataSourceInteractive, setInteractiveState]);
 
+  const sortedColumns = dataSampleColumns ? getSortedColumns(dataSampleColumns) : [];
   const decorateOptions = useGlossaryDecoration();
+
   return (
     <div className={classNames(css.tecRockTable, { [css.report]: report })}>
       {
@@ -59,7 +61,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
           <thead>
             <tr>
               {
-                dataSampleColumns && dataSampleColumns.map((column: DataSampleColumnName) => (
+                sortedColumns.map((column: DataSampleColumnName) => (
                   <th key={column} className={css[column]}>{ dataSampleColumnLabel[column] }</th>
                 ))
               }
@@ -70,7 +72,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
               dataSamples && dataSamples.map(sample => dataSampleToTableRow(sample)).map((rockRowData, idx) => (
                 <tr key={idx}>
                   {
-                    dataSampleColumns && dataSampleColumns.map((column: DataSampleColumnName) => (
+                    sortedColumns.map((column: DataSampleColumnName) => (
                       <td key={column} className={css[column]}>{ rockRowData[column] }</td>
                     ))
                   }

--- a/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
@@ -32,7 +32,7 @@ export const DataCollectionDialog = ({ currentDataSample, onClose, onSubmit, onN
     >
       <div className={css.dataCollectionDialogContent}>
         <table>
-          <tbody>
+          <thead>
             <tr>
               {
                 config.dataSampleColumns.map((column: DataSampleColumnName) => (
@@ -40,6 +40,8 @@ export const DataCollectionDialog = ({ currentDataSample, onClose, onSubmit, onN
                 ))
               }
             </tr>
+          </thead>
+          <tbody>
             <tr>
               {
                 config.dataSampleColumns.map((column: DataSampleColumnName) => (

--- a/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { DraggableDialog } from "./draggable-dialog";
 import { Button, DialogActions } from "@mui/material";
-import { dataSampleColumnLabel, dataSampleToTableRow, DataSampleColumnName } from "@concord-consortium/tecrock-shared";
+import { dataSampleColumnLabel, dataSampleToTableRow, DataSampleColumnName, getSortedColumns } from "@concord-consortium/tecrock-shared";
 import { IDataSample } from "../types";
 import config from "../config";
 
@@ -23,6 +23,13 @@ export const DataCollectionDialog = ({ currentDataSample, onClose, onSubmit, onN
 
   const rockRowData = dataSampleToTableRow(currentDataSample);
 
+  const notesEnabled = config.dataSampleColumns.includes("notes");
+  // When user is collecting data, notes should show as a separate textfield under the table,
+  // so notes column require special handling.
+  const columnsWithoutNotes = notesEnabled ?
+    config.dataSampleColumns.filter((column: DataSampleColumnName) => column !== "notes") : config.dataSampleColumns;
+  const sortedColumns = getSortedColumns(columnsWithoutNotes);
+
   return (
     <DraggableDialog
       title="Selected Data"
@@ -35,7 +42,7 @@ export const DataCollectionDialog = ({ currentDataSample, onClose, onSubmit, onN
           <thead>
             <tr>
               {
-                config.dataSampleColumns.map((column: DataSampleColumnName) => (
+                sortedColumns.map((column: DataSampleColumnName) => (
                   <th key={column} className={css[column]}>{ dataSampleColumnLabel[column] }</th>
                 ))
               }
@@ -44,14 +51,17 @@ export const DataCollectionDialog = ({ currentDataSample, onClose, onSubmit, onN
           <tbody>
             <tr>
               {
-                config.dataSampleColumns.map((column: DataSampleColumnName) => (
+                sortedColumns.map((column: DataSampleColumnName) => (
                   <td key={column} className={css[column]}>{ rockRowData[column] }</td>
                 ))
               }
             </tr>
           </tbody>
         </table>
-        <textarea key="notes" placeholder="Add notes…" value={currentDataSample.notes} onChange={handleNotesChange} />
+        {
+          notesEnabled &&
+          <textarea key="notes" placeholder="Add notes…" value={currentDataSample.notes} onChange={handleNotesChange} />
+        }
       </div>
       <DialogActions>
         <Button onClick={onClose}>Discard</Button>

--- a/packages/tectonic-explorer/js/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/js/stores/simulation-store.ts
@@ -2,7 +2,7 @@ import { observable, computed, action, runInAction, autorun, makeObservable, toJ
 import config, { Colormap } from "../config";
 import * as THREE from "three";
 import isEqual from "lodash/isEqual";
-import { addInteractiveStateListener, getInteractiveState, IDataset, setInteractiveState, setNavigation } from "@concord-consortium/lara-interactive-api";
+import { addInteractiveStateListener, getInteractiveState, setInteractiveState, setNavigation } from "@concord-consortium/lara-interactive-api";
 import { getCrossSectionRectangle, shouldSwapDirection } from "../plates-model/cross-section-utils";
 import presets from "../presets";
 import { getImageData } from "../utils";
@@ -16,7 +16,7 @@ import { IGlobeInteractionName } from "../plates-interactions/globe-interactions
 import { ICrossSectionInteractionName } from "../plates-interactions/cross-section-interactions-manager";
 import {
   BoundaryType, DEFAULT_CROSS_SECTION_CAMERA_ANGLE, DEFAULT_CROSS_SECTION_CAMERA_ZOOM,
-  IBoundaryInfo, IVector2, IHotSpot, IDataSample, IVec3Array, RockKeyLabel, TabName, TempPressureValue, ITectonicExplorerInteractiveState, DATASET_PROPS, ICrossSectionWall
+  IBoundaryInfo, IVector2, IHotSpot, IDataSample, IVec3Array, RockKeyLabel, TabName, TempPressureValue, ITectonicExplorerInteractiveState, ICrossSectionWall
 } from "../types";
 import { ISerializedModel } from "../plates-model/model";
 import getGrid from "../plates-model/grid";


### PR DESCRIPTION
[#184214544]

This PR ensures that notes texarea (TE dialog) and notes column (TecRock Table) are disabled when "notes" value is not present in `dataSampleColumns` config value. I've also fixed some styles and ensured that column are always rendered in the same order.