### PR TITLE
Fix a bug in Data Collection dialog (notes textarea)

### DIFF
--- a/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
@@ -15,11 +15,12 @@ interface IProps {
 }
 
 // patterned after https://mui.com/components/dialogs/#draggable-dialog
-export const DataCollectionDialog = ({ currentDataSample, onClose, onSubmit, onNotesChange }: IProps) => {
+export const DataCollectionDialog: React.FC<IProps> = ({ currentDataSample, onClose, onSubmit, onNotesChange }) => {
 
   const handleNotesChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onNotesChange(event.target.value);
   }, [onNotesChange]);
+
 
   const rockRowData = dataSampleToTableRow(currentDataSample);
 
@@ -59,7 +60,7 @@ export const DataCollectionDialog = ({ currentDataSample, onClose, onSubmit, onN
         </table>
         {
           notesEnabled &&
-          <textarea key="notes" placeholder="Add notes…" value={currentDataSample.notes} onChange={handleNotesChange} />
+          <textarea placeholder="Add notes…" value={currentDataSample.notes} onChange={handleNotesChange} />
         }
       </div>
       <DialogActions>

--- a/packages/tectonic-explorer/js/components/draggable-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/draggable-dialog.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useMemo } from "react";
 import classNames from "classnames";
 import Draggable from "react-draggable";
 import Dialog from "@mui/material/Dialog";
@@ -37,7 +37,9 @@ interface IProps {
 
 // patterned after https://mui.com/components/dialogs/#draggable-dialog
 export const DraggableDialog: React.FC<IProps> = ({ backdrop, onClose, title, offset, initialPosition, children }) => {
-  function PaperComponent(props: PaperProps) {
+  // PaperComponent needs to be memoized, as otherwise it's recreated on every render. This might lead to unexpected
+  // side effects like losing input focus on each render.
+  const PaperComponentMemoized = useMemo(() => function PaperComponent(props: PaperProps) {
     return (
       <Draggable
         defaultPosition={offset}
@@ -48,7 +50,7 @@ export const DraggableDialog: React.FC<IProps> = ({ backdrop, onClose, title, of
         <Paper {...props} />
       </Draggable>
     );
-  }
+  }, [offset]);
 
   const vertClassName = verticalPositionClassName[initialPosition?.vertical || "center"];
   const horClassName = horizontalPositionClassName[initialPosition?.horizontal || "center"];
@@ -59,7 +61,7 @@ export const DraggableDialog: React.FC<IProps> = ({ backdrop, onClose, title, of
       className={classNames(css.draggableDialog, css[vertClassName], css[horClassName])}
       open={true}
       onClose={onClose}
-      PaperComponent={PaperComponent}
+      PaperComponent={PaperComponentMemoized}
       aria-labelledby="draggable-dialog-title"
       maxWidth={false}
     >

--- a/packages/tectonic-explorer/js/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/js/stores/simulation-store.ts
@@ -772,7 +772,7 @@ export class SimulationStore {
       version: 1,
       answerType: "interactive_state",
       dataSampleColumns: config.dataSampleColumns,
-      dataSamples: JSON.parse(JSON.stringify(this.dataSamples)) // copy MobX observable array to plain JS array
+      dataSamples: toJS(this.dataSamples) // copy MobX observable array to plain JS array
     };
     if (this.dataSamples.length === 0) {
       // Remove snapshots if there are no data samples.
@@ -823,7 +823,6 @@ export class SimulationStore {
           // Mark the request as processed.
           if (requestTimestamp === this.lastSnapshotRequestTimestamp) {
             this.lastSnapshotRequestTimestamp = null;
-            // this.playing = true;
             // Slightly delay enabling forward navigation, as Activity Player also takes some time to save the updated
             // interactive state in Firestore. This possibly should be managed better by AP itself in the future.
             setTimeout(() => setNavigation({ enableForwardNav: true, message: "" }), 500);

--- a/packages/tectonic-explorer/js/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/js/stores/simulation-store.ts
@@ -736,7 +736,10 @@ export class SimulationStore {
 
   @action.bound setCurrentDataSampleNotes(notes: string) {
     if (this.currentDataSample) {
-      this.currentDataSample.notes = notes;
+      this.currentDataSample = {
+        ...this.currentDataSample,
+        notes
+      };
     }
   }
 
@@ -769,7 +772,7 @@ export class SimulationStore {
       version: 1,
       answerType: "interactive_state",
       dataSampleColumns: config.dataSampleColumns,
-      dataSamples: toJS(this.dataSamples) // copy MobX observable array to plain JS array
+      dataSamples: JSON.parse(JSON.stringify(this.dataSamples)) // copy MobX observable array to plain JS array
     };
     if (this.dataSamples.length === 0) {
       // Remove snapshots if there are no data samples.
@@ -820,6 +823,7 @@ export class SimulationStore {
           // Mark the request as processed.
           if (requestTimestamp === this.lastSnapshotRequestTimestamp) {
             this.lastSnapshotRequestTimestamp = null;
+            // this.playing = true;
             // Slightly delay enabling forward navigation, as Activity Player also takes some time to save the updated
             // interactive state in Firestore. This possibly should be managed better by AP itself in the future.
             setTimeout(() => setNavigation({ enableForwardNav: true, message: "" }), 500);


### PR DESCRIPTION
The bug was pretty weird, but it's well described by Saravanan here:
https://www.pivotaltracker.com/story/show/184074624/comments/235007860

Half of the problem was:
```
this.currentDataSample.notes = notes;
```
instead of:
```
this.currentDataSample = {
  ...this.currentDataSample,
  notes
};
```

but that revealed another problem in the dialog. The notes textarea was losing focus on each key stroke. That's fixed by memoization of the PaperComponent.