### PR TITLE
Prevent cross section rotation in data collection mode

### DIFF
--- a/packages/tectonic-explorer/js/components/cross-section-3d.tsx
+++ b/packages/tectonic-explorer/js/components/cross-section-3d.tsx
@@ -47,7 +47,7 @@ export default class CrossSection3D extends BaseComponent<IProps, IState> {
       this.view.setCameraAngleAndZoom(store.crossSectionCameraAngle, store.crossSectionCameraZoom);
     }));
     this.disposeObserver.push(autorun(() => {
-      this.view.setCameraLocked(store.crossSectionCameraAnimating);
+      this.view.setCameraLocked(store.crossSectionCameraAnimating || store.interaction === "collectData");
     }));
     // Observe changes to store properties and update interactions helper.
     this.disposeObserver.push(autorun(() => {

--- a/packages/tectonic-explorer/js/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/js/stores/simulation-store.ts
@@ -338,8 +338,11 @@ export class SimulationStore {
       }
       this.playing = false;
     }
-    if (this.interaction === "collectData" && interaction !== "collectData" && this.dataSamples.length > 0) {
-      this.dataSavingDialogVisible = true;
+    if (this.interaction === "collectData" && interaction !== "collectData") {
+      this.clearCurrentDataSample();
+      if (this.dataSamples.length > 0) {
+        this.dataSavingDialogVisible = true;
+      }
     }
     this.interaction = interaction;
   }


### PR DESCRIPTION
[[#184186030]](https://www.pivotaltracker.com/story/show/184186030)

This PR:
1. Locks CS view in the data collection mode (first commit)
2. Fix a small random bug - sometimes data collection dialog could be visible even after user extits the data collection mode (second commit)