### PR TITLE
Redesign exit data collection dialog, add logs related to data collection

### DIFF
--- a/packages/tectonic-explorer/css-modules/data-saving-dialog.less
+++ b/packages/tectonic-explorer/css-modules/data-saving-dialog.less
@@ -1,5 +1,16 @@
 .dataSavingDialogContent {
-  width: 395px;
-  text-align: center;
-  padding: 5px;
+  :global(.MuiDialogActions-root) {
+    padding: 10px 0 3px 0;
+  }
+
+  width: 580px;
+  font-size: 16px;
+
+  p {
+    margin-top: 6px;
+  }
+
+  .dataSavingMessage {
+    text-align: center;
+  }
 }

--- a/packages/tectonic-explorer/css-modules/exit-data-collection-dialog.less
+++ b/packages/tectonic-explorer/css-modules/exit-data-collection-dialog.less
@@ -1,4 +1,4 @@
-.dataSavingDialogContent {
+.exitDataCollectionDialogContent {
   :global(.MuiDialogActions-root) {
     padding: 10px 0 3px 0;
   }

--- a/packages/tectonic-explorer/js/components/bottom-panel.tsx
+++ b/packages/tectonic-explorer/js/components/bottom-panel.tsx
@@ -105,14 +105,12 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
       "crossSection": { action: "CrossSectionDrawingEnabled" },
       "measureTempPressure": { action: "MeasureTempPressureEnabled" },
       "takeRockSample": { action: "RockPickerEnabled" },
-      "collectData": { action: "DataCollectionEnabled" },
     };
     const enableEvent = enableInteractionEvents[interaction];
     const disableInteractionEvents: Partial<Record<IGlobeInteractionName | ICrossSectionInteractionName, LogEvent>> = {
       "crossSection": { action: "CrossSectionDrawingDisabled" },
       "measureTempPressure": { action: "MeasureTempPressureDisabled" },
       "takeRockSample": { action: "RockPickerDisabled" },
-      "collectData": { action: "DataCollectionDisabled" },
     };
     // log the disabling of the current interaction (if any)
     const disableEvent = disableInteractionEvents[currentInteraction as IGlobeInteractionName | ICrossSectionInteractionName];
@@ -127,6 +125,24 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
     // just log the change for other interactions
     if (!enableEvent || !disableEvent) {
       log({ action: "InteractionUpdated", data: { value: interaction } });
+    }
+  };
+
+  handleDataCollectionToggle = () => {
+    if (this.simulationStore.interaction !== "collectData") {
+      // Turn on data collection mode.
+      this.simulationStore.setInteraction("collectData");
+      log({ action: "DataCollectionEnabled" });
+    } else {
+      if (this.simulationStore.dataSamples.length > 0) {
+        // Data samples exist, show exit data collection dialog.
+        this.simulationStore.showExitDataCollectionDialog();
+        log({ action: "ExitDataCollectionDialogOpened" });
+      } else {
+        // No data samples, exit data collection mode immediately.
+        this.simulationStore.setInteraction("none");
+        log({ action: "DataCollectionDisabled" });
+      }
     }
   };
 
@@ -191,7 +207,7 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
                   <ControlGroup>
                     <IconHighlightButton active={isCollectingData} disabled={!showCrossSectionView} style={{ width: 64 }} data-test="collect-data"
                       label={<>Collect<br/>Data</>} Icon={PointyPinOutlineClickedSVG}
-                      onClick={() => this.toggleInteraction("collectData")} />
+                      onClick={this.handleDataCollectionToggle} />
                   </ControlGroup> }
               </div>
             </ControlGroup> }

--- a/packages/tectonic-explorer/js/components/bottom-panel.tsx
+++ b/packages/tectonic-explorer/js/components/bottom-panel.tsx
@@ -150,7 +150,7 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
     const {
       showDrawCrossSectionButton, showTempPressureTool, showTakeSampleButton, showCollectDataButton, showEarthquakesSwitch, showVolcanoesSwitch
     } = config;
-    const { interaction, colormap, showCrossSectionView } = this.simulationStore;
+    const { interaction, colormap, showCrossSectionView, currentDataSample } = this.simulationStore;
     const { reload, restoreSnapshot, restoreInitialSnapshot, stepForward, simulationDisabled } = this.simulationStore;
     const options = this.options;
     const isDrawingCrossSection = interaction === "crossSection";
@@ -205,7 +205,7 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
                   </ControlGroup> }
                 { showCollectDataButton &&
                   <ControlGroup>
-                    <IconHighlightButton active={isCollectingData} disabled={!showCrossSectionView} style={{ width: 64 }} data-test="collect-data"
+                    <IconHighlightButton active={isCollectingData} disabled={!showCrossSectionView || !!currentDataSample} style={{ width: 64 }} data-test="collect-data"
                       label={<>Collect<br/>Data</>} Icon={PointyPinOutlineClickedSVG}
                       onClick={this.handleDataCollectionToggle} />
                   </ControlGroup> }

--- a/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
@@ -3,8 +3,9 @@ import { DialogButton, DraggableDialog } from "./draggable-dialog";
 import { DialogActions } from "@mui/material";
 import { dataSampleColumnLabel, dataSampleToTableRow, DataSampleColumnName, getSortedColumns } from "@concord-consortium/tecrock-shared";
 import { IDataSample } from "../types";
-import CheckIcon from "../../images/check-icon.svg";
+import { log } from "../log";
 import config from "../config";
+import CheckIcon from "../../images/check-icon.svg";
 
 import css from "../../css-modules/data-collection-dialog.less";
 
@@ -22,6 +23,15 @@ export const DataCollectionDialog: React.FC<IProps> = ({ currentDataSample, onCl
     onNotesChange(event.target.value);
   }, [onNotesChange]);
 
+  const handleOnSubmit = useCallback(() => {
+    log({ action: "DataCollectionDialogSubmitClicked", data: currentDataSample });
+    onSubmit();
+  }, [onSubmit, currentDataSample]);
+
+  const handleOnDiscard = useCallback(() => {
+    log({ action: "DataCollectionDialogDiscardClicked" });
+    onClose();
+  }, [onClose]);
 
   const rockRowData = dataSampleToTableRow(currentDataSample);
 
@@ -34,7 +44,7 @@ export const DataCollectionDialog: React.FC<IProps> = ({ currentDataSample, onCl
   return (
     <DraggableDialog
       title="Selected Data"
-      onClose={onClose}
+      onClose={handleOnDiscard}
       backdrop={false}
       initialPosition={{ vertical: "top", horizontal: "center" }}
     >
@@ -64,8 +74,8 @@ export const DataCollectionDialog: React.FC<IProps> = ({ currentDataSample, onCl
           <textarea placeholder="Add notes…" value={currentDataSample.notes} onChange={handleNotesChange} />
         }
         <DialogActions>
-          <DialogButton className={css.dialogButton} onClick={onClose}>Discard</DialogButton>
-          <DialogButton className={css.dialogButton} onClick={onSubmit}><CheckIcon /> Submit</DialogButton>
+          <DialogButton className={css.dialogButton} onClick={handleOnDiscard}>Discard</DialogButton>
+          <DialogButton className={css.dialogButton} onClick={handleOnSubmit}><CheckIcon /> Submit</DialogButton>
         </DialogActions>
       </div>
     </DraggableDialog>

--- a/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/data-collection-dialog.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { toJS } from "mobx";
 import { DialogButton, DraggableDialog } from "./draggable-dialog";
 import { DialogActions } from "@mui/material";
 import { dataSampleColumnLabel, dataSampleToTableRow, DataSampleColumnName, getSortedColumns } from "@concord-consortium/tecrock-shared";
@@ -24,7 +25,9 @@ export const DataCollectionDialog: React.FC<IProps> = ({ currentDataSample, onCl
   }, [onNotesChange]);
 
   const handleOnSubmit = useCallback(() => {
-    log({ action: "DataCollectionDialogSubmitClicked", data: currentDataSample });
+    // toJS is necessary, as otherwise postMessage throws an error that it can't clone the object.
+    // Apparently, MobX observable objects are not cloneable.
+    log({ action: "DataCollectionDialogSubmitClicked", data: toJS(currentDataSample) });
     onSubmit();
   }, [onSubmit, currentDataSample]);
 

--- a/packages/tectonic-explorer/js/components/data-saving-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/data-saving-dialog.tsx
@@ -1,32 +1,71 @@
-import * as React from "react";
-import { DraggableDialog } from "./draggable-dialog";
+import React, { useState } from "react";
+import { DialogActions } from "@mui/material";
+import { DialogButton, DraggableDialog } from "./draggable-dialog";
 import ProgressBar from "react-toolbox/lib/progress_bar";
+import CheckIcon from "../../images/check-icon.svg";
+import { log } from "../log";
 
 import css from "../../css-modules/data-saving-dialog.less";
 
 interface IProps {
-  onClose: () => void;
+  onContinue: () => void;
+  onSaveAndExit: () => void;
   dataSavingInProgress: boolean;
 }
 
-export const DataSavingDialog = ({ onClose, dataSavingInProgress }: IProps) => {
-  const dataSavingMsg = (
+const QuestionContent: React.FC<Pick<IProps, "onContinue" | "onSaveAndExit">> = ({ onContinue, onSaveAndExit }) => {
+  return (
     <>
-      <ProgressBar type="circular" mode="indeterminate" multicolor />
-      <p>Please wait while data is being saved...</p>
+      <p>
+        Are you finished collecting data? If you are finished placing pins, click Save & Exit.
+        Your data will be saved in the table, you will exit data collection mode, and your pins will be removed.
+      </p>
+      <p>If you are not finished collecting data, click Continue.</p>
+      <DialogActions>
+        <DialogButton className={css.dialogButton} onClick={onContinue}>Continue</DialogButton>
+        <DialogButton className={css.dialogButton} onClick={onSaveAndExit}><CheckIcon /> Save & Exit</DialogButton>
+      </DialogActions>
     </>
   );
-  const dataSavedMsg = <p>Your data has been saved to the table below. Your pins will now be removed.</p>;
+};
+
+const DataSavingContent: React.FC = () => {
+  return (
+    <div className={css.dataSavingMessage}>
+      <ProgressBar type="circular" mode="indeterminate" multicolor />
+      <p>Please wait while data is being saved...</p>
+    </div>
+  );
+};
+
+export const DataSavingDialog: React.FC<IProps> = (props) => {
+  const { dataSavingInProgress, onContinue, onSaveAndExit } = props;
+  const [saveAndExitClicked, setSaveAndExitClicked] = useState(false);
+
+  const handleContinue = () => {
+    log({ action: "ExitDataCollectionDialogContinueClicked" });
+    onContinue();
+  };
+
+  const handleSaveAndExit = () => {
+    setSaveAndExitClicked(true);
+    log({ action: "ExitDataCollectionDialogSaveAndExitClicked" });
+    onSaveAndExit();
+  };
+
   return (
     <DraggableDialog
-      title={dataSavingInProgress ? "Data Saving..." : "Data Saved"}
-      // Users can't close the dialog while data is being saved.
-      onClose={dataSavingInProgress ? undefined : onClose}
+      title="Exit Data Collection Mode"
+      onClose={undefined}
       backdrop={true}
-      initialPosition={{ vertical: "center", horizontal: "center" }}
+      initialPosition={{ vertical: "top", horizontal: "center" }}
     >
       <div className={css.dataSavingDialogContent}>
-        { dataSavingInProgress ? dataSavingMsg : dataSavedMsg }
+        {
+          dataSavingInProgress && saveAndExitClicked ?
+          <DataSavingContent /> :
+          <QuestionContent onContinue={handleContinue} onSaveAndExit={handleSaveAndExit} />
+        }
       </div>
     </DraggableDialog>
   );

--- a/packages/tectonic-explorer/js/components/exit-data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/exit-data-collection-dialog.tsx
@@ -5,7 +5,7 @@ import ProgressBar from "react-toolbox/lib/progress_bar";
 import CheckIcon from "../../images/check-icon.svg";
 import { log } from "../log";
 
-import css from "../../css-modules/data-saving-dialog.less";
+import css from "../../css-modules/exit-data-collection-dialog.less";
 
 interface IProps {
   onContinue: () => void;
@@ -38,7 +38,7 @@ const DataSavingContent: React.FC = () => {
   );
 };
 
-export const DataSavingDialog: React.FC<IProps> = (props) => {
+export const ExitDataCollectionDialog: React.FC<IProps> = (props) => {
   const { dataSavingInProgress, onContinue, onSaveAndExit } = props;
   const [saveAndExitClicked, setSaveAndExitClicked] = useState(false);
 
@@ -60,7 +60,7 @@ export const DataSavingDialog: React.FC<IProps> = (props) => {
       backdrop={true}
       initialPosition={{ vertical: "top", horizontal: "center" }}
     >
-      <div className={css.dataSavingDialogContent}>
+      <div className={css.exitDataCollectionDialogContent}>
         {
           dataSavingInProgress && saveAndExitClicked ?
           <DataSavingContent /> :

--- a/packages/tectonic-explorer/js/components/simulation.tsx
+++ b/packages/tectonic-explorer/js/components/simulation.tsx
@@ -12,7 +12,6 @@ import SplashScreen from "./splash-screen";
 import config from "../config";
 import { enableShutterbug, disableShutterbug } from "../shutterbug-support";
 import { BaseComponent, IBaseProps } from "./base";
-import { BoundaryType } from "../types";
 import { SideContainer } from "./side-container";
 import { TempPressureOverlay } from "./temp-pressure-overlay";
 import { RelativeMotionStoppedDialog } from "./relative-motion-stopped-dialog";
@@ -73,38 +72,6 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
     return plate?.hue;
   };
 
-  handleBoundaryAssign = (type: BoundaryType) => {
-    this.simulationStore.setSelectedBoundaryType(type);
-  };
-
-  handleBoundaryDialogClose = () => {
-    this.simulationStore.clearSelectedBoundary();
-  };
-
-  handleRelativeMotionDialogClose = () => {
-    this.simulationStore.closeRelativeMotionDialog();
-  };
-
-  handleExitDataCollectionDialogContinue = () => {
-    this.simulationStore.exitDataCollectionDialogContinue();
-  };
-
-  handleExitDataCollectionDialogSaveAndExit = () => {
-    this.simulationStore.exitDataCollectionDialogSaveAndExit();
-  };
-
-  handleDataCollectionDialogClose = () => {
-    this.simulationStore.clearCurrentDataSample();
-  };
-
-  handleDataCollectionSubmit = () => {
-    this.simulationStore.submitCurrentDataSample();
-  };
-
-  handleDataSampleNotesChange = (notes: string) => {
-    this.simulationStore.setCurrentDataSampleNotes(notes);
-  };
-
   render() {
     const {
       planetWizard, modelState, savingModel, selectedBoundary, interaction, relativeMotionStoppedDialogVisible,
@@ -144,18 +111,18 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
           selectedBoundary &&
           <BoundaryConfigDialog
             boundary={selectedBoundary} offset={this.getDialogOffset()} getPlateHue={this.getPlateHue}
-            onAssign={this.handleBoundaryAssign} onClose={this.handleBoundaryDialogClose}
+            onAssign={this.simulationStore.setSelectedBoundaryType} onClose={this.simulationStore.clearSelectedBoundary}
           />
         }
         {
           relativeMotionStoppedDialogVisible &&
-          <RelativeMotionStoppedDialog onClose={this.handleRelativeMotionDialogClose} />
+          <RelativeMotionStoppedDialog onClose={this.simulationStore.closeRelativeMotionDialog} />
         }
         {
           exitDataCollectionDialogVisible &&
           <ExitDataCollectionDialog
-            onContinue={this.handleExitDataCollectionDialogContinue}
-            onSaveAndExit={this.handleExitDataCollectionDialogSaveAndExit}
+            onContinue={this.simulationStore.exitDataCollectionDialogContinue}
+            onSaveAndExit={this.simulationStore.exitDataCollectionDialogSaveAndExit}
             dataSavingInProgress={dataSavingInProgress}
           />
         }
@@ -163,9 +130,9 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
           currentDataSample &&
           <DataCollectionDialog
             currentDataSample={currentDataSample}
-            onNotesChange={this.handleDataSampleNotesChange}
-            onSubmit={this.handleDataCollectionSubmit}
-            onClose={this.handleDataCollectionDialogClose}
+            onNotesChange={this.simulationStore.setCurrentDataSampleNotes}
+            onSubmit={this.simulationStore.submitCurrentDataSample}
+            onClose={this.simulationStore.clearCurrentDataSample}
           />
         }
       </div>

--- a/packages/tectonic-explorer/js/components/simulation.tsx
+++ b/packages/tectonic-explorer/js/components/simulation.tsx
@@ -17,7 +17,7 @@ import { SideContainer } from "./side-container";
 import { TempPressureOverlay } from "./temp-pressure-overlay";
 import { RelativeMotionStoppedDialog } from "./relative-motion-stopped-dialog";
 import { DataCollectionDialog } from "./data-collection-dialog";
-import { DataSavingDialog } from "./data-saving-dialog";
+import { ExitDataCollectionDialog } from "./exit-data-collection-dialog";
 
 import "../../css/simulation.less";
 import "../../css/react-toolbox-theme.less";
@@ -85,12 +85,12 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
     this.simulationStore.closeRelativeMotionDialog();
   };
 
-  handleDataSavingDialogContinue = () => {
-    this.simulationStore.dataSavingDialogContinue();
+  handleExitDataCollectionDialogContinue = () => {
+    this.simulationStore.exitDataCollectionDialogContinue();
   };
 
-  handleDataSavingDialogSaveAndExit = () => {
-    this.simulationStore.dataSavingDialogSaveAndExit();
+  handleExitDataCollectionDialogSaveAndExit = () => {
+    this.simulationStore.exitDataCollectionDialogSaveAndExit();
   };
 
   handleDataCollectionDialogClose = () => {
@@ -108,7 +108,7 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
   render() {
     const {
       planetWizard, modelState, savingModel, selectedBoundary, interaction, relativeMotionStoppedDialogVisible,
-      dataSavingDialogVisible, dataSavingInProgress, currentDataSample
+      exitDataCollectionDialogVisible, dataSavingInProgress, currentDataSample
     } = this.simulationStore;
     const isMeasuringTempPressure = interaction === "measureTempPressure";
     return (
@@ -152,10 +152,10 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
           <RelativeMotionStoppedDialog onClose={this.handleRelativeMotionDialogClose} />
         }
         {
-          dataSavingDialogVisible &&
-          <DataSavingDialog
-            onContinue={this.handleDataSavingDialogContinue}
-            onSaveAndExit={this.handleDataSavingDialogSaveAndExit}
+          exitDataCollectionDialogVisible &&
+          <ExitDataCollectionDialog
+            onContinue={this.handleExitDataCollectionDialogContinue}
+            onSaveAndExit={this.handleExitDataCollectionDialogSaveAndExit}
             dataSavingInProgress={dataSavingInProgress}
           />
         }

--- a/packages/tectonic-explorer/js/components/simulation.tsx
+++ b/packages/tectonic-explorer/js/components/simulation.tsx
@@ -85,8 +85,12 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
     this.simulationStore.closeRelativeMotionDialog();
   };
 
-  handleDataSavingDialogClose = () => {
-    this.simulationStore.closeDataSavingDialog();
+  handleDataSavingDialogContinue = () => {
+    this.simulationStore.dataSavingDialogContinue();
+  };
+
+  handleDataSavingDialogSaveAndExit = () => {
+    this.simulationStore.dataSavingDialogSaveAndExit();
   };
 
   handleDataCollectionDialogClose = () => {
@@ -149,7 +153,11 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
         }
         {
           dataSavingDialogVisible &&
-          <DataSavingDialog onClose={this.handleDataSavingDialogClose} dataSavingInProgress={dataSavingInProgress} />
+          <DataSavingDialog
+            onContinue={this.handleDataSavingDialogContinue}
+            onSaveAndExit={this.handleDataSavingDialogSaveAndExit}
+            dataSavingInProgress={dataSavingInProgress}
+          />
         }
         {
           currentDataSample &&

--- a/packages/tectonic-explorer/js/log.ts
+++ b/packages/tectonic-explorer/js/log.ts
@@ -2,7 +2,7 @@ import { log as laraLog } from "@concord-consortium/lara-interactive-api";
 import { Colormap } from "./config";
 import { ICrossSectionInteractionName } from "./plates-interactions/cross-section-interactions-manager";
 import { IGlobeInteractionName } from "./plates-interactions/globe-interactions-manager";
-import { BoundaryType, RockKeyLabel, TabName } from "./types";
+import { BoundaryType, IDataSample, RockKeyLabel, TabName } from "./types";
 
 type SimulationStarted =  { action: "SimulationStarted", data?: undefined };
 type SimulationStopped = { action: "SimulationStopped", data?: undefined };
@@ -22,11 +22,15 @@ type MeasureTempPressureEnabled = { action: "MeasureTempPressureEnabled", data?:
 type MeasureTempPressureDisabled = { action: "MeasureTempPressureDisabled", data?: undefined };
 type RockPickerEnabled = { action: "RockPickerEnabled", data?: undefined };
 type RockPickerDisabled = { action: "RockPickerDisabled", data?: undefined };
+// Data collection events
 type DataCollectionEnabled = { action: "DataCollectionEnabled", data?: undefined };
 type DataCollectionDisabled = { action: "DataCollectionDisabled", data?: undefined };
 type ExitDataCollectionDialogOpened = { action: "ExitDataCollectionDialogOpened", data?: undefined };
 type ExitDataCollectionDialogContinueClicked = { action: "ExitDataCollectionDialogContinueClicked", data?: undefined };
 type ExitDataCollectionDialogSaveAndExitClicked = { action: "ExitDataCollectionDialogSaveAndExitClicked", data?: undefined };
+type DataCollectionDialogSubmitClicked = { action: "DataCollectionDialogSubmitClicked", data: IDataSample };
+type DataCollectionDialogDiscardClicked = { action: "DataCollectionDialogDiscardClicked", data?: undefined };
+type CrossSectionDataSamplePlaced = { action: "CrossSectionDataSamplePlaced", data: IDataSample };
 // InteractionUpdated does NOT include cross section drawing and rock picker tool that have separate log events
 // as they seem to be the most important.
 // IGlobeInteractionName: "force" | "fieldInfo" | "markField" | "assignBoundary" | "continentDrawing" | "continentErasing" | "none"
@@ -76,7 +80,8 @@ export type LogEvent = SimulationStarted | SimulationStopped | EarthquakesVisibl
   PlanetWizardNumberOfPlatesSelected | ContinentAdded | ContinentRemoved | BoundaryTypeSelected | PlateDensitiesUpdated |
   PlanetWizardNextButtonClicked | PlanetWizardBackButtonClicked | PlanetWizardFailedValidationContinueAnywayButtonClicked |
   PlanetWizardFailedValidationTryAgainButtonClicked | DataCollectionEnabled | DataCollectionDisabled | ExitDataCollectionDialogOpened |
-  ExitDataCollectionDialogContinueClicked | ExitDataCollectionDialogSaveAndExitClicked
+  ExitDataCollectionDialogContinueClicked | ExitDataCollectionDialogSaveAndExitClicked | DataCollectionDialogSubmitClicked |
+  DataCollectionDialogDiscardClicked | CrossSectionDataSamplePlaced
 ;
 
 export const log = (event: LogEvent) => {

--- a/packages/tectonic-explorer/js/log.ts
+++ b/packages/tectonic-explorer/js/log.ts
@@ -24,6 +24,9 @@ type RockPickerEnabled = { action: "RockPickerEnabled", data?: undefined };
 type RockPickerDisabled = { action: "RockPickerDisabled", data?: undefined };
 type DataCollectionEnabled = { action: "DataCollectionEnabled", data?: undefined };
 type DataCollectionDisabled = { action: "DataCollectionDisabled", data?: undefined };
+type ExitDataCollectionDialogOpened = { action: "ExitDataCollectionDialogOpened", data?: undefined };
+type ExitDataCollectionDialogContinueClicked = { action: "ExitDataCollectionDialogContinueClicked", data?: undefined };
+type ExitDataCollectionDialogSaveAndExitClicked = { action: "ExitDataCollectionDialogSaveAndExitClicked", data?: undefined };
 // InteractionUpdated does NOT include cross section drawing and rock picker tool that have separate log events
 // as they seem to be the most important.
 // IGlobeInteractionName: "force" | "fieldInfo" | "markField" | "assignBoundary" | "continentDrawing" | "continentErasing" | "none"
@@ -72,7 +75,8 @@ export type LogEvent = SimulationStarted | SimulationStopped | EarthquakesVisibl
   CrossSectionClosed | CrossSectionZoomInClicked | CrossSectionZoomOutClicked |
   PlanetWizardNumberOfPlatesSelected | ContinentAdded | ContinentRemoved | BoundaryTypeSelected | PlateDensitiesUpdated |
   PlanetWizardNextButtonClicked | PlanetWizardBackButtonClicked | PlanetWizardFailedValidationContinueAnywayButtonClicked |
-  PlanetWizardFailedValidationTryAgainButtonClicked | DataCollectionEnabled | DataCollectionDisabled
+  PlanetWizardFailedValidationTryAgainButtonClicked | DataCollectionEnabled | DataCollectionDisabled | ExitDataCollectionDialogOpened |
+  ExitDataCollectionDialogContinueClicked | ExitDataCollectionDialogSaveAndExitClicked
 ;
 
 export const log = (event: LogEvent) => {

--- a/packages/tectonic-explorer/js/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/js/stores/simulation-store.ts
@@ -750,7 +750,9 @@ export class SimulationStore {
       id: nextId,
       ...data
     };
-    log({ action: "CrossSectionDataSamplePlaced", data: this.currentDataSample });
+    // toJS is necessary, as otherwise postMessage throws an error that it can't clone the object.
+    // Apparently, MobX observable objects are not cloneable.
+    log({ action: "CrossSectionDataSamplePlaced", data: toJS(this.currentDataSample) });
   }
 
   @action.bound setCurrentDataSampleNotes(notes: string) {

--- a/packages/tectonic-explorer/js/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/js/stores/simulation-store.ts
@@ -85,7 +85,7 @@ export class SimulationStore {
   @observable lastStoredModel: string | null = null;
   @observable savingModel = false;
   @observable relativeMotionStoppedDialogVisible = false;
-  @observable dataSavingDialogVisible = false;
+  @observable exitDataCollectionDialogVisible = false;
   // Note that this value should never be serialized and restored. It uses client time, which is not guaranteed to be
   // correct. It's only used to determine whether we should discard the current snapshot response within current session.
   @observable lastSnapshotRequestTimestamp: number | null = null;
@@ -518,16 +518,16 @@ export class SimulationStore {
   }
 
   @action.bound showExitDataCollectionDialog() {
-    this.dataSavingDialogVisible = true;
+    this.exitDataCollectionDialogVisible = true;
   }
 
-  @action.bound dataSavingDialogContinue() {
-    this.dataSavingDialogVisible = false;
+  @action.bound exitDataCollectionDialogContinue() {
+    this.exitDataCollectionDialogVisible = false;
   }
 
-  @action.bound dataSavingDialogSaveAndExit() {
+  @action.bound exitDataCollectionDialogSaveAndExit() {
     const exitDataSavingMode = () => {
-      this.dataSavingDialogVisible = false;
+      this.exitDataCollectionDialogVisible = false;
       this.clearDataSamples();
       this.setInteraction("none");
     };

--- a/packages/tectonic-explorer/js/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/js/stores/simulation-store.ts
@@ -750,6 +750,7 @@ export class SimulationStore {
       id: nextId,
       ...data
     };
+    log({ action: "CrossSectionDataSamplePlaced", data: this.currentDataSample });
   }
 
   @action.bound setCurrentDataSampleNotes(notes: string) {


### PR DESCRIPTION
[[#184186037]](https://www.pivotaltracker.com/story/show/184186037)
[[#184230774]](https://www.pivotaltracker.com/story/show/184230774)

This PR changes what happens after user clicks "Collect Data" button to exit data collection mode. The expected workflow is described in the PT story: https://www.pivotaltracker.com/story/show/184186037

I've also added a new story that covers logging, as it seems it might be useful for the MVP and first tests with users.