### PR TITLE
TecRock table: let users expand snapshots in a lightbox

### DIFF
--- a/packages/tecrock-table/src/assets/zoom-in.svg
+++ b/packages/tecrock-table/src/assets/zoom-in.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <circle style="fill: none; stroke: white; stroke-width: 20px;" cx="80" cy="80" r="70"/>
+    <line style="stroke: white; stroke-linecap: round; stroke-width: 20px;" x1="80" y1="40" x2="80" y2="120"/>
+    <line style="stroke: white; stroke-linecap: round; stroke-width: 20px;" x1="40" y1="80" x2="120" y2="80"/>
+  </g>
+  <line style="stroke: white; stroke-width: 20px; stroke-linecap: round;" x1="130" y1="130" x2="190" y2="190"/>
+</svg>

--- a/packages/tecrock-table/src/components/runtime.scss
+++ b/packages/tecrock-table/src/components/runtime.scss
@@ -18,6 +18,7 @@
   .tableAndSnapshots {
     display: flex;
     flex-direction: row;
+    margin-top: 10px;
 
     .table {
       overflow-x: auto;
@@ -50,8 +51,25 @@
 
     .snapshots {
       max-width: 30%;
-      img {
+
+      .imgContainer {
+        position: relative;
         width: 100%;
+        margin-bottom: 5px;
+        cursor: pointer;
+
+        img {
+          width: 100%;
+        }
+
+        svg {
+          display: block;
+          position: absolute;
+          bottom: 3px;
+          right: 3px;
+          height: 30px;
+          pointer-events: none;
+        }
       }
     }
   }

--- a/packages/tectonic-explorer/css-modules/data-collection-dialog.less
+++ b/packages/tectonic-explorer/css-modules/data-collection-dialog.less
@@ -1,11 +1,12 @@
 .dataCollectionDialogContent {
   :global(.MuiDialogActions-root) {
-    padding: 10px 0 3px 0;
+    padding: 10px 0 0 0;
   }
 
   width: auto;
   font-size: 16px;
   overflow-x: auto;
+  padding: 5px;
 
   table {
     margin-top: 5px;

--- a/packages/tectonic-explorer/css-modules/exit-data-collection-dialog.less
+++ b/packages/tectonic-explorer/css-modules/exit-data-collection-dialog.less
@@ -1,10 +1,11 @@
 .exitDataCollectionDialogContent {
   :global(.MuiDialogActions-root) {
-    padding: 10px 0 3px 0;
+    padding: 10px 0 0 0;
   }
 
   width: 580px;
   font-size: 16px;
+  padding: 5px;
 
   p {
     margin-top: 6px;


### PR DESCRIPTION
[[#184186001]](https://www.pivotaltracker.com/story/show/184186001)

This PR lets user expand snapshots in a lightbox:
<img width="894" alt="Screenshot 2023-01-15 at 18 28 19" src="https://user-images.githubusercontent.com/767857/212556899-ca37688e-4793-42d7-a560-288c301396c1.png">

There are two separate buttons, as the current Interactive API `showModal({ type: "lightbox" })` accepts only one image URL. 

I could use  `showModal({ type: "dialog" })` and render an iframe with two images together, but this approach has some issues. AP dialog implementation is slightly broken and doesn't show the close icon and doesn't let the user close the dialog using backdrop (I've added a PT bug: https://www.pivotaltracker.com/story/show/184232312). Also, the dialog size won't match the image and there's not much we could do about it. It'd be also more code here. So, I'm trying this approach for now, as it's cleaner and lightbox UX is nicer for users.
