### PR TITLE
Replace native alert with custom dialog that asks for clearing previously saved data

### DIFF
--- a/packages/tectonic-explorer/css-modules/enter-data-collection-dialog.less
+++ b/packages/tectonic-explorer/css-modules/enter-data-collection-dialog.less
@@ -1,0 +1,13 @@
+.enterDataCollectionDialogContent {
+  :global(.MuiDialogActions-root) {
+    padding: 10px 0 0 0;
+  }
+
+  width: 580px;
+  font-size: 16px;
+  padding: 5px;
+
+  p {
+    margin-top: 6px;
+  }
+}

--- a/packages/tectonic-explorer/js/components/bottom-panel.tsx
+++ b/packages/tectonic-explorer/js/components/bottom-panel.tsx
@@ -130,9 +130,14 @@ export default class BottomPanel extends BaseComponent<IBaseProps, IState> {
 
   handleDataCollectionToggle = () => {
     if (this.simulationStore.interaction !== "collectData") {
-      // Turn on data collection mode.
-      this.simulationStore.setInteraction("collectData");
-      log({ action: "DataCollectionEnabled" });
+      if (this.simulationStore.interactiveState && this.simulationStore.interactiveState.dataSamples.length > 0) {
+        this.simulationStore.showEnterDataCollectionDialog();
+        log({ action: "EnterDataCollectionDialogOpened" });
+      } else {
+        // No previously saved data, turn on data collection mode immediately.
+        this.simulationStore.setInteraction("collectData");
+        log({ action: "DataCollectionEnabled" });
+      }
     } else {
       if (this.simulationStore.dataSamples.length > 0) {
         // Data samples exist, show exit data collection dialog.

--- a/packages/tectonic-explorer/js/components/enter-data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/js/components/enter-data-collection-dialog.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { DialogActions } from "@mui/material";
+import { DialogButton, DraggableDialog } from "./draggable-dialog";
+import { log } from "../log";
+
+import css from "../../css-modules/enter-data-collection-dialog.less";
+
+interface IProps {
+  onCancel: () => void;
+  onEraseAndStartOver: () => void;
+}
+
+export const EnterDataCollectionDialog: React.FC<IProps> = (props) => {
+  const { onCancel, onEraseAndStartOver } = props;
+
+  const handleCancel = () => {
+    log({ action: "EnterDataCollectionDialogCancelClicked" });
+    onCancel();
+  };
+
+  const handleSaveAndExit = () => {
+    log({ action: "EnterDataCollectionDialogEraseAndStartOverClicked" });
+    onEraseAndStartOver();
+  };
+
+  return (
+    <DraggableDialog
+      title="Data Collection Mode"
+      onClose={undefined}
+      backdrop={true}
+      initialPosition={{ vertical: "top", horizontal: "center" }}
+    >
+      <div className={css.enterDataCollectionDialogContent}>
+        <p>
+          Entering data collection mode again will erase previously saved samples.
+          If you are sure you want to do it, click Erase data & Start over.
+        </p>
+        <p>If you do not want to erase previous data, click Cancel.</p>
+        <DialogActions>
+          <DialogButton className={css.dialogButton} onClick={handleCancel}>Cancel</DialogButton>
+          <DialogButton className={css.dialogButton} onClick={handleSaveAndExit}>Erase previous data & Start over</DialogButton>
+        </DialogActions>
+      </div>
+    </DraggableDialog>
+  );
+};

--- a/packages/tectonic-explorer/js/components/simulation.tsx
+++ b/packages/tectonic-explorer/js/components/simulation.tsx
@@ -17,6 +17,7 @@ import { TempPressureOverlay } from "./temp-pressure-overlay";
 import { RelativeMotionStoppedDialog } from "./relative-motion-stopped-dialog";
 import { DataCollectionDialog } from "./data-collection-dialog";
 import { ExitDataCollectionDialog } from "./exit-data-collection-dialog";
+import { EnterDataCollectionDialog } from "./enter-data-collection-dialog";
 
 import "../../css/simulation.less";
 import "../../css/react-toolbox-theme.less";
@@ -75,7 +76,7 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
   render() {
     const {
       planetWizard, modelState, savingModel, selectedBoundary, interaction, relativeMotionStoppedDialogVisible,
-      exitDataCollectionDialogVisible, dataSavingInProgress, currentDataSample
+      exitDataCollectionDialogVisible, enterDataCollectionDialogVisible, dataSavingInProgress, currentDataSample
     } = this.simulationStore;
     const isMeasuringTempPressure = interaction === "measureTempPressure";
     return (
@@ -124,6 +125,13 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
             onContinue={this.simulationStore.exitDataCollectionDialogContinue}
             onSaveAndExit={this.simulationStore.exitDataCollectionDialogSaveAndExit}
             dataSavingInProgress={dataSavingInProgress}
+          />
+        }
+        {
+          enterDataCollectionDialogVisible &&
+          <EnterDataCollectionDialog
+            onCancel={this.simulationStore.enterDataCollectionDialogCancel}
+            onEraseAndStartOver={this.simulationStore.enterDataCollectionDialogEraseAndStartOver}
           />
         }
         {

--- a/packages/tectonic-explorer/js/log.ts
+++ b/packages/tectonic-explorer/js/log.ts
@@ -31,6 +31,9 @@ type ExitDataCollectionDialogSaveAndExitClicked = { action: "ExitDataCollectionD
 type DataCollectionDialogSubmitClicked = { action: "DataCollectionDialogSubmitClicked", data: IDataSample };
 type DataCollectionDialogDiscardClicked = { action: "DataCollectionDialogDiscardClicked", data?: undefined };
 type CrossSectionDataSamplePlaced = { action: "CrossSectionDataSamplePlaced", data: IDataSample };
+type EnterDataCollectionDialogOpened = { action: "EnterDataCollectionDialogOpened", data?: undefined };
+type EnterDataCollectionDialogCancelClicked = { action: "EnterDataCollectionDialogCancelClicked", data?: undefined };
+type EnterDataCollectionDialogEraseAndStartOverClicked = { action: "EnterDataCollectionDialogEraseAndStartOverClicked", data?: undefined };
 // InteractionUpdated does NOT include cross section drawing and rock picker tool that have separate log events
 // as they seem to be the most important.
 // IGlobeInteractionName: "force" | "fieldInfo" | "markField" | "assignBoundary" | "continentDrawing" | "continentErasing" | "none"
@@ -81,7 +84,8 @@ export type LogEvent = SimulationStarted | SimulationStopped | EarthquakesVisibl
   PlanetWizardNextButtonClicked | PlanetWizardBackButtonClicked | PlanetWizardFailedValidationContinueAnywayButtonClicked |
   PlanetWizardFailedValidationTryAgainButtonClicked | DataCollectionEnabled | DataCollectionDisabled | ExitDataCollectionDialogOpened |
   ExitDataCollectionDialogContinueClicked | ExitDataCollectionDialogSaveAndExitClicked | DataCollectionDialogSubmitClicked |
-  DataCollectionDialogDiscardClicked | CrossSectionDataSamplePlaced
+  DataCollectionDialogDiscardClicked | CrossSectionDataSamplePlaced | EnterDataCollectionDialogOpened | EnterDataCollectionDialogCancelClicked |
+  EnterDataCollectionDialogEraseAndStartOverClicked
 ;
 
 export const log = (event: LogEvent) => {

--- a/packages/tectonic-explorer/js/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/js/stores/simulation-store.ts
@@ -86,6 +86,7 @@ export class SimulationStore {
   @observable savingModel = false;
   @observable relativeMotionStoppedDialogVisible = false;
   @observable exitDataCollectionDialogVisible = false;
+  @observable enterDataCollectionDialogVisible = false;
   // Note that this value should never be serialized and restored. It uses client time, which is not guaranteed to be
   // correct. It's only used to determine whether we should discard the current snapshot response within current session.
   @observable lastSnapshotRequestTimestamp: number | null = null;
@@ -329,17 +330,7 @@ export class SimulationStore {
       this.playing = false;
     }
     if (interaction === "collectData") {
-      if (this.interactiveState && this.interactiveState.dataSamples.length > 0) {
-        if (!window.confirm("Entering data collection mode again will erase previously saved samples. Are you sure you want to do it?")) {
-          return;
-        }
-        this.clearDataSamples();
-        this.saveInteractiveState();
-      }
       this.playing = false;
-    }
-    if (this.interaction === "collectData" && interaction !== "collectData") {
-      this.clearCurrentDataSample();
     }
     this.interaction = interaction;
   }
@@ -537,6 +528,21 @@ export class SimulationStore {
     } else {
       exitDataSavingMode();
     }
+  }
+
+  @action.bound showEnterDataCollectionDialog() {
+    this.enterDataCollectionDialogVisible = true;
+  }
+
+  @action.bound enterDataCollectionDialogCancel() {
+    this.enterDataCollectionDialogVisible = false;
+  }
+
+  @action.bound enterDataCollectionDialogEraseAndStartOver() {
+    this.clearDataSamples();
+    this.saveInteractiveState();
+    this.enterDataCollectionDialogVisible = false;
+    this.setInteraction("collectData");
   }
 
   @action.bound unloadModel() {


### PR DESCRIPTION
[[#184232569]](https://www.pivotaltracker.com/story/show/184232569)

This PR replaces the native browser confirm dialog with a custom one that is consistent with other dialogs that we use in data collection mode. It also adds a few log messages.