### PR TITLE
Update serialized state version, add v4 to v5 migration

### DIFF
--- a/packages/tectonic-explorer/src/state-migrations.ts
+++ b/packages/tectonic-explorer/src/state-migrations.ts
@@ -1,3 +1,4 @@
+import * as THREE from "three";
 // Converts state JSON created using an old version of the app to the most recent one.
 // Ensures that the app is backward compatible.
 
@@ -40,9 +41,9 @@ function convertVer1toVer2(stateVer1: any) {
   return newState;
 }
 
-function convertVer2toVer3(stateVer1: any) {
+function convertVer2toVer3(stateVer2: any) {
   console.time("[migrations] state migration: v2 -> v3");
-  const model = JSON.parse(stateVer1.modelState);
+  const model = JSON.parse(stateVer2.modelState);
   model.plates.forEach((plate: any) => {
     plate.quaternion = plate.quaternion.array;
     plate.angularVelocity = plate.angularVelocity.array;
@@ -51,7 +52,7 @@ function convertVer2toVer3(stateVer1: any) {
     plate.hotSpot.force = plate.hotSpot.force.array;
     plate.hotSpot.position = plate.hotSpot.position.array;
   });
-  const newState = stateVer1;
+  const newState = stateVer2;
   newState.version = 3;
   newState.modelState = JSON.stringify(model);
   console.timeEnd("[migrations] state migration: v2 -> v3");
@@ -61,10 +62,26 @@ function convertVer2toVer3(stateVer1: any) {
 // state version 3
 function convertVer3toVer4(stateVer3: any) {
   // It's not possible to load a state saved in Tectonic Explorer V1.x in Tectonic Explorer V2.x.
-  // Version 2.x is not backward compatible with version 1.x. There are multiple new features that cannot be restored 
+  // Version 2.x is not backward compatible with version 1.x. There are multiple new features that cannot be restored
   // from an old state format. Simply redirect to the last 1.x version.
   window.location.replace(LATEST_V1_URL + window.location.search);
   return "incompatibleModel";
+}
+
+// missing momentOfInertia property, it can be calculated from invMomentOfInertia
+function convertVer4toVer5(stateVer4: any) {
+  console.time("[migrations] state migration: v4 -> v5");
+  const model = JSON.parse(stateVer4.modelState);
+  model.plates.forEach((plate: any) => {
+    const momentOfInertia = (new THREE.Matrix3()).fromArray(plate.invMomentOfInertia);
+    momentOfInertia.invert();
+    plate.momentOfInertia = momentOfInertia.toArray();
+  });
+  const newState = stateVer4;
+  newState.version = 5;
+  newState.modelState = JSON.stringify(model);
+  console.timeEnd("[migrations] state migration: v4 -> v5");
+  return newState;
 }
 
 const migrations: Record<number, (state: any) => any> = {
@@ -72,6 +89,7 @@ const migrations: Record<number, (state: any) => any> = {
   1: convertVer1toVer2,
   2: convertVer2toVer3,
   3: convertVer3toVer4,
+  4: convertVer4toVer5,
   // In the future (in case of need):
   // 3: convertVer3toVer4
   // etc.

--- a/packages/tectonic-explorer/src/stores/simulation-store.ts
+++ b/packages/tectonic-explorer/src/stores/simulation-store.ts
@@ -28,7 +28,7 @@ import { log } from "../log";
 import { takeCrossSectionSnapshot, takePlanetViewSnapshot } from "../shutterbug-support";
 
 export interface ISerializedState {
-  version: 4;
+  version: 5;
   appState: ISerializedAppState;
   modelState: ISerializedModel;
 }
@@ -492,7 +492,7 @@ export class SimulationStore {
   @action.bound saveStateToCloud(modelState: ISerializedModel) {
     this.savingModel = true;
     const data: ISerializedState = {
-      version: 4,
+      version: 5,
       appState: this.serializableAppState,
       modelState
     };


### PR DESCRIPTION
[[#184421894]](https://www.pivotaltracker.com/story/show/184421894)

More context: https://concord-consortium.slack.com/archives/C01F450JVE1/p1675707376900469 

Trudi noticed that TE interactives that load serialized models don't work anymore. I accidentally made TE v2.5.0 not backward compatible with v2.4.1. This was not necessary. This PR updates the version number of the serialized state and adds automatic migration.