### PR TITLE
Display placeholder graphic when data is cleared. (PT-185002145)

### DIFF
--- a/packages/tecrock-table/src/components/runtime.tsx
+++ b/packages/tecrock-table/src/components/runtime.tsx
@@ -75,7 +75,7 @@ export const Runtime: React.FC<IProps> = ({ authoredState, interactiveState, set
       }
       {
         // Render placeholder image if there are no data samples.
-        !dataSamples &&
+        (!dataSamples || !dataSamples.length) &&
         <div className={css.placeholder}>
           <img src={Prompt}/>
         </div>


### PR DESCRIPTION
Before, placeholder graphic was only displaying when the dataSamples array was not defined, which led to the graphic not displaying when collection data was cleared. Now, display the graphic when array is defined but has no length.