### PR TITLE
 Data collection dialog boxes viewable when in Chromebook. (PT-185002507)

### DIFF
--- a/packages/tectonic-explorer/src/components/data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/src/components/data-collection-dialog.tsx
@@ -3,7 +3,7 @@ import { toJS } from "mobx";
 import { DialogButton, DraggableDialog } from "./draggable-dialog";
 import { DialogActions } from "@mui/material";
 import { dataSampleColumnLabel, dataSampleToTableRow, DataSampleColumnName, getSortedColumns } from "@concord-consortium/tecrock-shared";
-import { DATA_COLLECTION_YOFFSET, IDataSample } from "../types";
+import { IDataSample } from "../types";
 import { log } from "../log";
 import config from "../config";
 import CheckIcon from "../assets/check-icon.svg";
@@ -16,10 +16,11 @@ interface IProps {
   onNotesChange: (notes: string) => void;
   currentDataSample: IDataSample;
   lastDataSample: boolean;
+  yOffset: number;
 }
 
 // patterned after https://mui.com/components/dialogs/#draggable-dialog
-export const DataCollectionDialog: React.FC<IProps> = ({ currentDataSample, lastDataSample, onClose, onSubmit, onNotesChange, }) => {
+export const DataCollectionDialog: React.FC<IProps> = ({ currentDataSample, lastDataSample, onClose, onSubmit, onNotesChange, yOffset}) => {
 
   const handleNotesChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onNotesChange(event.target.value);
@@ -50,7 +51,7 @@ export const DataCollectionDialog: React.FC<IProps> = ({ currentDataSample, last
       title="Selected Data"
       onClose={handleOnDiscard}
       backdrop={false}
-      offset={{x: 0, y: DATA_COLLECTION_YOFFSET }}
+      offset={{x: 0, y: yOffset}}
       initialPosition={{ vertical: "bottom", horizontal: "center" }}
     >
       <div className={css.dataCollectionDialogContent}>

--- a/packages/tectonic-explorer/src/components/enter-data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/src/components/enter-data-collection-dialog.tsx
@@ -4,15 +4,15 @@ import { DialogButton, DraggableDialog } from "./draggable-dialog";
 import { log } from "../log";
 
 import css from "./enter-data-collection-dialog.scss";
-import { DATA_COLLECTION_YOFFSET } from "../types";
 
 interface IProps {
   onCancel: () => void;
   onEraseAndStartOver: () => void;
+  yOffset: number;
 }
 
 export const EnterDataCollectionDialog: React.FC<IProps> = (props) => {
-  const { onCancel, onEraseAndStartOver } = props;
+  const { onCancel, onEraseAndStartOver, yOffset } = props;
 
   const handleCancel = () => {
     log({ action: "EnterDataCollectionDialogCancelClicked" });
@@ -29,7 +29,7 @@ export const EnterDataCollectionDialog: React.FC<IProps> = (props) => {
       title="Data Collection Mode"
       onClose={undefined}
       backdrop={true}
-      offset={{x: 0, y: DATA_COLLECTION_YOFFSET }}
+      offset={{x: 0, y: yOffset}}
       initialPosition={{ vertical: "bottom", horizontal: "center" }}
     >
       <div className={css.enterDataCollectionDialogContent}>

--- a/packages/tectonic-explorer/src/components/exit-data-collection-dialog.tsx
+++ b/packages/tectonic-explorer/src/components/exit-data-collection-dialog.tsx
@@ -6,12 +6,12 @@ import CheckIcon from "../assets/check-icon.svg";
 import { log } from "../log";
 
 import css from "./exit-data-collection-dialog.scss";
-import { DATA_COLLECTION_YOFFSET } from "../types";
 
 interface IProps {
   onContinue: () => void;
   onSaveAndExit: () => void;
   dataSavingInProgress: boolean;
+  yOffset: number;
 }
 
 const QuestionContent: React.FC<Pick<IProps, "onContinue" | "onSaveAndExit">> = ({ onContinue, onSaveAndExit }) => {
@@ -40,7 +40,7 @@ const DataSavingContent: React.FC = () => {
 };
 
 export const ExitDataCollectionDialog: React.FC<IProps> = (props) => {
-  const { dataSavingInProgress, onContinue, onSaveAndExit } = props;
+  const { dataSavingInProgress, onContinue, onSaveAndExit, yOffset } = props;
   const [saveAndExitClicked, setSaveAndExitClicked] = useState(false);
 
   const handleContinue = () => {
@@ -59,7 +59,7 @@ export const ExitDataCollectionDialog: React.FC<IProps> = (props) => {
       title="Exit Data Collection Mode"
       onClose={undefined}
       backdrop={true}
-      offset={{x: 0, y: DATA_COLLECTION_YOFFSET}}
+      offset={{x: 0, y: yOffset}}
       initialPosition={{ vertical: "bottom", horizontal: "center" }}
     >
       <div className={css.exitDataCollectionDialogContent}>

--- a/packages/tectonic-explorer/src/types.ts
+++ b/packages/tectonic-explorer/src/types.ts
@@ -37,5 +37,3 @@ export const DEFAULT_CROSS_SECTION_CAMERA_ZOOM = 1;
 export const MIN_CAMERA_ZOOM = 0.8;
 export const MAX_CAMERA_ZOOM = 4.0;
 export const CAMERA_ZOOM_STEP = 0.1;
-
-export const DATA_COLLECTION_YOFFSET = -350-45;


### PR DESCRIPTION
This PR addresses the following issues in [this story](https://www.pivotaltracker.com/story/show/185002507):
- Shows full data collection dialog box when sim is viewed in Chromebook (even if it covers cross-section) 
- If not in Chromebook, data collection dialog boxes are pinned to top of the cross-section