### PR TITLE
Update ThreeJS to r160

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33937,9 +33937,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.151.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.151.0.tgz",
-      "integrity": "sha512-ZvjJbNhZ/t0L8I36tc1I1ZP9j1q42ANE9WTlR+P3lZfOzlSfNa5VfR1rZRHNyjn/ZPP4kU7xGI1v8QSJOpxE4w=="
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng=="
     },
     "node_modules/throat": {
       "version": "5.0.0",
@@ -38208,7 +38208,7 @@
         "screenfull": "^6.0.2",
         "seedrandom": "^3.0.5",
         "shutterbug": "^1.5.0",
-        "three": "0.151.0",
+        "three": "^0.160.0",
         "timeseries-analysis": "^1.0.12",
         "uuid": "^9.0.0"
       },
@@ -66356,7 +66356,7 @@
         "seedrandom": "^3.0.5",
         "shutterbug": "^1.5.0",
         "style-loader": "^3.3.1",
-        "three": "0.151.0",
+        "three": "^0.160.0",
         "timeseries-analysis": "^1.0.12",
         "ts-jest": "^29.0.3",
         "ts-loader": "^9.4.1",
@@ -66449,9 +66449,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.151.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.151.0.tgz",
-      "integrity": "sha512-ZvjJbNhZ/t0L8I36tc1I1ZP9j1q42ANE9WTlR+P3lZfOzlSfNa5VfR1rZRHNyjn/ZPP4kU7xGI1v8QSJOpxE4w=="
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng=="
     },
     "throat": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11042,6 +11042,12 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.3.tgz",
+      "integrity": "sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ==",
+      "dev": true
+    },
     "node_modules/@types/tapable": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
@@ -11058,12 +11064,15 @@
       }
     },
     "node_modules/@types/three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==",
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w==",
       "dev": true,
       "dependencies": {
-        "@types/webxr": "*"
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.6.10",
+        "meshoptimizer": "~0.18.1"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -17822,6 +17831,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "dev": true
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -25593,6 +25608,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -38230,7 +38251,7 @@
         "@types/react-tabs": "^5.0.5",
         "@types/react-transition-group": "^4.4.5",
         "@types/seedrandom": "^3.0.2",
-        "@types/three": "^0.146.0",
+        "@types/three": "^0.160.0",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -46943,6 +46964,12 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/stats.js": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.3.tgz",
+      "integrity": "sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ==",
+      "dev": true
+    },
     "@types/tapable": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
@@ -46959,12 +46986,15 @@
       }
     },
     "@types/three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==",
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w==",
       "dev": true,
       "requires": {
-        "@types/webxr": "*"
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.6.10",
+        "meshoptimizer": "~0.18.1"
       }
     },
     "@types/tough-cookie": {
@@ -52159,6 +52189,12 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "dev": true
     },
     "figures": {
       "version": "3.2.0",
@@ -58153,6 +58189,12 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
       "dev": true
     },
     "methods": {
@@ -66301,7 +66343,7 @@
         "@types/react-tabs": "^5.0.5",
         "@types/react-transition-group": "^4.4.5",
         "@types/seedrandom": "^3.0.2",
-        "@types/three": "^0.146.0",
+        "@types/three": "^0.160.0",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33937,9 +33937,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A=="
+      "version": "0.151.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.151.0.tgz",
+      "integrity": "sha512-ZvjJbNhZ/t0L8I36tc1I1ZP9j1q42ANE9WTlR+P3lZfOzlSfNa5VfR1rZRHNyjn/ZPP4kU7xGI1v8QSJOpxE4w=="
     },
     "node_modules/throat": {
       "version": "5.0.0",
@@ -38208,7 +38208,7 @@
         "screenfull": "^6.0.2",
         "seedrandom": "^3.0.5",
         "shutterbug": "^1.5.0",
-        "three": "^0.146.0",
+        "three": "0.151.0",
         "timeseries-analysis": "^1.0.12",
         "uuid": "^9.0.0"
       },
@@ -66356,7 +66356,7 @@
         "seedrandom": "^3.0.5",
         "shutterbug": "^1.5.0",
         "style-loader": "^3.3.1",
-        "three": "^0.146.0",
+        "three": "0.151.0",
         "timeseries-analysis": "^1.0.12",
         "ts-jest": "^29.0.3",
         "ts-loader": "^9.4.1",
@@ -66449,9 +66449,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A=="
+      "version": "0.151.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.151.0.tgz",
+      "integrity": "sha512-ZvjJbNhZ/t0L8I36tc1I1ZP9j1q42ANE9WTlR+P3lZfOzlSfNa5VfR1rZRHNyjn/ZPP4kU7xGI1v8QSJOpxE4w=="
     },
     "throat": {
       "version": "5.0.0",

--- a/packages/tectonic-explorer/package.json
+++ b/packages/tectonic-explorer/package.json
@@ -73,7 +73,7 @@
     "screenfull": "^6.0.2",
     "seedrandom": "^3.0.5",
     "shutterbug": "^1.5.0",
-    "three": "0.151.0",
+    "three": "^0.160.0",
     "timeseries-analysis": "^1.0.12",
     "uuid": "^9.0.0"
   },

--- a/packages/tectonic-explorer/package.json
+++ b/packages/tectonic-explorer/package.json
@@ -73,7 +73,7 @@
     "screenfull": "^6.0.2",
     "seedrandom": "^3.0.5",
     "shutterbug": "^1.5.0",
-    "three": "^0.146.0",
+    "three": "0.151.0",
     "timeseries-analysis": "^1.0.12",
     "uuid": "^9.0.0"
   },

--- a/packages/tectonic-explorer/package.json
+++ b/packages/tectonic-explorer/package.json
@@ -95,7 +95,7 @@
     "@types/react-tabs": "^5.0.5",
     "@types/react-transition-group": "^4.4.5",
     "@types/seedrandom": "^3.0.2",
-    "@types/three": "^0.146.0",
+    "@types/three": "^0.160.0",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",

--- a/packages/tectonic-explorer/src/components/simulation.tsx
+++ b/packages/tectonic-explorer/src/components/simulation.tsx
@@ -84,7 +84,8 @@ export default class Simulation extends BaseComponent<IBaseProps, IState> {
     const {
       planetWizard, modelState, savingModel, selectedBoundary, interaction, relativeMotionStoppedDialogVisible,
       exitDataCollectionDialogVisible, enterDataCollectionDialogVisible, onLastPin, dataSavingInProgress,
-      currentDataSample} = this.simulationStore;
+      currentDataSample
+    } = this.simulationStore;
     const isMeasuringTempPressure = interaction === "measureTempPressure";
     return (
       <div className={APP_CLASS_NAME} ref={this.appRef} >

--- a/packages/tectonic-explorer/src/peels/sphere/int-arr.ts
+++ b/packages/tectonic-explorer/src/peels/sphere/int-arr.ts
@@ -33,8 +33,7 @@ function _smallestIntArr(max: number, size: number) {
   if (max <= uint16Max) return new Uint16Array(size);
   if (max <= uint32Max) return new Uint32Array(size);
 
-  console.warn("Indices are too large for a typed array buffer.");
-  return new Array(size);
+  throw new Error("Indices are too large for a typed array buffer.");
 }
 
 export default _smallestIntArr;

--- a/packages/tectonic-explorer/src/peels/sphere/to-cg.ts
+++ b/packages/tectonic-explorer/src/peels/sphere/to-cg.ts
@@ -35,7 +35,7 @@ interface IOptions {
 interface IAttributesResult {
   positions: Float32Array;
   normals: Float32Array;
-  indices: Uint16Array | Uint32Array | Array<number>;
+  indices: Uint16Array | Uint32Array;
   colors: Float32Array;
   uvs: Float32Array;
 }

--- a/packages/tectonic-explorer/src/plates-interactions/helpers.ts
+++ b/packages/tectonic-explorer/src/plates-interactions/helpers.ts
@@ -1,4 +1,5 @@
 import $ from "jquery";
+import * as THREE from "three";
 import RockSampleCursorSrc from "../assets/rock-sample-cursor.png";
 import TempPressureCursorPng from "../assets/temp-pressure-cursor.png";
 import CollectDataCursorPng from "../assets/collect-data-cursor.png";
@@ -32,7 +33,7 @@ export function mousePos(event: any, targetElement: any) {
     x = event.touches[0].pageX;
     y = event.touches[0].pageY;
   }
-  return { x: x - parentX, y: y - parentY };
+  return new THREE.Vector2(x - parentX, y - parentY);
 }
 
 // Normalized mouse position [-1, 1].

--- a/packages/tectonic-explorer/src/plates-view/cross-section-3d.ts
+++ b/packages/tectonic-explorer/src/plates-view/cross-section-3d.ts
@@ -16,7 +16,7 @@ interface IDataSamples {
 
 const HORIZONTAL_MARGIN = 200; // px
 const VERTICAL_MARGIN = 80; // px
-const SHADING_STRENGTH = 0.8;
+const LIGHT_STRENGTH = 3.4;
 const POINT_SIZE = 40; // px
 const POINT_PADDING = 9; // px
 const CAMERA_VERT_ANGLE = Math.PI * 0.483; // radians
@@ -50,6 +50,7 @@ function getPointTexture(label: string) {
   ctx.textBaseline = "middle";
   ctx.fillText(label, size / 2, size / 2);
   const texture = new THREE.Texture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
   texture.needsUpdate = true;
   return texture;
 }
@@ -296,12 +297,11 @@ export default class CrossSection3D {
     this.controls.minPolarAngle = CAMERA_VERT_ANGLE;
     this.controls.maxPolarAngle = CAMERA_VERT_ANGLE;
 
-    const topLight = new THREE.DirectionalLight(0xffffff, 1);
+    const topLight = new THREE.DirectionalLight(0xffffff, LIGHT_STRENGTH);
     topLight.position.y = 10000;
     this.scene.add(topLight);
-    this.scene.add(new THREE.AmbientLight(0xffffff, 1 - SHADING_STRENGTH));
 
-    this.dirLight = new THREE.DirectionalLight(0xffffff, SHADING_STRENGTH);
+    this.dirLight = new THREE.DirectionalLight(0xffffff, LIGHT_STRENGTH);
     this.scene.add(this.dirLight);
   }
 
@@ -311,7 +311,7 @@ export default class CrossSection3D {
     this.planeGeometry = new THREE.PlaneGeometry(1, 1);
 
     this.frontWallCanvas = document.createElement("canvas");
-    this.frontWallMaterial = new THREE.MeshLambertMaterial();
+    this.frontWallMaterial = new THREE.MeshPhongMaterial();
     this.frontWall = new THREE.Mesh(this.planeGeometry, this.frontWallMaterial);
     this.scene.add(this.frontWall);
 
@@ -344,6 +344,7 @@ export default class CrossSection3D {
       this.frontWallTexture.dispose();
     }
     this.frontWallTexture = new THREE.Texture(this.frontWallCanvas);
+    this.frontWallTexture.colorSpace = THREE.SRGBColorSpace;
     this.frontWallTexture.minFilter = THREE.LinearFilter;
     this.frontWallMaterial.map = this.frontWallTexture;
 
@@ -351,6 +352,7 @@ export default class CrossSection3D {
       this.rightWallTexture.dispose();
     }
     this.rightWallTexture = new THREE.Texture(this.rightWallCanvas);
+    this.rightWallTexture.colorSpace = THREE.SRGBColorSpace;
     this.rightWallTexture.minFilter = THREE.LinearFilter;
     this.rightWallMaterial.map = this.rightWallTexture;
 
@@ -358,6 +360,7 @@ export default class CrossSection3D {
       this.backWallTexture.dispose();
     }
     this.backWallTexture = new THREE.Texture(this.backWallCanvas);
+    this.backWallTexture.colorSpace = THREE.SRGBColorSpace;
     this.backWallTexture.minFilter = THREE.LinearFilter;
     this.backWallMaterial.map = this.backWallTexture;
 
@@ -365,6 +368,7 @@ export default class CrossSection3D {
       this.leftWallTexture.dispose();
     }
     this.leftWallTexture = new THREE.Texture(this.leftWallCanvas);
+    this.leftWallTexture.colorSpace = THREE.SRGBColorSpace;
     this.leftWallTexture.minFilter = THREE.LinearFilter;
     this.leftWallMaterial.map = this.leftWallTexture;
   }

--- a/packages/tectonic-explorer/src/plates-view/earthquake-helpers.ts
+++ b/packages/tectonic-explorer/src/plates-view/earthquake-helpers.ts
@@ -32,6 +32,7 @@ export function earthquakeTexture() {
   // So, if the texture color is white, it will end up being the custom color after multiplication.
   drawEarthquakeShape(ctx, TEXTURE_SIZE * 0.5, TEXTURE_SIZE * 0.5, TEXTURE_SIZE, "#fff");
   const texture = new THREE.Texture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
   texture.needsUpdate = true;
   return texture;
 }

--- a/packages/tectonic-explorer/src/plates-view/n-pole-label.ts
+++ b/packages/tectonic-explorer/src/plates-view/n-pole-label.ts
@@ -31,6 +31,7 @@ function labelTexture(label: any) {
   ctx.textBaseline = "middle";
   ctx.fillText(label, width / 2, height / 4);
   const texture = new THREE.Texture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
   texture.needsUpdate = true;
   return texture;
 }

--- a/packages/tectonic-explorer/src/plates-view/planet-view.ts
+++ b/packages/tectonic-explorer/src/plates-view/planet-view.ts
@@ -155,8 +155,8 @@ export default class PlanetView {
     this.controls.minDistance = 1.8;
     this.controls.maxDistance = 10;
 
-    this.scene.add(new THREE.AmbientLight(0xffffff, 0.5));
-    this.light = new THREE.PointLight(0xffffff, 0.5);
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+    this.light = new THREE.DirectionalLight(0xffffff, 2.3);
     this.scene.add(this.light);
   }
 

--- a/packages/tectonic-explorer/src/plates-view/plate-mesh-vertex.glsl
+++ b/packages/tectonic-explorer/src/plates-view/plate-mesh-vertex.glsl
@@ -24,7 +24,6 @@ varying vec3 vViewPosition;
 
 #include <common>
 #include <uv_pars_vertex>
-#include <uv2_pars_vertex>
 #include <displacementmap_pars_vertex>
 #include <envmap_pars_vertex>
 #include <color_pars_vertex>
@@ -45,8 +44,7 @@ void main() {
   vPatternIdx = patternIdx;
   // ---
 
-	#include <uv_vertex>
-	#include <uv2_vertex>
+  #include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
 
@@ -66,7 +64,7 @@ void main() {
   transformed += normalize(objectNormal) * elevation;
   // ---
 
-	#include <project_vertex>
+  #include <project_vertex>
 	#include <logdepthbuf_vertex>
 	#include <clipping_planes_vertex>
 

--- a/packages/tectonic-explorer/src/plates-view/plate-mesh-vertex.glsl
+++ b/packages/tectonic-explorer/src/plates-view/plate-mesh-vertex.glsl
@@ -1,5 +1,5 @@
 // Slightly modified Phong shader taken from THREE.ShaderLib.
-// https://github.com/mrdoob/three.js/blob/b398bc410bd161a88e8087898eb66639f03762be/src/renderers/shaders/ShaderLib/meshphong.glsl.js
+// https://github.com/mrdoob/three.js/blob/d04539a76736ff500cae883d6a38b3dd8643c548/src/renderers/shaders/ShaderLib/meshphong.glsl.js
 // It supports alpha channel in color attribute (vec4 is used instead of vec3) + a few custom features like
 // hiding vertices, colormap texture, and so on. Custom code is always enclosed in // --- CUSTOM comment.
 
@@ -23,6 +23,7 @@ flat out int vPatternIdx;
 varying vec3 vViewPosition;
 
 #include <common>
+#include <batching_pars_vertex>
 #include <uv_pars_vertex>
 #include <displacementmap_pars_vertex>
 #include <envmap_pars_vertex>
@@ -44,9 +45,10 @@ void main() {
   vPatternIdx = patternIdx;
   // ---
 
-  #include <uv_vertex>
+	#include <uv_vertex>
 	#include <color_vertex>
 	#include <morphcolor_vertex>
+	#include <batching_vertex>
 
 	#include <beginnormal_vertex>
 	#include <morphnormal_vertex>

--- a/packages/tectonic-explorer/src/plates-view/point-label.ts
+++ b/packages/tectonic-explorer/src/plates-view/point-label.ts
@@ -34,6 +34,7 @@ function pointTexture(label: string | number, labelColor: string, textColor: str
   ctx.textBaseline = "middle";
   ctx.fillText(label, textureSize * 0.5, textureSize * 0.52);
   const texture = new THREE.Texture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
   texture.needsUpdate = true;
   return texture;
 }

--- a/packages/tectonic-explorer/src/plates-view/temporal-event-fragment.glsl
+++ b/packages/tectonic-explorer/src/plates-view/temporal-event-fragment.glsl
@@ -6,4 +6,8 @@ varying vec2 vUv;
 void main() {
     gl_FragColor = vColor * texture2D(textureUniform, vUv);
     if (gl_FragColor.a < 0.5) discard;
+
+    // Necessary since Three.js r152/153
+    #include <tonemapping_fragment>
+	  #include <colorspace_fragment>
 }

--- a/packages/tectonic-explorer/src/plates-view/volcanic-eruption-helpers.ts
+++ b/packages/tectonic-explorer/src/plates-view/volcanic-eruption-helpers.ts
@@ -27,6 +27,7 @@ export function volcanicEruptionTexture() {
   const ctx = canvas.getContext("2d");
   drawVolcanicEruptionShape(ctx, TEXTURE_SIZE * 0.5, TEXTURE_SIZE, TEXTURE_SIZE);
   const texture = new THREE.Texture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
   texture.needsUpdate = true;
   return texture;
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186622948

This PR updates ThreeJS to r160. Necessary changes include:
- Updating custom shaders. This is expected, and I hope my improved comments make future modifications easier.
- Updates necessary to address the new color management introduced in ThreeJS r152/153: [ThreeJS Color Management](https://threejs.org/docs/#manual/en/introduction/Color-management). This is a bit painful, as there is no way to convert the code and achieve exactly identical results. Thus, the updates involve setting the correct color space in various places, converting some colors from sRGB to linear sRGB, and adjusting lighting.
- One of the more recent ThreeJS versions also updated the logic related to bump mapping. This required some tweaking of the TecRock code to achieve a similar effect as before.

Generally, the colors, lighting, and bump mapping are not 100% identical, but I hope they are close enough to avoid any noticeable differences.