### PR TITLE
Update descriptions of rock, fix wrong diagram path

### DIFF
--- a/packages/shared/data-sample-info.tsx
+++ b/packages/shared/data-sample-info.tsx
@@ -33,7 +33,7 @@ import MetamorphicHighGradeSubductionZoneDiagram from "./rock-diagrams/metamorph
 import MetamorphicMediumGradeCCCollisionDiagram from "./rock-diagrams/metamorphic-rock-medium-grade-cc-collision-diagram.svg";
 import MetamorphicMediumGradeSubductionZoneDiagram from "./rock-diagrams/metamorphic-rock-medium-grade-subduction-zone-diagram.svg";
 import MetamorphicLowGradeCCCollisionDiagram from "./rock-diagrams/metamorphic-rock-low-grade-cc-collision-diagram.svg";
-import MetamorphicLowGradeSubductionZoneDiagram from "./rock-diagrams/metamorphic-rock-low-grade-subduction-zone-diagram-table.svg";
+import MetamorphicLowGradeSubductionZoneDiagram from "./rock-diagrams/metamorphic-rock-low-grade-subduction-zone-diagram.svg";
 import MetamorphicHighGradeCCCollisionDiagramSmall from "./rock-diagrams/metamorphic-rock-high-grade-cc-collision-diagram-table.svg";
 import MetamorphicHighGradeContactDiagramSmall from "./rock-diagrams/metamorphic-rock-high-grade-contact-metamorphism-diagram-table.svg";
 import MetamorphicHighGradeSubductionZoneDiagramSmall from "./rock-diagrams/metamorphic-rock-high-grade-subduction-zone-diagram-table.svg";

--- a/packages/tecrock-simulation/src/components/keys/rock-types.tsx
+++ b/packages/tecrock-simulation/src/components/keys/rock-types.tsx
@@ -248,7 +248,7 @@ const TecRockKey: IContainerDef[] = [
               <div>
                 <p><b>Tectonic Environment:</b> convergent boundary</p>
                 <p><b>Origin Rock:</b> any</p>
-                <p><b>Metamorphic Conditions:</b> low temperature, medium pressure</p>
+                <p><b>Metamorphic Conditions:</b> low temperature and medium pressure</p>
               </div>
             )
           },
@@ -276,9 +276,9 @@ const TecRockKey: IContainerDef[] = [
             diagram: dataSampleInfo["High Grade Metamorphic Rock (Subduction Zone)"].metamorphicGrade,
             notes: (
               <div>
-                <p><b>Tectonic Environment:</b> convergent boundary,</p>
+                <p><b>Tectonic Environment:</b> convergent boundary</p>
                 <p><b>Origin Rock:</b> any</p>
-                <p><b>Metamorphic Conditions:</b> low temperature, high pressure</p>
+                <p><b>Metamorphic Conditions:</b> low temperature and high pressure</p>
               </div>
             )
           }
@@ -291,9 +291,9 @@ const TecRockKey: IContainerDef[] = [
         diagram: dataSampleInfo["Contact Metamorphism"].metamorphicGrade,
         notes: (
           <div>
-            <p><b>Tectonic Environment:</b> convergent boundary</p>
+            <p><b>Tectonic Environment:</b> convergent boundary, near magma</p>
             <p><b>Origin Rock:</b> any</p>
-            <p><b>Metamorphic Conditions:</b> high temperature, low pressure</p>
+            <p><b>Metamorphic Conditions:</b> high temperature and low pressure</p>
           </div>
         )
       }


### PR DESCRIPTION
A small PR addressing the comments made by Chris Lore on this PT story: https://www.pivotaltracker.com/story/show/185032941/comments/239929908. 
It corrects one incorrect diagram path and makes a few updates to the description wording.