### PR TITLE
Scale down the table in the Question Details view, allow teachers to enlarge snapshots

### DIFF
--- a/packages/tecrock-simulation/src/components/keys/rock-types.scss
+++ b/packages/tecrock-simulation/src/components/keys/rock-types.scss
@@ -127,6 +127,9 @@
         .selectedRockDiagram {
           padding: 5px 0;
           text-align: center;
+          svg + svg {
+            margin-top: 4px;
+          }
         }
         .selectedRockNotes {
           width: 248px;

--- a/packages/tecrock-table/src/components/report-item/report-item.tsx
+++ b/packages/tecrock-table/src/components/report-item/report-item.tsx
@@ -15,39 +15,40 @@ import classMap from "../table.scss";
 // A method to execute any JavaScript code in the report-item iframe. This is necessary to set up table scaling for
 // narrow views and to enable snapshot clicking. This approach is quite limited, but it suffices for our needs in
 // this specific case.
-const reportItemScript =
-  "<script>" + (function runInReportItem() {
-    // Setup table scaling
-    const table = document.body.getElementsByTagName("table")[0];
-    if (!table) {
-      return;
-    }
-    const tableParent = table.parentElement;
-    if (!tableParent) {
-      return;
-    }
-    if (table.offsetWidth > tableParent.offsetWidth) {
-      // Table is wider than its parent, there is a horizontal scrollbar, so we need to scale it down.
-      const originalWidth = table.offsetWidth;
-      const originalHeight = table.offsetHeight;
-      const scale = tableParent.offsetWidth / (originalWidth + 1);
-      table.style.transform = `scale(${scale})`;
-      table.style.width = tableParent.style.width = `${scale * originalWidth}px`;
-      table.style.height = tableParent.style.height = (scale * originalHeight) + "px";
-      tableParent.style.overflow = "hidden";
-    }
-    // Set up the snapshot click handler. This is implemented in the Table component, but it won't work in the report
-    // item because the component is rendered to a string and sent in that form. Fortunately, it's easy to
-    // reimplement it here.
-    const snapshots = document.body.getElementsByTagName("img");
-    for (let i = 0; i < snapshots.length; i++) {
-      const snapshot = snapshots[i];
-      snapshot.addEventListener("click", () => {
-        window.open(snapshot.src, "_blank");
-      });
-    }
-  }).toString() +
-  "\nrunInReportItem(); </script>";
+function runInReportItem() {
+  // Setup table scaling
+  const table = document.body.getElementsByTagName("table")[0];
+  if (!table) {
+    return;
+  }
+  const tableParent = table.parentElement;
+  if (!tableParent) {
+    return;
+  }
+  if (table.offsetWidth > tableParent.offsetWidth) {
+    // Table is wider than its parent, there is a horizontal scrollbar, so we need to scale it down.
+    const originalWidth = table.offsetWidth;
+    const originalHeight = table.offsetHeight;
+    const scale = tableParent.offsetWidth / (originalWidth + 1);
+    table.style.transform = `scale(${scale})`;
+    table.style.width = tableParent.style.width = `${scale * originalWidth}px`;
+    table.style.height = tableParent.style.height = (scale * originalHeight) + "px";
+    tableParent.style.overflow = "hidden";
+  }
+  // Set up the snapshot click handler. This is implemented in the Table component, but it won't work in the report
+  // item because the component is rendered to a string and sent in that form. Fortunately, it's easy to
+  // reimplement it here.
+  const snapshots = document.body.getElementsByTagName("img");
+  for (let i = 0; i < snapshots.length; i++) {
+    const snapshot = snapshots[i];
+    snapshot.addEventListener("click", () => {
+      window.open(snapshot.src, "_blank");
+    });
+  }
+}
+// runInReportItem.name is necessary (rather than just using runInReportItem()) because the webpack optimizer might
+// change function name or even inline the function, which would break the code.
+const reportItemScript = "<script>" + runInReportItem.toString() + `\n ${runInReportItem.name}(); </script>`;
 
 export const reportItemHandler: IGetReportItemAnswerHandler<ITectonicExplorerInteractiveState, IAuthoredState> = request => {
   const {platformUserId, version, itemsType} = request;

--- a/packages/tecrock-table/src/components/table.scss
+++ b/packages/tecrock-table/src/components/table.scss
@@ -11,6 +11,7 @@
     table {
       border-collapse: collapse;
       table-layout: auto;
+      transform-origin: top left;
 
       td, th {
         border: 0.5px solid #979797;

--- a/packages/tecrock-table/src/components/table.tsx
+++ b/packages/tecrock-table/src/components/table.tsx
@@ -51,14 +51,14 @@ export const Table: React.FC<IProps> = ({ interactiveState, handleExpandSnapshot
           planetViewSnapshot &&
           <div className={css.imgContainer}>
             <img style={{width: "100%"}} src={planetViewSnapshot} alt="Planet view snapshot" onClick={handleExpandSnapshot} />
-            { handleExpandSnapshot && <ZoomIn /> }
+            <ZoomIn />
           </div>
         }
         {
           crossSectionSnapshot &&
           <div className={css.imgContainer}>
             <img style={{width: "100%"}} src={crossSectionSnapshot} alt="Cross-section snapshot" onClick={handleExpandSnapshot} />
-            { handleExpandSnapshot && <ZoomIn /> }
+            <ZoomIn />
           </div>
         }
       </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186921649
https://www.pivotaltracker.com/story/show/186921720

This PR scales down the table in the Question Details view and allows teachers to enlarge snapshots. It's done using a pretty basic JavaScript script, as the report-item doesn't have access to any libraries. Fortunately, in this case, the basic DOM API was sufficient.