### PR TITLE
Fix index.html template

### DIFF
--- a/packages/tecrock-simulation/src/index.html
+++ b/packages/tecrock-simulation/src/index.html
@@ -40,6 +40,5 @@
 </head>
 <body>
 <div id="app"></div>
-<script src="app.js"></script>
 </body>
 </html>

--- a/packages/tecrock-simulation/webpack.config.js
+++ b/packages/tecrock-simulation/webpack.config.js
@@ -169,9 +169,16 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [{ from: 'public' }]
     }),
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      template: './src/index.html',
+      favicon: './public/favicon.ico',
+      publicPath: '.',
+    }),
     ...(DEPLOY_PATH ? [new HtmlWebpackPlugin({
       filename: 'index-top.html',
-      template: './public/index.html',
+      template: './src/index.html',
+      favicon: './public/favicon.ico',
       publicPath: DEPLOY_PATH,
     })] : [])
   ]


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186957289

This doesn't seem related to the bug, but I believe the issue is that the script tag was added twice: once via HtmlWebpackPlugin and then again through an explicit `<script src="app.js"></script>` line. This wasn't visible in most cases because the same script was loaded twice, until we released this project to production. Two slightly different scripts were loaded (from `version/v2.7.0` and top-level production dir), which possibly caused the linked bug.