### PR TITLE
Load Web Worker script from a correct location

### DIFF
--- a/packages/tecrock-simulation/src/worker-controller.ts
+++ b/packages/tecrock-simulation/src/worker-controller.ts
@@ -6,12 +6,14 @@ import { ISerializedField } from "./plates-model/field";
 export type EventName = ModelWorkerMsg["type"];
 export type ResponseHandler = (response: any) => void;
 
+declare var __WEBPACK_DEPLOY_PATH__: string;
+
 let _requestId = 0;
 const getRequestId = () => ++_requestId;
 
 class WorkerController {
   // Plate tectonics model, handles all the aspects of simulation which are not related to view and interaction.
-  modelWorker = new window.Worker(`modelWorker.js${window.location.search}`);
+  modelWorker = new window.Worker(`${__WEBPACK_DEPLOY_PATH__}/modelWorker.js${window.location.search}`);
   modelState = "notRequested";
   // Messages to model worker are queued before model is loaded.
   modelMessagesQueue: IncomingModelWorkerMsg[] = [];

--- a/packages/tecrock-simulation/webpack.config.js
+++ b/packages/tecrock-simulation/webpack.config.js
@@ -176,7 +176,11 @@ module.exports = {
       template: './src/index.html',
       favicon: './public/favicon.ico',
       publicPath: DEPLOY_PATH,
-    })] : [])
+    })] : []),
+    // Define DEPLOY_PATH globally so it can be used to load Web Worker script from a correct location
+    new webpack.DefinePlugin({
+      '__WEBPACK_DEPLOY_PATH__': JSON.stringify(DEPLOY_PATH || ".")
+    })
   ]
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187028887
https://www.pivotaltracker.com/story/show/186957289

Another PR has been created to improve the new release process. The Web Worker script was being loaded from a local directory instead of the /version/v2.7.0 directory after the production release and that was causing the issue reported by Trudi.

I've explored better approaches, and there are two separate ones:
- The recommended approach by Webpack 5, as detailed at https://webpack.js.org/guides/web-workers/, won't work because the project does not use ESM.
- The worker-loader might work, but I was unable to pass custom URL parameters to the worker script to set up the configuration. Using postMessage is not feasible, as a significant amount of code requires certain values to be set at initialization.

So, I have opted to pass the deployment path to the TS script and use it there.