### PR TITLE
Use built-in __webpack_public_path__ instead of custom global variable

### DIFF
--- a/packages/tecrock-simulation/src/global.d.ts
+++ b/packages/tecrock-simulation/src/global.d.ts
@@ -7,3 +7,5 @@ declare module "*.css";
 declare module "*.png";
 declare module "*.jpg";
 declare module "*.svg";
+
+declare var __webpack_public_path__: string;

--- a/packages/tecrock-simulation/src/worker-controller.ts
+++ b/packages/tecrock-simulation/src/worker-controller.ts
@@ -6,14 +6,12 @@ import { ISerializedField } from "./plates-model/field";
 export type EventName = ModelWorkerMsg["type"];
 export type ResponseHandler = (response: any) => void;
 
-declare var __WEBPACK_DEPLOY_PATH__: string;
-
 let _requestId = 0;
 const getRequestId = () => ++_requestId;
 
 class WorkerController {
   // Plate tectonics model, handles all the aspects of simulation which are not related to view and interaction.
-  modelWorker = new window.Worker(`${__WEBPACK_DEPLOY_PATH__}/modelWorker.js${window.location.search}`);
+  modelWorker = new window.Worker(`${__webpack_public_path__}modelWorker.js${window.location.search}`);
   modelState = "notRequested";
   // Messages to model worker are queued before model is loaded.
   modelMessagesQueue: IncomingModelWorkerMsg[] = [];

--- a/packages/tecrock-simulation/webpack.config.js
+++ b/packages/tecrock-simulation/webpack.config.js
@@ -176,11 +176,7 @@ module.exports = {
       template: './src/index.html',
       favicon: './public/favicon.ico',
       publicPath: DEPLOY_PATH,
-    })] : []),
-    // Define DEPLOY_PATH globally so it can be used to load Web Worker script from a correct location
-    new webpack.DefinePlugin({
-      '__WEBPACK_DEPLOY_PATH__': JSON.stringify(DEPLOY_PATH || ".")
-    })
+    })] : [])
   ]
 }
 


### PR DESCRIPTION
This PR addresses @scytacki's comment:
https://github.com/concord-consortium/tectonic-explorer/pull/354#discussion_r1487063479
It simplifies the configuration slightly.

I tested it both using webpack-dev server and on production (releasing v2.7.2-pre.1) and it seems to work fine.